### PR TITLE
Reverse subscription order in WithLatestFrom. In case both observable…

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable.Multiple.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable.Multiple.cs
@@ -1516,6 +1516,8 @@ namespace System.Reactive.Linq
 
         /// <summary>
         /// Merges two observable sequences into one observable sequence by combining each element from the first source with the latest element from the second source, if any.
+        /// Starting from Rx.NET 4.0, this will subscribe to <paramref name="second"/> before subscribing to <paramref name="first" /> to have a latest element readily available
+        /// in case <paramref name="first" /> emits an element right away.
         /// </summary>
         /// <typeparam name="TFirst">The type of the elements in the first source sequence.</typeparam>
         /// <typeparam name="TSecond">The type of the elements in the second source sequence.</typeparam>

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/WithLatestFrom.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/WithLatestFrom.cs
@@ -49,8 +49,8 @@ namespace System.Reactive.Linq.ObservableImpl
                 var fstO = new FirstObserver(this);
                 var sndO = new SecondObserver(this, sndSubscription);
 
-                var fstSubscription = first.SubscribeSafe(fstO);
                 sndSubscription.Disposable = second.SubscribeSafe(sndO);
+                var fstSubscription = first.SubscribeSafe(fstO);
 
                 return StableCompositeDisposable.Create(fstSubscription, sndSubscription);
             }

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/ObservableMultipleTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/ObservableMultipleTest.cs
@@ -11364,6 +11364,24 @@ namespace ReactiveTests.Tests
         }
 
         [Fact]
+        public void WithLatestFrom_immediate()
+        {
+            var scheduler = new TestScheduler();
+
+            var xs = Observable.Return(1);
+            var ys = Observable.Return("bar");
+
+            var res = scheduler.Start(() =>
+                xs.WithLatestFrom(ys, (x, y) => x + y)
+            );
+
+            res.Messages.AssertEqual(
+                OnNext(200, "1bar"),
+                OnCompleted<string>(200)
+            );
+        }
+
+        [Fact]
         public void WithLatestFrom_Error1()
         {
             var scheduler = new TestScheduler();


### PR DESCRIPTION
…s produce values immediately on subscription, I claim that most of the time, the expected behavior is to already have the value from the context-observable when source produces a value.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/reactive-extensions/rx.net/152)

<!-- Reviewable:end -->
