### PR TITLE
Lockfree SerialDisposable

### DIFF
--- a/Rx.NET/Source/System.Reactive.Core/Reactive/Disposables/SerialDisposable.cs
+++ b/Rx.NET/Source/System.Reactive.Core/Reactive/Disposables/SerialDisposable.cs
@@ -46,7 +46,7 @@ namespace System.Reactive.Disposables
                 // Don't leak the DISPOSED sentinel
                 if (a == BooleanDisposable.True)
                 {
-                    a = DefaultDisposable.Instance;
+                    a = null;
                 }
                 return a;
             }


### PR DESCRIPTION
After a review of #241, @akarnokd identified a race condition error in the implementation.

This PR follows his guidance to take from https://github.com/reactor/reactor-core-dotnet/blob/master/Reactor.Core/util/DisposableHelper.cs the pattern to implement a lock free `SerialDispoable`. It also would bring the `SerialDisposable` inline with the `MultipleAssignmentDisposable` changes from #246 

Initial tests indicate there is a large improvement in Single Threaded performance, but a reduction in multi threaded performance. Results and benchmark code to follow.

I would like to benchmark how this change would affect the Rx lib at a higher level, i.e. the performance impact on the classes that use `SerialDisposable`
