### PR TITLE
Don't warn on blocking operations on Desktop CLR

### DIFF
--- a/Rx.NET/Source/Common.targets
+++ b/Rx.NET/Source/Common.targets
@@ -113,7 +113,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(BuildTarget)' == '8' ">
-    <DefineConstants>$(DefineConstants);NO_EVENTARGS_CONSTRAINT;HAS_EDI;HAS_WINRT;HAS_PROGRESS;PREFER_ASYNC;HAS_AWAIT;          NO_REMOTING;NO_SERIALIZABLE;NO_THREAD;CRIPPLED_REFLECTION;USE_TIMER_SELF_ROOT</DefineConstants>
+    <DefineConstants>$(DefineConstants);NO_EVENTARGS_CONSTRAINT;HAS_EDI;HAS_WINRT;HAS_PROGRESS;NO_BLOCKING;PREFER_ASYNC;HAS_AWAIT;          NO_REMOTING;NO_SERIALIZABLE;NO_THREAD;CRIPPLED_REFLECTION;USE_TIMER_SELF_ROOT</DefineConstants>
     <TargetFrameworkIdentifier>.NETCore</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <NoStdLib>true</NoStdLib>

--- a/Rx.NET/Source/System.Reactive.Linq/Reactive/Linq/Observable.Blocking.cs
+++ b/Rx.NET/Source/System.Reactive.Linq/Reactive/Linq/Observable.Blocking.cs
@@ -87,7 +87,7 @@ namespace System.Reactive.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         /// <exception cref="InvalidOperationException">The source sequence is empty.</exception>
         /// <seealso cref="Observable.FirstAsync{TSource}(IObservable{TSource})"/>
-#if PREFER_ASYNC
+#if NO_BLOCKING
         [Obsolete(Constants_Linq.USE_ASYNC)]
 #endif
         public static TSource First<TSource>(this IObservable<TSource> source)
@@ -108,7 +108,7 @@ namespace System.Reactive.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="predicate"/> is null.</exception>
         /// <exception cref="InvalidOperationException">No element satisfies the condition in the predicate. -or- The source sequence is empty.</exception>
         /// <seealso cref="Observable.FirstAsync{TSource}(IObservable{TSource}, Func{TSource, bool})"/>
-#if PREFER_ASYNC
+#if NO_BLOCKING
         [Obsolete(Constants_Linq.USE_ASYNC)]
 #endif
         public static TSource First<TSource>(this IObservable<TSource> source, Func<TSource, bool> predicate)
@@ -133,7 +133,7 @@ namespace System.Reactive.Linq
         /// <returns>The first element in the observable sequence, or a default value if no such element exists.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         /// <seealso cref="Observable.FirstOrDefaultAsync{TSource}(IObservable{TSource})"/>
-#if PREFER_ASYNC
+#if NO_BLOCKING
         [Obsolete(Constants_Linq.USE_ASYNC)]
 #endif
         public static TSource FirstOrDefault<TSource>(this IObservable<TSource> source)
@@ -153,7 +153,7 @@ namespace System.Reactive.Linq
         /// <returns>The first element in the observable sequence that satisfies the condition in the predicate, or a default value if no such element exists.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="predicate"/> is null.</exception>
         /// <seealso cref="Observable.FirstOrDefaultAsync{TSource}(IObservable{TSource}, Func{TSource, bool})"/>
-#if PREFER_ASYNC
+#if NO_BLOCKING
         [Obsolete(Constants_Linq.USE_ASYNC)]
 #endif
         public static TSource FirstOrDefault<TSource>(this IObservable<TSource> source, Func<TSource, bool> predicate)
@@ -178,7 +178,7 @@ namespace System.Reactive.Linq
         /// <param name="onNext">Action to invoke for each element in the observable sequence.</param>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="onNext"/> is null.</exception>
         /// <remarks>Because of its blocking nature, this operator is mainly used for testing.</remarks>
-#if PREFER_ASYNC
+#if NO_BLOCKING
         [Obsolete(Constants_Linq.USE_ASYNC)]
 #endif
         public static void ForEach<TSource>(this IObservable<TSource> source, Action<TSource> onNext)
@@ -199,7 +199,7 @@ namespace System.Reactive.Linq
         /// <param name="onNext">Action to invoke for each element in the observable sequence.</param>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="onNext"/> is null.</exception>
         /// <remarks>Because of its blocking nature, this operator is mainly used for testing.</remarks>
-#if PREFER_ASYNC
+#if NO_BLOCKING
         [Obsolete(Constants_Linq.USE_ASYNC)]
 #endif
         public static void ForEach<TSource>(this IObservable<TSource> source, Action<TSource, int> onNext)
@@ -244,7 +244,7 @@ namespace System.Reactive.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         /// <exception cref="InvalidOperationException">The source sequence is empty.</exception>
         /// <seealso cref="Observable.LastAsync{TSource}(IObservable{TSource})"/>
-#if PREFER_ASYNC
+#if NO_BLOCKING
         [Obsolete(Constants_Linq.USE_ASYNC)]
 #endif
         public static TSource Last<TSource>(this IObservable<TSource> source)
@@ -265,7 +265,7 @@ namespace System.Reactive.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="predicate"/> is null.</exception>
         /// <exception cref="InvalidOperationException">No element satisfies the condition in the predicate. -or- The source sequence is empty.</exception>
         /// <seealso cref="Observable.LastAsync{TSource}(IObservable{TSource}, Func{TSource, bool})"/>
-#if PREFER_ASYNC
+#if NO_BLOCKING
         [Obsolete(Constants_Linq.USE_ASYNC)]
 #endif
         public static TSource Last<TSource>(this IObservable<TSource> source, Func<TSource, bool> predicate)
@@ -290,7 +290,7 @@ namespace System.Reactive.Linq
         /// <returns>The last element in the observable sequence, or a default value if no such element exists.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         /// <seealso cref="Observable.LastOrDefaultAsync{TSource}(IObservable{TSource})"/>
-#if PREFER_ASYNC
+#if NO_BLOCKING
         [Obsolete(Constants_Linq.USE_ASYNC)]
 #endif
         public static TSource LastOrDefault<TSource>(this IObservable<TSource> source)
@@ -310,7 +310,7 @@ namespace System.Reactive.Linq
         /// <returns>The last element in the observable sequence that satisfies the condition in the predicate, or a default value if no such element exists.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="predicate"/> is null.</exception>
         /// <seealso cref="Observable.LastOrDefaultAsync{TSource}(IObservable{TSource}, Func{TSource, bool})"/>
-#if PREFER_ASYNC
+#if NO_BLOCKING
         [Obsolete(Constants_Linq.USE_ASYNC)]
 #endif
         public static TSource LastOrDefault<TSource>(this IObservable<TSource> source, Func<TSource, bool> predicate)
@@ -396,7 +396,7 @@ namespace System.Reactive.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         /// <exception cref="InvalidOperationException">The source sequence contains more than one element. -or- The source sequence is empty.</exception>
         /// <seealso cref="Observable.SingleAsync{TSource}(IObservable{TSource})"/>
-#if PREFER_ASYNC
+#if NO_BLOCKING
         [Obsolete(Constants_Linq.USE_ASYNC)]
 #endif
         public static TSource Single<TSource>(this IObservable<TSource> source)
@@ -417,7 +417,7 @@ namespace System.Reactive.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="predicate"/> is null.</exception>
         /// <exception cref="InvalidOperationException">No element satisfies the condition in the predicate. -or- More than one element satisfies the condition in the predicate. -or- The source sequence is empty.</exception>
         /// <seealso cref="Observable.SingleAsync{TSource}(IObservable{TSource}, Func{TSource, bool})"/>
-#if PREFER_ASYNC
+#if NO_BLOCKING
         [Obsolete(Constants_Linq.USE_ASYNC)]
 #endif
         public static TSource Single<TSource>(this IObservable<TSource> source, Func<TSource, bool> predicate)
@@ -443,7 +443,7 @@ namespace System.Reactive.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         /// <exception cref="InvalidOperationException">The source sequence contains more than one element.</exception>
         /// <seealso cref="Observable.SingleOrDefaultAsync{TSource}(IObservable{TSource})"/>
-#if PREFER_ASYNC
+#if NO_BLOCKING
         [Obsolete(Constants_Linq.USE_ASYNC)]
 #endif
         public static TSource SingleOrDefault<TSource>(this IObservable<TSource> source)
@@ -464,7 +464,7 @@ namespace System.Reactive.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="predicate"/> is null.</exception>
         /// <exception cref="InvalidOperationException">The sequence contains more than one element that satisfies the condition in the predicate.</exception>
         /// <seealso cref="Observable.SingleOrDefaultAsync{TSource}(IObservable{TSource}, Func{TSource, bool})"/>
-#if PREFER_ASYNC
+#if NO_BLOCKING
         [Obsolete(Constants_Linq.USE_ASYNC)]
 #endif
         public static TSource SingleOrDefault<TSource>(this IObservable<TSource> source, Func<TSource, bool> predicate)


### PR DESCRIPTION
First() and friends should only be deprecated on platforms where you _must_ await everything (i.e. WinRT and WP8). If you're developing for a Desktop OS, it's entirely reasonable to block, especially in a unit test runner. 

I originally submitted this to CodePlex but it doesn't seem to get much traction
