### PR TITLE
EventLoopScheduler: set _nextItem to null on Tick

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Concurrency/EventLoopScheduler.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/EventLoopScheduler.cs
@@ -352,6 +352,10 @@ namespace System.Reactive.Concurrency
                 if (!_disposed)
                 {
                     var item = (ScheduledItem<TimeSpan>)state;
+                    if (item == _nextItem)
+                    {
+                        _nextItem = null;
+                    }
                     if (_queue.Remove(item))
                     {
                         _readyList.Enqueue(item);


### PR DESCRIPTION
This fixes a potential memory leak.

If _queue is empty after the item is removed from it, then _nextItem is never overriden and therefore keeps a reference to item.
Until another action is scheduled with a future due time, the item and all its associated state is kept in memory.
(cherry picked from commit 2679e8e9f10f2674cfa88fd7e13f7f1cea7d2172)

see also https://github.com/Reactive-Extensions/Rx.NET/pull/325