### PR TITLE
Fix the logic of the Sample operator

### DIFF
--- a/Rx.NET/Source/System.Reactive.Linq/Reactive/Linq/Observable/Sample.cs
+++ b/Rx.NET/Source/System.Reactive.Linq/Reactive/Linq/Observable/Sample.cs
@@ -40,6 +40,7 @@ namespace System.Reactive.Linq.ObservableImpl
             private object _gate;
 
             private IDisposable _sourceSubscription;
+            private IDisposable _periodicSchedulerSubscription;
 
             private bool _hasValue;
             private TSource _value;
@@ -166,6 +167,7 @@ namespace System.Reactive.Linq.ObservableImpl
         class _ : Sink<TSource>, IObserver<TSource>
         {
             private readonly Sample<TSource> _parent;
+            private IDisposable _periodicSchedulerSubscription;
 
             public _(Sample<TSource> parent, IObserver<TSource> observer, IDisposable cancel)
                 : base(observer, cancel)
@@ -236,6 +238,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 lock (_gate)
                 {
                     _atEnd = true;
+                    Tick();
                     _sourceSubscription.Dispose();
                 }
             }

--- a/Rx.NET/Source/Tests.System.Reactive/Tests/Linq/ObservableTimeTest.cs
+++ b/Rx.NET/Source/Tests.System.Reactive/Tests/Linq/ObservableTimeTest.cs
@@ -2815,8 +2815,8 @@ namespace ReactiveTests.Tests
                 OnNext(250, 3),
                 OnNext(300, 5), /* CHECK: boundary of sampling */
                 OnNext(350, 6),
-                OnNext(400, 7), /* Sample in last bucket */
-                OnCompleted<int>(400)
+                OnNext(390, 7), /* Sample in last bucket */
+                OnCompleted<int>(390)
             );
 
             xs.Subscriptions.AssertEqual(
@@ -2848,8 +2848,8 @@ namespace ReactiveTests.Tests
                 OnNext(250, 3),
                 OnNext(300, 5), /* CHECK: boundary of sampling */
                 OnNext(350, 6),
-                OnNext(400, 7), /* Sample in last bucket */
-                OnCompleted<int>(400)
+                OnNext(390, 7), /* Sample in last bucket */
+                OnCompleted<int>(390)
             );
 
             xs.Subscriptions.AssertEqual(
@@ -2858,7 +2858,7 @@ namespace ReactiveTests.Tests
 
 #if !WINDOWS
             scheduler.Timers.AssertEqual(
-                new TimerRun(200, 400) { 250, 300, 350, 400 }
+                new TimerRun(200, 390) { 250, 300, 350 }
             );
 #endif
         }
@@ -2980,7 +2980,7 @@ namespace ReactiveTests.Tests
 
 #if !WINDOWS
             scheduler.Timers.AssertEqual(
-                new TimerRun(200, 300) { 250, 300 }
+                new TimerRun(200, 300) { 250 }
             );
 #endif
         }


### PR DESCRIPTION
When the source observable complete
the Sample immediately sending the last value
and not waiting for the periodic schedule event

This fix was sent before but I had some problem with the Git
so I had to close the request and do it again
