### PR TITLE
Add a new 'partition' operator to split a sequence based on a given predicate

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/IQueryLanguage.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/IQueryLanguage.cs
@@ -624,6 +624,7 @@ namespace System.Reactive.Linq
         IObservable<TResult> GroupJoin<TLeft, TRight, TLeftDuration, TRightDuration, TResult>(IObservable<TLeft> left, IObservable<TRight> right, Func<TLeft, IObservable<TLeftDuration>> leftDurationSelector, Func<TRight, IObservable<TRightDuration>> rightDurationSelector, Func<TLeft, IObservable<TRight>, TResult> resultSelector);
         IObservable<TResult> Join<TLeft, TRight, TLeftDuration, TRightDuration, TResult>(IObservable<TLeft> left, IObservable<TRight> right, Func<TLeft, IObservable<TLeftDuration>> leftDurationSelector, Func<TRight, IObservable<TRightDuration>> rightDurationSelector, Func<TLeft, TRight, TResult> resultSelector);
         IObservable<TResult> OfType<TResult>(IObservable<object> source);
+        Tuple<IObservable<TSource>, IObservable<TSource>> Partition<TSource>(IObservable<TSource> source, Func<TSource, bool> predicate);
         IObservable<TResult> Select<TSource, TResult>(IObservable<TSource> source, Func<TSource, TResult> selector);
         IObservable<TResult> Select<TSource, TResult>(IObservable<TSource> source, Func<TSource, int, TResult> selector);
         IObservable<TOther> SelectMany<TSource, TOther>(IObservable<TSource> source, IObservable<TOther> other);

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable.StandardSequenceOperators.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable.StandardSequenceOperators.cs
@@ -709,6 +709,27 @@ namespace System.Reactive.Linq
 
         #endregion
 
+        #region + Partition +
+
+        /// <summary>
+        /// Partitions an observable sequence into a pair of sequences based on the specified predicate. A subscription will be opened on the source sequence once both partitions have at least one subscription. The source subscription will be closed once all partition subscriptions have been closed.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
+        /// <param name="source">The observable sequence that contains the elements to be partitioned.</param>
+        /// <returns>A pair of observable sequences. The first sequence contains the elements from the input sequence for which the predicate returned true. The second sequence contains the elements for which the predicate returned false.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="predicate"/> is null.</exception>
+        public static Tuple<IObservable<TSource>, IObservable<TSource>> Partition<TSource>(this IObservable<TSource> source, Func<TSource, bool> predicate)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+            if (predicate == null)
+                throw new ArgumentNullException(nameof(predicate));
+
+            return s_impl.Partition(source, predicate);
+        }
+
+        #endregion
+
         #region + Select +
 
         /// <summary>

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Partition.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Partition.cs
@@ -1,0 +1,184 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information. 
+
+using System.Collections.Generic;
+using System.Reactive.Disposables;
+
+namespace System.Reactive.Linq.ObservableImpl
+{
+    internal sealed class Partition<TSource>
+    {
+        private readonly PartitionProducer[] _producers = new PartitionProducer[2];
+        private readonly InnerSink _innerSink;
+
+        public Partition(IObservable<TSource> source, Func<TSource, bool> predicate)
+        {
+            _producers[0] = new PartitionProducer(this, 0);
+            _producers[1] = new PartitionProducer(this, 1);
+            _innerSink = new InnerSink(source, predicate);
+        }
+
+        public Tuple<IObservable<TSource>, IObservable<TSource>> AsTuple()
+        {
+            return Tuple.Create<IObservable<TSource>, IObservable<TSource>>(_producers[0], _producers[1]);
+        }
+
+        // An outer sink is created for each subscription on either of the subscriptions
+        internal sealed class OuterSink : Sink<TSource>, IObserver<TSource>
+        {
+            private readonly Partition<TSource> _parent;
+            private readonly int _index;
+
+            public OuterSink(Partition<TSource> parent, int index, IObserver<TSource> observer, IDisposable cancel)
+                : base(observer, cancel)
+            {
+                _parent = parent;
+                _index = index;
+            }
+
+            public IDisposable Run()
+            {
+                return _parent._innerSink.Run(this, _index);
+            }
+
+            public void OnNext(TSource value)
+            {
+                base._observer.OnNext(value);
+            }
+
+            public void OnError(Exception error)
+            {
+                base._observer.OnError(error);
+                base.Dispose();
+            }
+
+            public void OnCompleted()
+            {
+                base._observer.OnCompleted();
+                base.Dispose();
+            }
+        }
+
+        // One inner sink is created for the partition operation and is shared amongst all the outer sinks
+        // The inner sink is responsible for subscribing to the source sequence
+        internal sealed class InnerSink : IObserver<TSource>
+        {
+            private readonly IObservable<TSource> _source;
+            private readonly Func<TSource, bool> _predicate;
+            private readonly List<OuterSink>[] _outerSinks = new List<OuterSink>[2];
+            private IDisposable _sourceSubscription;
+
+            public InnerSink(IObservable<TSource> source, Func<TSource, bool> predicate)
+            {
+                _source = source;
+                _predicate = predicate;
+                _outerSinks[0] = new List<OuterSink>();
+                _outerSinks[1] = new List<OuterSink>();
+            }
+
+            public IDisposable Run(OuterSink outerSink, int index)
+            {
+                // Save a reference to the outer sink
+                _outerSinks[index].Add(outerSink);
+                var subscription = Disposable.Create(() =>
+                {
+                    for (int i = 0; i < _outerSinks[index].Count; i++)
+                    {
+                        if (_outerSinks[index][i] == outerSink)
+                        {
+                            _outerSinks[index].RemoveAt(i);
+                            break;
+                        }
+                    }
+
+                    // Dispose the source subscription if nothing else is listening
+                    if (_sourceSubscription != null && _outerSinks[0].Count == 0 && _outerSinks[1].Count == 0)
+                    {
+                        _sourceSubscription.Dispose();
+                        _sourceSubscription = null;
+                    }
+                });
+
+                // Subscribe to the source once both partitions have subscriptions
+                if (_sourceSubscription == null && _outerSinks[0].Count > 0 && _outerSinks[1].Count > 0)
+                {
+                    _sourceSubscription = _source.SubscribeSafe(this);
+                }
+
+                return subscription;
+            }
+
+            public void OnNext(TSource value)
+            {
+                bool result;
+                try
+                {
+                    result = _predicate(value);
+                }
+                catch (Exception error)
+                {
+                    OnError(error);
+                    return;
+                }
+
+                if (result)
+                {
+                    foreach (var sink in _outerSinks[0])
+                    {
+                        sink.OnNext(value);
+                    }
+                }
+                else
+                {
+                    foreach (var sink in _outerSinks[1])
+                    {
+                        sink.OnNext(value);
+                    }
+                }
+            }
+
+            public void OnError(Exception error)
+            {
+                // The sinks should remove themselves from the lists as they are disposed, so iterate backwards to make this safe
+                for (int i = _outerSinks[0].Count - 1; i >= 0; i--)
+                {
+                    _outerSinks[0][i].OnError(error);
+                }
+                for (int i = _outerSinks[1].Count - 1; i >= 0; i--)
+                {
+                    _outerSinks[1][i].OnError(error);
+                }
+            }
+
+            public void OnCompleted()
+            {
+                // The sinks should remove themselves from the lists as they are disposed, so iterate backwards to make this safe
+                for (int i = _outerSinks[0].Count - 1; i >= 0; i--)
+                {
+                    _outerSinks[0][i].OnCompleted();
+                }
+                for (int i = _outerSinks[1].Count - 1; i >= 0; i--)
+                {
+                    _outerSinks[1][i].OnCompleted();
+                }
+            }
+        }
+
+        internal sealed class PartitionProducer : Producer<TSource, OuterSink>
+        {
+            private readonly Partition<TSource> _parent;
+            private readonly int _index;
+
+            public PartitionProducer(Partition<TSource> parent, int index)
+            {
+                _parent = parent;
+                _index = index;
+            }
+
+            protected override OuterSink CreateSink(IObserver<TSource> observer, IDisposable cancel) => new OuterSink(_parent, _index, observer, cancel);
+
+            protected override IDisposable Run(OuterSink sink) => sink.Run();
+        }
+    }
+}

--- a/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.StandardSequenceOperators.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.StandardSequenceOperators.cs
@@ -195,6 +195,15 @@ namespace System.Reactive.Linq
 
         #endregion
 
+        #region + Partition +
+
+        public virtual Tuple<IObservable<TSource>, IObservable<TSource>> Partition<TSource>(IObservable<TSource> source, Func<TSource, bool> predicate)
+        {
+            return new Partition<TSource>(source, predicate).AsTuple();
+        }
+
+        #endregion
+
         #region + Select +
 
         public virtual IObservable<TResult> Select<TSource, TResult>(IObservable<TSource> source, Func<TSource, TResult> selector)


### PR DESCRIPTION
Inspired by the equivalents from F# and RxJS, this is a new Linq operator which allows a sequence to be split in two based on some predicate. This is useful as an alternative to `Where` in case you are interested in both the true and false branches and want to process them independently.

Example usage:

```
var (evens, odds) = observable.Partition(x => x % 2 == 0);
evens.Subscribe(x => Console.WriteLine("Even: " + x));
odds.Subscribe(x => Console.WriteLine("Odd: " + x));
```

This is roughly equivalent to the below. The benefits being that the sequence is only evaluated once (so no need to convert the sequence into a connectable), and the predicate only needs to be evaluated once for each element.

```
var numbers = observable.Publish();
numbers.Where(x => x % 2 == 0).Subscribe(x => Console.WriteLine("Even: " + x));
numbers.Where(x => x % 2 != 0).Subscribe(x => Console.WriteLine("Odd: " + x));
numbers.Connect();
```

I think I need to do something to `Qbservable`, but I'm not sure what exactly. The HomoIcon tool seems to be a bit broken, at least on develop. The `Qbservable_Observable_Parity` test is currently failing because `Partition` is missing.

This is my first time trying to do anything in the Rx.NET codebase so there's a decent chance I've messed it up one way or another. Any feedback would be welcome.