### PR TITLE
WIP Fix #319

### DIFF
--- a/Ix.NET/Source/System.Interactive.Async/AsyncIterator.cs
+++ b/Ix.NET/Source/System.Interactive.Async/AsyncIterator.cs
@@ -84,7 +84,6 @@ namespace System.Linq
                     return false;
                 }
 
-                using (cancellationToken.Register(Dispose))
                 using (var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, cancellationTokenSource.Token))
                 {
                     try
@@ -95,6 +94,7 @@ namespace System.Linq
                         var result = await MoveNextCore(cts.Token)
                                          .ConfigureAwait(false);
 
+                        cancellationToken.ThrowIfCancellationRequested();
                         currentIsInvalid = !result; // if move next is false, invalid otherwise valid
 
                         return result;


### PR DESCRIPTION
Alternative to #320.

This fix will restore the behavior of `AnonymousAsyncEnumerator<T>` in Rx 2.x which did not observe the `CancellationToken` passed to `MoveNext` and subsequently did not dispose the enumerator on cancellation.

While #320 catches all exceptions occuring due to races (refer to #319 for details), this fix will hopefully prevent such races.