### PR TITLE
Fix dispose ownership issues with GroupBy and GroupByUntil

### DIFF
--- a/Rx.NET/Source/Tests.System.Reactive/Tests/Linq/ObservableStandardQueryOperatorTest.cs
+++ b/Rx.NET/Source/Tests.System.Reactive/Tests/Linq/ObservableStandardQueryOperatorTest.cs
@@ -2130,6 +2130,24 @@ namespace ReactiveTests.Tests
         }
 
         [Fact]
+        public void GroupBy_Outer_Multiple_Independence()
+        {
+            var outerDisposeCount = 0;
+            var source = new Subject<int>();
+            var outer = source
+                .Finally(() => outerDisposeCount++)
+                .GroupBy(x => x % 2)
+                .SelectMany(x => x);
+
+            var outerSubscription1 = outer.Subscribe();
+            var outerSubscription2 = outer.Subscribe();
+            source.OnNext(1);
+            outerSubscription2.Dispose();
+
+            Assert.AreEqual(1, outerDisposeCount);
+        }
+
+        [TestMethod]
         public void GroupBy_Inner_Independence()
         {
             var scheduler = new TestScheduler();
@@ -5569,6 +5587,24 @@ namespace ReactiveTests.Tests
         }
 
         [Fact]
+        public void GroupByUntil_Outer_Multiple_Independence()
+        {
+            var outerDisposeCount = 0;
+            var source = new Subject<int>();
+            var outer = source
+                .Finally(() => outerDisposeCount++)
+                .GroupByUntil(x => x % 2, group => Observable.Never<int>())
+                .SelectMany(x => x);
+
+            var outerSubscription1 = outer.Subscribe();
+            var outerSubscription2 = outer.Subscribe();
+            source.OnNext(1);
+            outerSubscription2.Dispose();
+
+            Assert.AreEqual(1, outerDisposeCount);
+        }
+
+        [TestMethod]
         public void GroupByUntil_Inner_Independence()
         {
             var scheduler = new TestScheduler();


### PR DESCRIPTION
The classes implementing **GroupBy** and **GroupByUntil** own private fields that are shared across all the groups, which are potentially created by multiple independent subscriptions. The problem is that these shared fields are reinitialized on each subscription without any kind of safeguard.

This seems like a consistency issue, as different **GroupedObservable** instances from the same sink can suddenly become associated with **CompositeDisposable** instances created by subscriptions to an entirely unrelated sink for another observer.

Is this intended behavior? The associated pull request should make it clear where my worry is with the code (and was also a nice opportunity to learn about GitHub collaborative code review).
