### PR TITLE
Add overloads for AsyncEnumerable.Scan that allow async accumulators

### DIFF
--- a/Ix.NET/Source/Tests/AsyncTests.Single.cs
+++ b/Ix.NET/Source/Tests/AsyncTests.Single.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text;
 using Xunit;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Tests
 {
@@ -2320,16 +2321,29 @@ namespace Tests
         public void Scan_Null()
         {
             AssertThrows<ArgumentNullException>(() => AsyncEnumerable.Scan(default(IAsyncEnumerable<int>), 3, (x, y) => x + y));
-            AssertThrows<ArgumentNullException>(() => AsyncEnumerable.Scan(AsyncEnumerable.Return(42), 3, null));
-
+            AssertThrows<ArgumentNullException>(() => AsyncEnumerable.Scan(AsyncEnumerable.Return(42), 3, (Func<int, int, int>)null));
+            AssertThrows<ArgumentNullException>(() => AsyncEnumerable.Scan(AsyncEnumerable.Return(42), 3, (Func<int, int, CancellationToken, Task<int>>)null));
             AssertThrows<ArgumentNullException>(() => AsyncEnumerable.Scan(default(IAsyncEnumerable<int>), (x, y) => x + y));
-            AssertThrows<ArgumentNullException>(() => AsyncEnumerable.Scan(AsyncEnumerable.Return(42), null));
+            AssertThrows<ArgumentNullException>(() => AsyncEnumerable.Scan(AsyncEnumerable.Return(42), (Func<int, int, int>)null));
+            AssertThrows<ArgumentNullException>(() => AsyncEnumerable.Scan(AsyncEnumerable.Return(42), (Func<int, int, CancellationToken, Task<int>>)null));
         }
 
         [Fact]
         public void Scan1()
         {
             var xs = new[] { 1, 2, 3 }.ToAsyncEnumerable().Scan(8, (x, y) => x + y);
+
+            var e = xs.GetEnumerator();
+            HasNext(e, 9);
+            HasNext(e, 11);
+            HasNext(e, 14);
+            NoNext(e);
+        }
+
+        [Fact]
+        public void Scan_Async1()
+        {
+            var xs = new[] { 1, 2, 3 }.ToAsyncEnumerable().Scan(8, (x, y, ct) => Task.FromResult(x + y));
 
             var e = xs.GetEnumerator();
             HasNext(e, 9);
@@ -2350,10 +2364,31 @@ namespace Tests
         }
 
         [Fact]
+        public void Scan_Async2()
+        {
+            var xs = new[] { 1, 2, 3 }.ToAsyncEnumerable().Scan((x, y, ct) => Task.FromResult(x + y));
+
+            var e = xs.GetEnumerator();
+            HasNext(e, 3);
+            HasNext(e, 6);
+            NoNext(e);
+        }
+
+        [Fact]
         public void Scan3()
         {
             var ex = new Exception("Bang!");
             var xs = new[] { 1, 2, 3 }.ToAsyncEnumerable().Scan(8, (x, y) => { throw ex; });
+
+            var e = xs.GetEnumerator();
+            AssertThrows<Exception>(() => e.MoveNext().Wait(), ex_ => ((AggregateException)ex_).Flatten().InnerExceptions.Single() == ex);
+        }
+
+        [Fact]
+        public void Scan_Async3()
+        {
+            var ex = new Exception("Bang!");
+            var xs = new[] { 1, 2, 3 }.ToAsyncEnumerable().Scan(8, async (x, y, ct) => { throw ex; });
 
             var e = xs.GetEnumerator();
             AssertThrows<Exception>(() => e.MoveNext().Wait(), ex_ => ((AggregateException)ex_).Flatten().InnerExceptions.Single() == ex);
@@ -2368,6 +2403,17 @@ namespace Tests
             var e = xs.GetEnumerator();
             AssertThrows<Exception>(() => e.MoveNext().Wait(), ex_ => ((AggregateException)ex_).Flatten().InnerExceptions.Single() == ex);
         }
+
+        [Fact]
+        public void Scan_Async4()
+        {
+            var ex = new Exception("Bang!");
+            var xs = new[] { 1, 2, 3 }.ToAsyncEnumerable().Scan(async (x, y, ct) => { throw ex; });
+
+            var e = xs.GetEnumerator();
+            AssertThrows<Exception>(() => e.MoveNext().Wait(), ex_ => ((AggregateException)ex_).Flatten().InnerExceptions.Single() == ex);
+        }
+
 
         [Fact]
         public void DistinctKey_Null()


### PR DESCRIPTION
As noted in the commit messages themselves, it is subject to discussion whether these overloads should be renamed (eg. ScanAsync) since they might induce ambiguities between the different overloads (see modified unit tests).
