### PR TITLE
AsyncEnumerable.Take: Dispose source AsyncEnumerator as soon as possible...

### DIFF
--- a/Ix.NET/Source/System.Interactive.Async/AsyncEnumerable.Single.cs
+++ b/Ix.NET/Source/System.Interactive.Async/AsyncEnumerable.Single.cs
@@ -491,6 +491,10 @@ namespace System.Linq
                             t.Handle(tcs, res =>
                             {
                                 --n;
+
+                                if (n == 0)
+                                    e.Dispose();
+
                                 tcs.TrySetResult(res);
                             });
                         });


### PR DESCRIPTION
..., i.e. when it's clear that MoveNext will not be called again on that enumerator. The rationale behind this is:

1) Observable.Take disposes subscription on source as soon as n elements are observed, not when n+1 elements are observed (or source completes/faults).
2) We want to free resources as early as possible.
3) The outer enumerator may not be disposed at all. While this is clearly the user's fault, in this case, Ix can (and should) ensure that the source enumerator is disposed anyway.
4) From the unit tests, it seems that nothing depends on the current behaviour.
