### PR TITLE
Review producers and sinks

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Concurrency/Synchronization.ObserveOn.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/Synchronization.ObserveOn.cs
@@ -62,7 +62,7 @@ namespace System.Reactive.Concurrency
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "2", Justification = "Visibility restricted to friend assemblies. Those should be correct by inspection.")]
             protected override IDisposable Run(_ sink) => sink.Run(_source);
 
-            internal sealed class _ : Sink<TSource>, IObserver<TSource>
+            internal sealed class _ : IdentitySink<TSource>
             {
                 private readonly SynchronizationContext _context;
 
@@ -89,36 +89,34 @@ namespace System.Reactive.Concurrency
                     return StableCompositeDisposable.Create(d, c);
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     _context.Post(OnNextPosted, value);
                 }
 
-                public void OnError(Exception error)
+                public override void OnError(Exception error)
                 {
                     _context.Post(OnErrorPosted, error);
                 }
 
-                public void OnCompleted()
+                public override void OnCompleted()
                 {
                     _context.Post(OnCompletedPosted, state: null);
                 }
 
                 private void OnNextPosted(object value)
                 {
-                    _observer.OnNext((TSource)value);
+                    ForwardOnNext((TSource)value);
                 }
 
                 private void OnErrorPosted(object error)
                 {
-                    _observer.OnError((Exception)error);
-                    Dispose();
+                    ForwardOnError((Exception)error);
                 }
 
                 private void OnCompletedPosted(object ignored)
                 {
-                    _observer.OnCompleted();
-                    Dispose();
+                    ForwardOnCompleted();
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/Synchronization.Synchronize.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/Synchronization.Synchronize.cs
@@ -25,7 +25,7 @@ namespace System.Reactive.Concurrency
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "2", Justification = "Visibility restricted to friend assemblies. Those should be correct by inspection.")]
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<TSource>, IObserver<TSource>
+        internal sealed class _ : IdentitySink<TSource>
         {
             private readonly Synchronize<TSource> _parent;
             private readonly object _gate;
@@ -37,29 +37,27 @@ namespace System.Reactive.Concurrency
                 _gate = _parent._gate ?? new object();
             }
 
-            public void OnNext(TSource value)
+            public override void OnNext(TSource value)
             {
                 lock (_gate)
                 {
-                    _observer.OnNext(value);
+                    ForwardOnNext(value);
                 }
             }
 
-            public void OnError(Exception error)
+            public override void OnError(Exception error)
             {
                 lock (_gate)
                 {
-                    _observer.OnError(error);
-                    Dispose();
+                    ForwardOnError(error);
                 }
             }
 
-            public void OnCompleted()
+            public override void OnCompleted()
             {
                 lock (_gate)
                 {
-                    _observer.OnCompleted();
-                    Dispose();
+                    ForwardOnCompleted();
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Internal/IdentitySink.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/IdentitySink.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information. 
+
+namespace System.Reactive
+{
+    internal abstract class IdentitySink<T> : Sink<T, T>
+    {
+        protected IdentitySink(IObserver<T> observer, IDisposable cancel) : base(observer, cancel)
+        {
+        }
+
+        public override void OnNext(T value)
+        {
+            ForwardOnNext(value);
+        }
+    }
+}

--- a/Rx.NET/Source/src/System.Reactive/Internal/Producer.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/Producer.cs
@@ -83,7 +83,7 @@ namespace System.Reactive
         protected abstract IDisposable Run(IObserver<TSource> observer);
     }
 
-    internal abstract class Producer<TSource, TSink> : IProducer<TSource>
+    internal abstract class Producer<TTarget, TSink> : IProducer<TTarget>
         where TSink : IDisposable
     {
         /// <summary>
@@ -91,7 +91,7 @@ namespace System.Reactive
         /// </summary>
         /// <param name="observer">Observer to send notifications on. The implementation of a producer must ensure the correct message grammar on the observer.</param>
         /// <returns>IDisposable to cancel the subscription. This causes the underlying sink to be notified of unsubscription, causing it to prevent further messages from being sent to the observer.</returns>
-        public IDisposable Subscribe(IObserver<TSource> observer)
+        public IDisposable Subscribe(IObserver<TTarget> observer)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -99,7 +99,7 @@ namespace System.Reactive
             return SubscribeRaw(observer, enableSafeguard: true);
         }
 
-        public IDisposable SubscribeRaw(IObserver<TSource> observer, bool enableSafeguard)
+        public IDisposable SubscribeRaw(IObserver<TTarget> observer, bool enableSafeguard)
         {
             var subscription = new SubscriptionDisposable();
 
@@ -109,7 +109,7 @@ namespace System.Reactive
             //
             if (enableSafeguard)
             {
-                observer = SafeObserver<TSource>.Create(observer, subscription);
+                observer = SafeObserver<TTarget>.Create(observer, subscription);
             }
 
             var sink = CreateSink(observer, subscription.Inner);
@@ -148,7 +148,7 @@ namespace System.Reactive
         /// <param name="sink">The sink object.</param>
         protected abstract IDisposable Run(TSink sink);
 
-        protected abstract TSink CreateSink(IObserver<TSource> observer, IDisposable cancel);
+        protected abstract TSink CreateSink(IObserver<TTarget> observer, IDisposable cancel);
     }
 
     internal sealed class SubscriptionDisposable : ICancelable

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/AddRef.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/AddRef.cs
@@ -21,28 +21,11 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<TSource>, IObserver<TSource>
+        internal sealed class _ : IdentitySink<TSource>
         {
             public _(IObserver<TSource> observer, IDisposable cancel)
                 : base(observer, cancel)
             {
-            }
-
-            public void OnNext(TSource value)
-            {
-                base._observer.OnNext(value);
-            }
-
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnCompleted();
-                base.Dispose();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/All.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/All.cs
@@ -19,7 +19,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<bool>, IObserver<TSource>
+        internal sealed class _ : Sink<TSource, bool> 
         {
             private readonly Func<TSource, bool> _predicate;
 
@@ -29,7 +29,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _predicate = predicate;
             }
 
-            public void OnNext(TSource value)
+            public override void OnNext(TSource value)
             {
                 var res = false;
                 try
@@ -38,30 +38,21 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception ex)
                 {
-                    base._observer.OnError(ex);
-                    base.Dispose();
+                    ForwardOnError(ex);
                     return;
                 }
 
                 if (!res)
                 {
-                    base._observer.OnNext(false);
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnNext(false);
+                    ForwardOnCompleted();
                 }
             }
-
-            public void OnError(Exception error)
+            
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext(true);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(true);
+                ForwardOnCompleted();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Any.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Any.cs
@@ -19,31 +19,23 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<bool>, IObserver<TSource>
+            internal sealed class _ : Sink<TSource, bool> 
             {
                 public _(IObserver<bool> observer, IDisposable cancel)
                     : base(observer, cancel)
                 {
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
-                    base._observer.OnNext(true);
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnNext(true);
+                    ForwardOnCompleted();
                 }
 
-                public void OnError(Exception error)
+                public override void OnCompleted()
                 {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnNext(false);
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnNext(false);
+                    ForwardOnCompleted();
                 }
             }
         }
@@ -63,7 +55,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<bool>, IObserver<TSource>
+            internal sealed class _ : Sink<TSource, bool> 
             {
                 private readonly Func<TSource, bool> _predicate;
 
@@ -73,7 +65,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     _predicate = predicate;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     var res = false;
                     try
@@ -82,30 +74,21 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception ex)
                     {
-                        base._observer.OnError(ex);
-                        base.Dispose();
+                        ForwardOnError(ex);
                         return;
                     }
 
                     if (res)
                     {
-                        base._observer.OnNext(true);
-                        base._observer.OnCompleted();
-                        base.Dispose();
+                        ForwardOnNext(true);
+                        ForwardOnCompleted();
                     }
                 }
 
-                public void OnError(Exception error)
+                public override void OnCompleted()
                 {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnNext(false);
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnNext(false);
+                    ForwardOnCompleted();
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/AsObservable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/AsObservable.cs
@@ -19,28 +19,11 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<TSource>, IObserver<TSource>
+        internal sealed class _ : IdentitySink<TSource>
         {
             public _(IObserver<TSource> observer, IDisposable cancel)
                 : base(observer, cancel)
             {
-            }
-
-            public void OnNext(TSource value)
-            {
-                base._observer.OnNext(value);
-            }
-
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnCompleted();
-                base.Dispose();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Average.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Average.cs
@@ -17,7 +17,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<double>, IObserver<double>
+        internal sealed class _ : IdentitySink<double>
         {
             private double _sum;
             private long _count;
@@ -29,7 +29,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _count = 0L;
             }
 
-            public void OnNext(double value)
+            public override void OnNext(double value)
             {
                 try
                 {
@@ -41,30 +41,21 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception ex)
                 {
-                    base._observer.OnError(ex);
-                    base.Dispose();
+                    ForwardOnError(ex);
                 }
             }
 
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
+            public override void OnCompleted()
             {
                 if (_count > 0)
                 {
-                    base._observer.OnNext(_sum / _count);
-                    base._observer.OnCompleted();
+                    ForwardOnNext(_sum / _count);
+                    ForwardOnCompleted();
                 }
                 else
                 {
-                    base._observer.OnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
                 }
-
-                base.Dispose();
             }
         }
     }
@@ -82,7 +73,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<float>, IObserver<float>
+        internal sealed class _ : IdentitySink<float>
         {
             private double _sum; // NOTE: Uses a different accumulator type (double), conform LINQ to Objects.
             private long _count;
@@ -94,7 +85,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _count = 0L;
             }
 
-            public void OnNext(float value)
+            public override void OnNext(float value)
             {
                 try
                 {
@@ -106,30 +97,21 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception ex)
                 {
-                    base._observer.OnError(ex);
-                    base.Dispose();
+                    ForwardOnError(ex);
                 }
             }
 
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
+            public override void OnCompleted()
             {
                 if (_count > 0)
                 {
-                    base._observer.OnNext((float)(_sum / _count));
-                    base._observer.OnCompleted();
+                    ForwardOnNext((float)(_sum / _count));
+                    ForwardOnCompleted();
                 }
                 else
                 {
-                    base._observer.OnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
                 }
-
-                base.Dispose();
             }
         }
     }
@@ -147,7 +129,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<decimal>, IObserver<decimal>
+        internal sealed class _ : IdentitySink<decimal>
         {
             private decimal _sum;
             private long _count;
@@ -159,7 +141,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _count = 0L;
             }
 
-            public void OnNext(decimal value)
+            public override void OnNext(decimal value)
             {
                 try
                 {
@@ -171,30 +153,21 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception ex)
                 {
-                    base._observer.OnError(ex);
-                    base.Dispose();
+                    ForwardOnError(ex);
                 }
             }
 
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
+            public override void OnCompleted()
             {
                 if (_count > 0)
                 {
-                    base._observer.OnNext(_sum / _count);
-                    base._observer.OnCompleted();
+                    ForwardOnNext(_sum / _count);
+                    ForwardOnCompleted();
                 }
                 else
                 {
-                    base._observer.OnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
                 }
-
-                base.Dispose();
             }
         }
     }
@@ -212,7 +185,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<double>, IObserver<int>
+        internal sealed class _ : Sink<int, double> 
         {
             private long _sum;
             private long _count;
@@ -224,7 +197,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _count = 0L;
             }
 
-            public void OnNext(int value)
+            public override void OnNext(int value)
             {
                 try
                 {
@@ -236,30 +209,21 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception ex)
                 {
-                    base._observer.OnError(ex);
-                    base.Dispose();
+                    ForwardOnError(ex);
                 }
             }
 
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
+            public override void OnCompleted()
             {
                 if (_count > 0)
                 {
-                    base._observer.OnNext((double)_sum / _count);
-                    base._observer.OnCompleted();
+                    ForwardOnNext((double)_sum / _count);
+                    ForwardOnCompleted();
                 }
                 else
                 {
-                    base._observer.OnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
                 }
-
-                base.Dispose();
             }
         }
     }
@@ -277,7 +241,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<double>, IObserver<long>
+        internal sealed class _ : Sink<long, double> 
         {
             private long _sum;
             private long _count;
@@ -289,7 +253,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _count = 0L;
             }
 
-            public void OnNext(long value)
+            public override void OnNext(long value)
             {
                 try
                 {
@@ -301,30 +265,21 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception ex)
                 {
-                    base._observer.OnError(ex);
-                    base.Dispose();
+                    ForwardOnError(ex);
                 }
             }
 
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
+            public override void OnCompleted()
             {
                 if (_count > 0)
                 {
-                    base._observer.OnNext((double)_sum / _count);
-                    base._observer.OnCompleted();
+                    ForwardOnNext((double)_sum / _count);
+                    ForwardOnCompleted();
                 }
                 else
                 {
-                    base._observer.OnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
                 }
-
-                base.Dispose();
             }
         }
     }
@@ -342,7 +297,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<double?>, IObserver<double?>
+        internal sealed class _ : IdentitySink<double?>
         {
             private double _sum;
             private long _count;
@@ -354,7 +309,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _count = 0L;
             }
 
-            public void OnNext(double? value)
+            public override void OnNext(double? value)
             {
                 try
                 {
@@ -369,30 +324,22 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception ex)
                 {
-                    base._observer.OnError(ex);
-                    base.Dispose();
+                    ForwardOnError(ex);
                 }
             }
 
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
+            public override void OnCompleted()
             {
                 if (_count > 0)
                 {
-                    base._observer.OnNext(_sum / _count);
+                    ForwardOnNext(_sum / _count);
                 }
                 else
                 {
-                    base._observer.OnNext(null);
+                    ForwardOnNext(null);
                 }
 
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnCompleted();
             }
         }
     }
@@ -410,7 +357,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<float?>, IObserver<float?>
+        internal sealed class _ : IdentitySink<float?>
         {
             private double _sum; // NOTE: Uses a different accumulator type (double), conform LINQ to Objects.
             private long _count;
@@ -422,7 +369,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _count = 0L;
             }
 
-            public void OnNext(float? value)
+            public override void OnNext(float? value)
             {
                 try
                 {
@@ -437,30 +384,22 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception ex)
                 {
-                    base._observer.OnError(ex);
-                    base.Dispose();
+                    ForwardOnError(ex);
                 }
             }
 
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
+            public override void OnCompleted()
             {
                 if (_count > 0)
                 {
-                    base._observer.OnNext((float)(_sum / _count));
+                    ForwardOnNext((float)(_sum / _count));
                 }
                 else
                 {
-                    base._observer.OnNext(null);
+                    ForwardOnNext(null);
                 }
 
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnCompleted();
             }
         }
     }
@@ -478,7 +417,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<decimal?>, IObserver<decimal?>
+        internal sealed class _ : IdentitySink<decimal?>
         {
             private decimal _sum;
             private long _count;
@@ -490,7 +429,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _count = 0L;
             }
 
-            public void OnNext(decimal? value)
+            public override void OnNext(decimal? value)
             {
                 try
                 {
@@ -505,30 +444,22 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception ex)
                 {
-                    base._observer.OnError(ex);
-                    base.Dispose();
+                    ForwardOnError(ex);
                 }
             }
 
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
+            public override void OnCompleted()
             {
                 if (_count > 0)
                 {
-                    base._observer.OnNext(_sum / _count);
+                    ForwardOnNext(_sum / _count);
                 }
                 else
                 {
-                    base._observer.OnNext(null);
+                    ForwardOnNext(null);
                 }
 
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnCompleted();
             }
         }
     }
@@ -546,7 +477,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<double?>, IObserver<int?>
+        internal sealed class _ : Sink<int?, double?> 
         {
             private long _sum;
             private long _count;
@@ -558,7 +489,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _count = 0L;
             }
 
-            public void OnNext(int? value)
+            public override void OnNext(int? value)
             {
                 try
                 {
@@ -573,30 +504,22 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception ex)
                 {
-                    base._observer.OnError(ex);
-                    base.Dispose();
+                    ForwardOnError(ex);
                 }
             }
 
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
+            public override void OnCompleted()
             {
                 if (_count > 0)
                 {
-                    base._observer.OnNext((double)_sum / _count);
+                    ForwardOnNext((double)_sum / _count);
                 }
                 else
                 {
-                    base._observer.OnNext(null);
+                    ForwardOnNext(null);
                 }
 
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnCompleted();
             }
         }
     }
@@ -614,7 +537,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<double?>, IObserver<long?>
+        internal sealed class _ : Sink<long?, double?> 
         {
             private long _sum;
             private long _count;
@@ -626,7 +549,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _count = 0L;
             }
 
-            public void OnNext(long? value)
+            public override void OnNext(long? value)
             {
                 try
                 {
@@ -641,30 +564,22 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception ex)
                 {
-                    base._observer.OnError(ex);
-                    base.Dispose();
+                    ForwardOnError(ex);
                 }
             }
 
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
+            public override void OnCompleted()
             {
                 if (_count > 0)
                 {
-                    base._observer.OnNext((double)_sum / _count);
+                    ForwardOnNext((double)_sum / _count);
                 }
                 else
                 {
-                    base._observer.OnNext(null);
+                    ForwardOnNext(null);
                 }
 
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnCompleted();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Case.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Case.cs
@@ -32,7 +32,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => sink.Run(this);
 
-        internal sealed class _ : Sink<TResult>, IObserver<TResult>
+        internal sealed class _ : IdentitySink<TResult>
         {
             public _(IObserver<TResult> observer, IDisposable cancel)
                 : base(observer, cancel)
@@ -48,29 +48,11 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception exception)
                 {
-                    base._observer.OnError(exception);
-                    base.Dispose();
+                    ForwardOnError(exception);
                     return Disposable.Empty;
                 }
 
                 return result.SubscribeSafe(this);
-            }
-
-            public void OnNext(TResult value)
-            {
-                base._observer.OnNext(value);
-            }
-
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnCompleted();
-                base.Dispose();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Cast.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Cast.cs
@@ -17,14 +17,14 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<TResult>, IObserver<TSource>
+        internal sealed class _ : Sink<TSource, TResult> 
         {
             public _(IObserver<TResult> observer, IDisposable cancel)
                 : base(observer, cancel)
             {
             }
 
-            public void OnNext(TSource value)
+            public override void OnNext(TSource value)
             {
                 var result = default(TResult);
                 try
@@ -33,24 +33,11 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception exception)
                 {
-                    base._observer.OnError(exception);
-                    base.Dispose();
+                    ForwardOnError(exception);
                     return;
                 }
 
-                base._observer.OnNext(result);
-            }
-
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(result);
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/CombineLatest.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/CombineLatest.cs
@@ -28,7 +28,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => sink.Run(_first, _second);
 
-        internal sealed class _ : Sink<TResult>
+        internal sealed class _ : IdentitySink<TResult>
         {
             private readonly Func<TFirst, TSecond, TResult> _resultSelector;
 
@@ -93,17 +93,15 @@ namespace System.Reactive.Linq.ObservableImpl
                             }
                             catch (Exception ex)
                             {
-                                _parent._observer.OnError(ex);
-                                _parent.Dispose();
+                                _parent.ForwardOnError(ex);
                                 return;
                             }
 
-                            _parent._observer.OnNext(res);
+                            _parent.ForwardOnNext(res);
                         }
                         else if (_other.Done)
                         {
-                            _parent._observer.OnCompleted();
-                            _parent.Dispose();
+                            _parent.ForwardOnCompleted();
                             return;
                         }
                     }
@@ -113,8 +111,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     lock (_parent._gate)
                     {
-                        _parent._observer.OnError(error);
-                        _parent.Dispose();
+                        _parent.ForwardOnError(error);
                     }
                 }
 
@@ -126,8 +123,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                         if (_other.Done)
                         {
-                            _parent._observer.OnCompleted();
-                            _parent.Dispose();
+                            _parent.ForwardOnCompleted();
                             return;
                         }
                         else
@@ -172,17 +168,15 @@ namespace System.Reactive.Linq.ObservableImpl
                             }
                             catch (Exception ex)
                             {
-                                _parent._observer.OnError(ex);
-                                _parent.Dispose();
+                                _parent.ForwardOnError(ex);
                                 return;
                             }
 
-                            _parent._observer.OnNext(res);
+                            _parent.ForwardOnNext(res);
                         }
                         else if (_other.Done)
                         {
-                            _parent._observer.OnCompleted();
-                            _parent.Dispose();
+                            _parent.ForwardOnCompleted();
                             return;
                         }
                     }
@@ -192,8 +186,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     lock (_parent._gate)
                     {
-                        _parent._observer.OnError(error);
-                        _parent.Dispose();
+                        _parent.ForwardOnError(error);
                     }
                 }
 
@@ -205,8 +198,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                         if (_other.Done)
                         {
-                            _parent._observer.OnCompleted();
-                            _parent.Dispose();
+                            _parent.ForwardOnCompleted();
                             return;
                         }
                         else
@@ -232,7 +224,7 @@ namespace System.Reactive.Linq.ObservableImpl
         void Done(int index);
     }
 
-    internal abstract class CombineLatestSink<TResult> : Sink<TResult>, ICombineLatest
+    internal abstract class CombineLatestSink<TResult> : IdentitySink<TResult>, ICombineLatest
     {
         protected readonly object _gate;
 
@@ -277,12 +269,12 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception ex)
                 {
-                    base._observer.OnError(ex);
-                    base.Dispose();
+                    ForwardOnError(ex);
+
                     return;
                 }
 
-                base._observer.OnNext(res);
+                ForwardOnNext(res);
             }
             else
             {
@@ -298,8 +290,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 if (allOthersDone)
                 {
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnCompleted();
                 }
             }
         }
@@ -308,8 +299,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         public void Fail(Exception error)
         {
-            base._observer.OnError(error);
-            base.Dispose();
+            ForwardOnError(error);
         }
 
         public void Done(int index)
@@ -328,8 +318,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             if (allDone)
             {
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnCompleted();
                 return;
             }
         }
@@ -404,7 +393,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => sink.Run(_sources);
 
-        internal sealed class _ : Sink<TResult>
+        internal sealed class _ : IdentitySink<TResult>
         {
             private readonly Func<IList<TSource>, TResult> _resultSelector;
 
@@ -471,28 +460,25 @@ namespace System.Reactive.Linq.ObservableImpl
                         }
                         catch (Exception ex)
                         {
-                            base._observer.OnError(ex);
-                            base.Dispose();
+                            ForwardOnError(ex);
                             return;
                         }
 
-                        _observer.OnNext(res);
+                        ForwardOnNext(res);
                     }
                     else if (_isDone.AllExcept(index))
                     {
-                        base._observer.OnCompleted();
-                        base.Dispose();
+                        ForwardOnCompleted();
                         return;
                     }
                 }
             }
 
-            private void OnError(Exception error)
+            private new void OnError(Exception error)
             {
                 lock (_gate)
                 {
-                    base._observer.OnError(error);
-                    base.Dispose();
+                    ForwardOnError(error);
                 }
             }
 
@@ -504,8 +490,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                     if (_isDone.All())
                     {
-                        base._observer.OnCompleted();
-                        base.Dispose();
+                        ForwardOnCompleted();
                         return;
                     }
                     else

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Concat.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Concat.cs
@@ -27,17 +27,6 @@ namespace System.Reactive.Linq.ObservableImpl
                 : base(observer, cancel)
             {
             }
-
-            public override void OnNext(TSource value)
-            {
-                base._observer.OnNext(value);
-            }
-
-            public override void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
         }
     }
 }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Contains.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Contains.cs
@@ -23,7 +23,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<bool>, IObserver<TSource>
+        internal sealed class _ : Sink<TSource, bool> 
         {
             private readonly TSource _value;
             private readonly IEqualityComparer<TSource> _comparer;
@@ -35,7 +35,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _comparer = parent._comparer;
             }
 
-            public void OnNext(TSource value)
+            public override void OnNext(TSource value)
             {
                 var res = false;
                 try
@@ -44,30 +44,21 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception ex)
                 {
-                    base._observer.OnError(ex);
-                    base.Dispose();
+                    ForwardOnError(ex);
                     return;
                 }
 
                 if (res)
                 {
-                    base._observer.OnNext(true);
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnNext(true);
+                    ForwardOnCompleted();
                 }
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext(false);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(false);
+                ForwardOnCompleted();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Count.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Count.cs
@@ -19,7 +19,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<int>, IObserver<TSource>
+            internal sealed class _ : Sink<TSource, int> 
             {
                 private int _count;
 
@@ -29,7 +29,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     _count = 0;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     try
                     {
@@ -40,22 +40,14 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception ex)
                     {
-                        base._observer.OnError(ex);
-                        base.Dispose();
+                        ForwardOnError(ex);
                     }
                 }
 
-                public void OnError(Exception error)
+                public override void OnCompleted()
                 {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnNext(_count);
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnNext(_count);
+                    ForwardOnCompleted();
                 }
             }
         }
@@ -75,7 +67,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<int>, IObserver<TSource>
+            internal sealed class _ : Sink<TSource, int> 
             {
                 private readonly Func<TSource, bool> _predicate;
                 private int _count;
@@ -87,7 +79,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     _count = 0;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     try
                     {
@@ -101,22 +93,14 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception ex)
                     {
-                        base._observer.OnError(ex);
-                        base.Dispose();
+                        ForwardOnError(ex);
                     }
                 }
 
-                public void OnError(Exception error)
+                public override void OnCompleted()
                 {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnNext(_count);
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnNext(_count);
+                    ForwardOnCompleted();
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/DefaultIfEmpty.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/DefaultIfEmpty.cs
@@ -19,7 +19,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<TSource>, IObserver<TSource>
+        internal sealed class _ : IdentitySink<TSource>
         {
             private readonly TSource _defaultValue;
             private bool _found;
@@ -31,24 +31,18 @@ namespace System.Reactive.Linq.ObservableImpl
                 _found = false;
             }
 
-            public void OnNext(TSource value)
+            public override void OnNext(TSource value)
             {
                 _found = true;
-                base._observer.OnNext(value);
+                ForwardOnNext(value);
             }
 
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
+            public override void OnCompleted()
             {
                 if (!_found)
-                    base._observer.OnNext(_defaultValue);
-                base._observer.OnCompleted();
-                base.Dispose();
+                    ForwardOnNext(_defaultValue);
+
+                ForwardOnCompleted();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Defer.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Defer.cs
@@ -21,7 +21,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         public IObservable<TValue> Eval() => _observableFactory();
 
-        internal sealed class _ : Sink<TValue>, IObserver<TValue>
+        internal sealed class _ : IdentitySink<TValue>
         {
             private readonly Func<IObservable<TValue>> _observableFactory;
 
@@ -40,29 +40,11 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception exception)
                 {
-                    base._observer.OnError(exception);
-                    base.Dispose();
+                    ForwardOnError(exception);
                     return Disposable.Empty;
                 }
 
                 return result.SubscribeSafe(this);
-            }
-
-            public void OnNext(TValue value)
-            {
-                base._observer.OnNext(value);
-            }
-
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnCompleted();
-                base.Dispose();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/DelaySubscription.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/DelaySubscription.cs
@@ -52,28 +52,11 @@ namespace System.Reactive.Linq.ObservableImpl
             return _source.SubscribeSafe(sink);
         }
 
-        internal sealed class _ : Sink<TSource>, IObserver<TSource>
+        internal sealed class _ : IdentitySink<TSource>
         {
             public _(IObserver<TSource> observer, IDisposable cancel)
                 : base(observer, cancel)
             {
-            }
-
-            public void OnNext(TSource value)
-            {
-                base._observer.OnNext(value);
-            }
-
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnCompleted();
-                base.Dispose();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Dematerialize.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Dematerialize.cs
@@ -17,41 +17,27 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<TSource>, IObserver<Notification<TSource>>
+        internal sealed class _ : Sink<Notification<TSource>, TSource> 
         {
             public _(IObserver<TSource> observer, IDisposable cancel)
                 : base(observer, cancel)
             {
             }
 
-            public void OnNext(Notification<TSource> value)
+            public override void OnNext(Notification<TSource> value)
             {
                 switch (value.Kind)
                 {
                     case NotificationKind.OnNext:
-                        base._observer.OnNext(value.Value);
+                        ForwardOnNext(value.Value);
                         break;
                     case NotificationKind.OnError:
-                        base._observer.OnError(value.Exception);
-                        base.Dispose();
+                        ForwardOnError(value.Exception);
                         break;
                     case NotificationKind.OnCompleted:
-                        base._observer.OnCompleted();
-                        base.Dispose();
+                        ForwardOnCompleted();
                         break;
                 }
-            }
-
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnCompleted();
-                base.Dispose();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Distinct.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Distinct.cs
@@ -23,7 +23,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<TSource>, IObserver<TSource>
+        internal sealed class _ : IdentitySink<TSource>
         {
             private readonly Func<TSource, TKey> _keySelector;
             private HashSet<TKey> _hashSet;
@@ -35,7 +35,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _hashSet = new HashSet<TKey>(parent._comparer);
             }
 
-            public void OnNext(TSource value)
+            public override void OnNext(TSource value)
             {
                 var key = default(TKey);
                 var hasAdded = false;
@@ -46,25 +46,12 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception exception)
                 {
-                    base._observer.OnError(exception);
-                    base.Dispose();
+                    ForwardOnError(exception);
                     return;
                 }
 
                 if (hasAdded)
-                    base._observer.OnNext(value);
-            }
-
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnCompleted();
-                base.Dispose();
+                    ForwardOnNext(value);
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/DistinctUntilChanged.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/DistinctUntilChanged.cs
@@ -23,7 +23,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<TSource>, IObserver<TSource>
+        internal sealed class _ : IdentitySink<TSource>
         {
             private readonly Func<TSource, TKey> _keySelector;
             private readonly IEqualityComparer<TKey> _comparer;
@@ -41,7 +41,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _hasCurrentKey = false;
             }
 
-            public void OnNext(TSource value)
+            public override void OnNext(TSource value)
             {
                 var key = default(TKey);
                 try
@@ -50,8 +50,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception exception)
                 {
-                    base._observer.OnError(exception);
-                    base.Dispose();
+                    ForwardOnError(exception);
                     return;
                 }
 
@@ -64,8 +63,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception exception)
                     {
-                        base._observer.OnError(exception);
-                        base.Dispose();
+                        ForwardOnError(exception);
                         return;
                     }
                 }
@@ -74,20 +72,8 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     _hasCurrentKey = true;
                     _currentKey = key;
-                    base._observer.OnNext(value);
+                    ForwardOnNext(value);
                 }
-            }
-
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnCompleted();
-                base.Dispose();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Do.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Do.cs
@@ -21,7 +21,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TSource>, IObserver<TSource>
+            internal sealed class _ : IdentitySink<TSource>
             {
                 private readonly Action<TSource> _onNext;
 
@@ -31,7 +31,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     _onNext = onNext;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     try
                     {
@@ -39,24 +39,11 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception ex)
                     {
-                        base._observer.OnError(ex);
-                        base.Dispose();
+                        ForwardOnError(ex);
                         return;
                     }
 
-                    base._observer.OnNext(value);
-                }
-
-                public void OnError(Exception error)
-                {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnNext(value);
                 }
             }
         }
@@ -76,7 +63,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TSource>, IObserver<TSource>
+            internal sealed class _ : IdentitySink<TSource>
             {
                 private readonly IObserver<TSource> _doObserver;
 
@@ -86,7 +73,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     _doObserver = doObserver;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     try
                     {
@@ -94,15 +81,14 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception ex)
                     {
-                        base._observer.OnError(ex);
-                        base.Dispose();
+                        ForwardOnError(ex);
                         return;
                     }
 
-                    base._observer.OnNext(value);
+                    ForwardOnNext(value);
                 }
 
-                public void OnError(Exception error)
+                public override void OnError(Exception error)
                 {
                     try
                     {
@@ -110,16 +96,14 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception ex)
                     {
-                        base._observer.OnError(ex);
-                        base.Dispose();
+                        ForwardOnError(ex);
                         return;
                     }
 
-                    base._observer.OnError(error);
-                    base.Dispose();
+                    ForwardOnError(error);
                 }
 
-                public void OnCompleted()
+                public override void OnCompleted()
                 {
                     try
                     {
@@ -127,13 +111,11 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception ex)
                     {
-                        base._observer.OnError(ex);
-                        base.Dispose();
+                        ForwardOnError(ex);
                         return;
                     }
 
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnCompleted();
                 }
             }
         }
@@ -157,7 +139,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TSource>, IObserver<TSource>
+            internal sealed class _ : IdentitySink<TSource>
             {
                 // CONSIDER: This sink has a parent reference that can be considered for removal.
 
@@ -169,7 +151,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     _parent = parent;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     try
                     {
@@ -177,15 +159,14 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception ex)
                     {
-                        base._observer.OnError(ex);
-                        base.Dispose();
+                        ForwardOnError(ex);
                         return;
                     }
 
-                    base._observer.OnNext(value);
+                    ForwardOnNext(value);
                 }
 
-                public void OnError(Exception error)
+                public override void OnError(Exception error)
                 {
                     try
                     {
@@ -193,16 +174,14 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception ex)
                     {
-                        base._observer.OnError(ex);
-                        base.Dispose();
+                        ForwardOnError(ex);
                         return;
                     }
 
-                    base._observer.OnError(error);
-                    base.Dispose();
+                    ForwardOnError(error);
                 }
 
-                public void OnCompleted()
+                public override void OnCompleted()
                 {
                     try
                     {
@@ -210,13 +189,11 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception ex)
                     {
-                        base._observer.OnError(ex);
-                        base.Dispose();
+                        ForwardOnError(ex);
                         return;
                     }
 
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnCompleted();
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/DoWhile.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/DoWhile.cs
@@ -34,17 +34,6 @@ namespace System.Reactive.Linq.ObservableImpl
                 : base(observer, cancel)
             {
             }
-
-            public override void OnNext(TSource value)
-            {
-                base._observer.OnNext(value);
-            }
-
-            public override void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
         }
     }
 }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/ElementAt.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/ElementAt.cs
@@ -19,7 +19,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<TSource>, IObserver<TSource>
+        internal sealed class _ : IdentitySink<TSource>
         {
             private int _i;
 
@@ -29,28 +29,20 @@ namespace System.Reactive.Linq.ObservableImpl
                 _i = index;
             }
 
-            public void OnNext(TSource value)
+            public override void OnNext(TSource value)
             {
                 if (_i == 0)
                 {
-                    base._observer.OnNext(value);
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnNext(value);
+                    ForwardOnCompleted();
                 }
 
                 _i--;
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnError(new ArgumentOutOfRangeException("index"));
-                base.Dispose();
+                ForwardOnError(new ArgumentOutOfRangeException("index"));
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/ElementAtOrDefault.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/ElementAtOrDefault.cs
@@ -19,7 +19,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<TSource>, IObserver<TSource>
+        internal sealed class _ : IdentitySink<TSource>
         {
             private int _i;
 
@@ -29,29 +29,21 @@ namespace System.Reactive.Linq.ObservableImpl
                 _i = index;
             }
 
-            public void OnNext(TSource value)
+            public override void OnNext(TSource value)
             {
                 if (_i == 0)
                 {
-                    base._observer.OnNext(value);
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnNext(value);
+                    ForwardOnCompleted();
                 }
 
                 _i--;
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext(default(TSource));
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(default(TSource));
+                ForwardOnCompleted();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Empty.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Empty.cs
@@ -19,7 +19,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => sink.Run(_scheduler);
 
-        internal sealed class _ : Sink<TResult>
+        internal sealed class _ : IdentitySink<TResult>
         {
             public _(IObserver<TResult> observer, IDisposable cancel)
                 : base(observer, cancel)
@@ -33,8 +33,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             private void Invoke()
             {
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnCompleted();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Finally.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Finally.cs
@@ -21,7 +21,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => sink.Run(_source);
 
-        internal sealed class _ : Sink<TSource>, IObserver<TSource>
+        internal sealed class _ : IdentitySink<TSource>
         {
             private readonly Action _finallyAction;
 
@@ -46,23 +46,6 @@ namespace System.Reactive.Linq.ObservableImpl
                         _finallyAction();
                     }
                 });
-            }
-
-            public void OnNext(TSource value)
-            {
-                base._observer.OnNext(value);
-            }
-
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnCompleted();
-                base.Dispose();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/FirstAsync.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/FirstAsync.cs
@@ -19,30 +19,22 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TSource>, IObserver<TSource>
+            internal sealed class _ : IdentitySink<TSource>
             {
                 public _(IObserver<TSource> observer, IDisposable cancel)
                     : base(observer, cancel)
                 {
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
-                    base._observer.OnNext(value);
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnNext(value);
+                    ForwardOnCompleted();
                 }
 
-                public void OnError(Exception error)
+                public override void OnCompleted()
                 {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
-                    base.Dispose();
+                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
                 }
             }
         }
@@ -62,7 +54,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TSource>, IObserver<TSource>
+            internal sealed class _ : IdentitySink<TSource>
             {
                 private readonly Func<TSource, bool> _predicate;
 
@@ -72,7 +64,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     _predicate = predicate;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     var b = false;
 
@@ -82,29 +74,20 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception ex)
                     {
-                        base._observer.OnError(ex);
-                        base.Dispose();
+                        ForwardOnError(ex);
                         return;
                     }
 
                     if (b)
                     {
-                        base._observer.OnNext(value);
-                        base._observer.OnCompleted();
-                        base.Dispose();
+                        ForwardOnNext(value);
+                        ForwardOnCompleted();
                     }
                 }
 
-                public void OnError(Exception error)
+                public override void OnCompleted()
                 {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnError(new InvalidOperationException(Strings_Linq.NO_MATCHING_ELEMENTS));
-                    base.Dispose();
+                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_MATCHING_ELEMENTS));
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/FirstOrDefaultAsync.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/FirstOrDefaultAsync.cs
@@ -19,31 +19,23 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TSource>, IObserver<TSource>
+            internal sealed class _ : IdentitySink<TSource>
             {
                 public _(IObserver<TSource> observer, IDisposable cancel)
                     : base(observer, cancel)
                 {
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
-                    base._observer.OnNext(value);
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnNext(value);
+                    ForwardOnCompleted();
                 }
 
-                public void OnError(Exception error)
+                public override void OnCompleted()
                 {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnNext(default(TSource));
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnNext(default(TSource));
+                    ForwardOnCompleted();
                 }
             }
         }
@@ -63,7 +55,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TSource>, IObserver<TSource>
+            internal sealed class _ : IdentitySink<TSource>
             {
                 private readonly Func<TSource, bool> _predicate;
 
@@ -73,7 +65,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     _predicate = predicate;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     var b = false;
 
@@ -83,30 +75,21 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception ex)
                     {
-                        base._observer.OnError(ex);
-                        base.Dispose();
+                        ForwardOnError(ex);
                         return;
                     }
 
                     if (b)
                     {
-                        base._observer.OnNext(value);
-                        base._observer.OnCompleted();
-                        base.Dispose();
+                        ForwardOnNext(value);
+                        ForwardOnCompleted();
                     }
                 }
 
-                public void OnError(Exception error)
+                public override void OnCompleted()
                 {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnNext(default(TSource));
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnNext(default(TSource));
+                    ForwardOnCompleted();
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/For.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/For.cs
@@ -33,17 +33,6 @@ namespace System.Reactive.Linq.ObservableImpl
                 : base(observer, cancel)
             {
             }
-
-            public override void OnNext(TResult value)
-            {
-                base._observer.OnNext(value);
-            }
-
-            public override void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
         }
     }
 }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Generate.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Generate.cs
@@ -30,7 +30,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => sink.Run();
 
-            internal sealed class _ : Sink<TResult>
+            internal sealed class _ : IdentitySink<TResult>
             {
                 // CONSIDER: This sink has a parent reference that can be considered for removal.
 
@@ -87,14 +87,13 @@ namespace System.Reactive.Linq.ObservableImpl
                         }
                         catch (Exception exception)
                         {
-                            base._observer.OnError(exception);
-                            base.Dispose();
+                            ForwardOnError(exception);
                             return;
                         }
 
                         if (hasResult)
                         {
-                            base._observer.OnNext(result);
+                            ForwardOnNext(result);
                         }
                         else
                         {
@@ -104,10 +103,8 @@ namespace System.Reactive.Linq.ObservableImpl
 
                     if (!cancel.IsDisposed)
                     {
-                        base._observer.OnCompleted();
+                        ForwardOnCompleted();
                     }
-
-                    base.Dispose();
                 }
 
                 private void LoopRec(Action recurse)
@@ -134,20 +131,18 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception exception)
                     {
-                        base._observer.OnError(exception);
-                        base.Dispose();
+                        ForwardOnError(exception);
                         return;
                     }
 
                     if (hasResult)
                     {
-                        base._observer.OnNext(result);
+                        ForwardOnNext(result);
                         recurse();
                     }
                     else
                     {
-                        base._observer.OnCompleted();
-                        base.Dispose();
+                        ForwardOnCompleted();
                     }
                 }
             }
@@ -176,7 +171,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => sink.Run();
 
-            internal sealed class _ : Sink<TResult>
+            internal sealed class _ : IdentitySink<TResult>
             {
                 // CONSIDER: This sink has a parent reference that can be considered for removal.
 
@@ -207,7 +202,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                     if (_hasResult)
                     {
-                        base._observer.OnNext(_result);
+                        ForwardOnNext(_result);
                     }
 
                     try
@@ -231,15 +226,13 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception exception)
                     {
-                        base._observer.OnError(exception);
-                        base.Dispose();
+                        ForwardOnError(exception);
                         return Disposable.Empty;
                     }
 
                     if (!_hasResult)
                     {
-                        base._observer.OnCompleted();
-                        base.Dispose();
+                        ForwardOnCompleted();
                         return Disposable.Empty;
                     }
 
@@ -271,7 +264,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => sink.Run();
 
-            internal sealed class _ : Sink<TResult>
+            internal sealed class _ : IdentitySink<TResult>
             {
                 // CONSIDER: This sink has a parent reference that can be considered for removal.
 
@@ -302,7 +295,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                     if (_hasResult)
                     {
-                        base._observer.OnNext(_result);
+                        ForwardOnNext(_result);
                     }
 
                     try
@@ -326,15 +319,13 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception exception)
                     {
-                        base._observer.OnError(exception);
-                        base.Dispose();
+                        ForwardOnError(exception);
                         return Disposable.Empty;
                     }
 
                     if (!_hasResult)
                     {
-                        base._observer.OnCompleted();
-                        base.Dispose();
+                        ForwardOnCompleted();
                         return Disposable.Empty;
                     }
 

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/GroupBy.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/GroupBy.cs
@@ -29,7 +29,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => sink.Run(_source);
 
-        internal sealed class _ : Sink<IGroupedObservable<TKey, TElement>>, IObserver<TSource>
+        internal sealed class _ : Sink<TSource, IGroupedObservable<TKey, TElement>> 
         {
             private readonly Func<TSource, TKey> _keySelector;
             private readonly Func<TSource, TElement> _elementSelector;
@@ -62,7 +62,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 return _refCountDisposable;
             }
 
-            public void OnNext(TSource value)
+            public override void OnNext(TSource value)
             {
                 var key = default(TKey);
                 try
@@ -126,7 +126,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 if (fireNewMapEntry)
                 {
                     var group = new GroupedObservable<TKey, TElement>(key, writer, _refCountDisposable);
-                    _observer.OnNext(group);
+                    ForwardOnNext(group);
                 }
 
                 var element = default(TElement);
@@ -143,20 +143,19 @@ namespace System.Reactive.Linq.ObservableImpl
                 writer.OnNext(element);
             }
 
-            public void OnError(Exception error)
+            public override void OnError(Exception error)
             {
                 Error(error);
             }
 
-            public void OnCompleted()
+            public override void OnCompleted()
             {
                 _null?.OnCompleted();
 
                 foreach (var w in _map.Values)
                     w.OnCompleted();
 
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnCompleted();
             }
 
             private void Error(Exception exception)
@@ -166,8 +165,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 foreach (var w in _map.Values)
                     w.OnError(exception);
 
-                base._observer.OnError(exception);
-                base.Dispose();
+                ForwardOnError(exception);
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/GroupJoin.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/GroupJoin.cs
@@ -29,7 +29,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => sink.Run(this);
 
-        internal sealed class _ : Sink<TResult>
+        internal sealed class _ : IdentitySink<TResult>
         {
             private readonly object _gate = new object();
             private readonly CompositeDisposable _group = new CompositeDisposable();
@@ -141,7 +141,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                     lock (_parent._gate)
                     {
-                        _parent._observer.OnNext(result);
+                        _parent.ForwardOnNext(result);
 
                         foreach (var rightValue in _parent._rightMap)
                         {
@@ -193,8 +193,7 @@ namespace System.Reactive.Linq.ObservableImpl
                             o.Value.OnError(error);
                         }
 
-                        _parent._observer.OnError(error);
-                        _parent.Dispose();
+                        _parent.ForwardOnError(error);
                     }
                 }
 
@@ -202,8 +201,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     lock (_parent._gate)
                     {
-                        _parent._observer.OnCompleted();
-                        _parent.Dispose();
+                        _parent.ForwardOnCompleted();
                     }
 
                     _self.Dispose();
@@ -308,8 +306,7 @@ namespace System.Reactive.Linq.ObservableImpl
                             o.Value.OnError(error);
                         }
 
-                        _parent._observer.OnError(error);
-                        _parent.Dispose();
+                        _parent.ForwardOnError(error);
                     }
                 }
 

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/If.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/If.cs
@@ -25,7 +25,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => sink.Run();
 
-        internal sealed class _ : Sink<TResult>, IObserver<TResult>
+        internal sealed class _ : IdentitySink<TResult>
         {
             private readonly If<TResult> _parent;
 
@@ -44,29 +44,11 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception exception)
                 {
-                    base._observer.OnError(exception);
-                    base.Dispose();
+                    ForwardOnError(exception);
                     return Disposable.Empty;
                 }
 
                 return result.SubscribeSafe(this);
-            }
-
-            public void OnNext(TResult value)
-            {
-                base._observer.OnNext(value);
-            }
-
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnCompleted();
-                base.Dispose();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/IgnoreElements.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/IgnoreElements.cs
@@ -17,27 +17,15 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<TSource>, IObserver<TSource>
+        internal sealed class _ : IdentitySink<TSource>
         {
             public _(IObserver<TSource> observer, IDisposable cancel)
                 : base(observer, cancel)
             {
             }
 
-            public void OnNext(TSource value)
+            public override void OnNext(TSource value)
             {
-            }
-
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnCompleted();
-                base.Dispose();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/IsEmpty.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/IsEmpty.cs
@@ -17,31 +17,23 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<bool>, IObserver<TSource>
+        internal sealed class _ : Sink<TSource, bool> 
         {
             public _(IObserver<bool> observer, IDisposable cancel)
                 : base(observer, cancel)
             {
             }
 
-            public void OnNext(TSource value)
+            public override void OnNext(TSource value)
             {
-                base._observer.OnNext(false);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(false);
+                ForwardOnCompleted();
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext(true);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(true);
+                ForwardOnCompleted();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Join.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Join.cs
@@ -28,7 +28,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => sink.Run(this);
 
-        internal sealed class _ : Sink<TResult>
+        internal sealed class _ : IdentitySink<TResult>
         {
             private readonly object _gate = new object();
             private readonly CompositeDisposable _group = new CompositeDisposable();
@@ -88,8 +88,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     {
                         if (_parent._leftMap.Remove(id) && _parent._leftMap.Count == 0 && _parent._leftDone)
                         {
-                            _parent._observer.OnCompleted();
-                            _parent.Dispose();
+                            _parent.ForwardOnCompleted();
                         }
                     }
 
@@ -117,8 +116,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception exception)
                     {
-                        _parent._observer.OnError(exception);
-                        _parent.Dispose();
+                        _parent.ForwardOnError(exception);
                         return;
                     }
 
@@ -137,12 +135,11 @@ namespace System.Reactive.Linq.ObservableImpl
                                 }
                                 catch (Exception exception)
                                 {
-                                    _parent._observer.OnError(exception);
-                                    _parent.Dispose();
+                                    _parent.ForwardOnError(exception);
                                     return;
                                 }
 
-                                _parent._observer.OnNext(result);
+                                _parent.ForwardOnNext(result);
                             }
                         }
                     }
@@ -181,8 +178,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     lock (_parent._gate)
                     {
-                        _parent._observer.OnError(error);
-                        _parent.Dispose();
+                        _parent.ForwardOnError(error);
                     }
                 }
 
@@ -193,8 +189,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         _parent._leftDone = true;
                         if (_parent._rightDone || _parent._leftMap.Count == 0)
                         {
-                            _parent._observer.OnCompleted();
-                            _parent.Dispose();
+                            _parent.ForwardOnCompleted();
                         }
                         else
                         {
@@ -221,8 +216,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     {
                         if (_parent._rightMap.Remove(id) && _parent._rightMap.Count == 0 && _parent._rightDone)
                         {
-                            _parent._observer.OnCompleted();
-                            _parent.Dispose();
+                            _parent.ForwardOnCompleted();
                         }
                     }
 
@@ -250,8 +244,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception exception)
                     {
-                        _parent._observer.OnError(exception);
-                        _parent.Dispose();
+                        _parent.ForwardOnError(exception);
                         return;
                     }
 
@@ -270,12 +263,11 @@ namespace System.Reactive.Linq.ObservableImpl
                                 }
                                 catch (Exception exception)
                                 {
-                                    _parent._observer.OnError(exception);
-                                    _parent.Dispose();
+                                    _parent.ForwardOnError(exception);
                                     return;
                                 }
 
-                                _parent._observer.OnNext(result);
+                                _parent.ForwardOnNext(result);
                             }
                         }
                     }
@@ -314,8 +306,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     lock (_parent._gate)
                     {
-                        _parent._observer.OnError(error);
-                        _parent.Dispose();
+                        _parent.ForwardOnError(error);
                     }
                 }
 
@@ -326,8 +317,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         _parent._rightDone = true;
                         if (_parent._leftDone || _parent._rightMap.Count == 0)
                         {
-                            _parent._observer.OnCompleted();
-                            _parent.Dispose();
+                            _parent.ForwardOnCompleted();
                         }
                         else
                         {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/LastAsync.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/LastAsync.cs
@@ -19,7 +19,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TSource>, IObserver<TSource>
+            internal sealed class _ : IdentitySink<TSource>
             {
                 private TSource _value;
                 private bool _seenValue;
@@ -31,31 +31,23 @@ namespace System.Reactive.Linq.ObservableImpl
                     _seenValue = false;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     _value = value;
                     _seenValue = true;
                 }
 
-                public void OnError(Exception error)
-                {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
+                public override void OnCompleted()
                 {
                     if (!_seenValue)
                     {
-                        base._observer.OnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                        ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
                     }
                     else
                     {
-                        base._observer.OnNext(_value);
-                        base._observer.OnCompleted();
+                        ForwardOnNext(_value);
+                        ForwardOnCompleted();
                     }
-
-                    base.Dispose();
                 }
             }
         }
@@ -75,7 +67,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TSource>, IObserver<TSource>
+            internal sealed class _ : IdentitySink<TSource>
             {
                 private readonly Func<TSource, bool> _predicate;
                 private TSource _value;
@@ -90,7 +82,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     _seenValue = false;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     var b = false;
 
@@ -100,8 +92,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception ex)
                     {
-                        base._observer.OnError(ex);
-                        base.Dispose();
+                        ForwardOnError(ex);
                         return;
                     }
 
@@ -112,25 +103,17 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                 }
 
-                public void OnError(Exception error)
-                {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
+                public override void OnCompleted()
                 {
                     if (!_seenValue)
                     {
-                        base._observer.OnError(new InvalidOperationException(Strings_Linq.NO_MATCHING_ELEMENTS));
+                        ForwardOnError(new InvalidOperationException(Strings_Linq.NO_MATCHING_ELEMENTS));
                     }
                     else
                     {
-                        base._observer.OnNext(_value);
-                        base._observer.OnCompleted();
+                        ForwardOnNext(_value);
+                        ForwardOnCompleted();
                     }
-
-                    base.Dispose();
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/LastOrDefaultAsync.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/LastOrDefaultAsync.cs
@@ -19,7 +19,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TSource>, IObserver<TSource>
+            internal sealed class _ : IdentitySink<TSource>
             {
                 private TSource _value;
 
@@ -29,22 +29,15 @@ namespace System.Reactive.Linq.ObservableImpl
                     _value = default(TSource);
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     _value = value;
                 }
 
-                public void OnError(Exception error)
+                public override void OnCompleted()
                 {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnNext(_value);
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnNext(_value);
+                    ForwardOnCompleted();
                 }
             }
         }
@@ -64,7 +57,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TSource>, IObserver<TSource>
+            internal sealed class _ : IdentitySink<TSource>
             {
                 private readonly Func<TSource, bool> _predicate;
                 private TSource _value;
@@ -77,7 +70,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     _value = default(TSource);
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     var b = false;
 
@@ -87,8 +80,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception ex)
                     {
-                        base._observer.OnError(ex);
-                        base.Dispose();
+                        ForwardOnError(ex);
                         return;
                     }
 
@@ -98,17 +90,10 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                 }
 
-                public void OnError(Exception error)
+                public override void OnCompleted()
                 {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnNext(_value);
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnNext(_value);
+                    ForwardOnCompleted();
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/LongCount.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/LongCount.cs
@@ -19,7 +19,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<long>, IObserver<TSource>
+            internal sealed class _ : Sink<TSource, long> 
             {
                 private long _count;
 
@@ -29,7 +29,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     _count = 0L;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     try
                     {
@@ -40,22 +40,14 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception ex)
                     {
-                        base._observer.OnError(ex);
-                        base.Dispose();
+                        ForwardOnError(ex);
                     }
                 }
 
-                public void OnError(Exception error)
+                public override void OnCompleted()
                 {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnNext(_count);
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnNext(_count);
+                    ForwardOnCompleted();
                 }
             }
         }
@@ -75,7 +67,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<long>, IObserver<TSource>
+            internal sealed class _ : Sink<TSource, long> 
             {
                 private readonly Func<TSource, bool> _predicate;
                 private long _count;
@@ -87,7 +79,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     _count = 0L;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     try
                     {
@@ -101,22 +93,14 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception ex)
                     {
-                        base._observer.OnError(ex);
-                        base.Dispose();
+                        ForwardOnError(ex);
                     }
                 }
 
-                public void OnError(Exception error)
+                public override void OnCompleted()
                 {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnNext(_count);
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnNext(_count);
+                    ForwardOnCompleted();
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Materialize.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Materialize.cs
@@ -19,30 +19,28 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<Notification<TSource>>, IObserver<TSource>
+        internal sealed class _ : Sink<TSource, Notification<TSource>> 
         {
             public _(IObserver<Notification<TSource>> observer, IDisposable cancel)
                 : base(observer, cancel)
             {
             }
 
-            public void OnNext(TSource value)
+            public override void OnNext(TSource value)
             {
-                base._observer.OnNext(Notification.CreateOnNext<TSource>(value));
+                ForwardOnNext(Notification.CreateOnNext<TSource>(value));
             }
 
-            public void OnError(Exception error)
+            public override void OnError(Exception error)
             {
-                base._observer.OnNext(Notification.CreateOnError<TSource>(error));
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(Notification.CreateOnError<TSource>(error));
+                ForwardOnCompleted();
             }
 
-            public void OnCompleted()
+            public override void OnCompleted()
             {
-                base._observer.OnNext(Notification.CreateOnCompleted<TSource>());
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(Notification.CreateOnCompleted<TSource>());
+                ForwardOnCompleted();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Max.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Max.cs
@@ -21,7 +21,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal abstract class _ : Sink<TSource>, IObserver<TSource>
+        internal abstract class _ : IdentitySink<TSource>
         {
             protected readonly IComparer<TSource> _comparer;
 
@@ -30,10 +30,6 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 _comparer = comparer;
             }
-
-            public abstract void OnCompleted();
-            public abstract void OnError(Exception error);
-            public abstract void OnNext(TSource value);
         }
 
         private sealed class NonNull : _
@@ -60,8 +56,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception ex)
                     {
-                        base._observer.OnError(ex);
-                        base.Dispose();
+                        ForwardOnError(ex);
                         return;
                     }
 
@@ -77,25 +72,17 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
 
-            public override void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
             public override void OnCompleted()
             {
                 if (!_hasValue)
                 {
-                    base._observer.OnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
                 }
                 else
                 {
-                    base._observer.OnNext(_lastValue);
-                    base._observer.OnCompleted();
+                    ForwardOnNext(_lastValue);
+                    ForwardOnCompleted();
                 }
-
-                base.Dispose();
             }
         }
 
@@ -127,8 +114,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         }
                         catch (Exception ex)
                         {
-                            base._observer.OnError(ex);
-                            base.Dispose();
+                            ForwardOnError(ex);
                             return;
                         }
 
@@ -142,15 +128,13 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public override void OnError(Exception error)
             {
-                base._observer.OnError(error);
-                base.Dispose();
+                ForwardOnError(error);
             }
 
             public override void OnCompleted()
             {
-                base._observer.OnNext(_lastValue);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_lastValue);
+                ForwardOnCompleted();
             }
         }
     }
@@ -168,7 +152,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<double>, IObserver<double>
+        internal sealed class _ : IdentitySink<double>
         {
             private bool _hasValue;
             private double _lastValue;
@@ -180,7 +164,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _lastValue = default(double);
             }
 
-            public void OnNext(double value)
+            public override void OnNext(double value)
             {
                 if (_hasValue)
                 {
@@ -196,25 +180,17 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
 
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
+            public override void OnCompleted()
             {
                 if (!_hasValue)
                 {
-                    base._observer.OnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
                 }
                 else
                 {
-                    base._observer.OnNext(_lastValue);
-                    base._observer.OnCompleted();
+                    ForwardOnNext(_lastValue);
+                    ForwardOnCompleted();
                 }
-
-                base.Dispose();
             }
         }
     }
@@ -232,7 +208,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<float>, IObserver<float>
+        internal sealed class _ : IdentitySink<float>
         {
             private bool _hasValue;
             private float _lastValue;
@@ -244,7 +220,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _lastValue = default(float);
             }
 
-            public void OnNext(float value)
+            public override void OnNext(float value)
             {
                 if (_hasValue)
                 {
@@ -260,25 +236,17 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
 
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
+            public override void OnCompleted()
             {
                 if (!_hasValue)
                 {
-                    base._observer.OnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
                 }
                 else
                 {
-                    base._observer.OnNext(_lastValue);
-                    base._observer.OnCompleted();
+                    ForwardOnNext(_lastValue);
+                    ForwardOnCompleted();
                 }
-
-                base.Dispose();
             }
         }
     }
@@ -296,7 +264,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<decimal>, IObserver<decimal>
+        internal sealed class _ : IdentitySink<decimal>
         {
             private bool _hasValue;
             private decimal _lastValue;
@@ -308,7 +276,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _lastValue = default(decimal);
             }
 
-            public void OnNext(decimal value)
+            public override void OnNext(decimal value)
             {
                 if (_hasValue)
                 {
@@ -324,25 +292,17 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
 
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
+            public override void OnCompleted()
             {
                 if (!_hasValue)
                 {
-                    base._observer.OnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
                 }
                 else
                 {
-                    base._observer.OnNext(_lastValue);
-                    base._observer.OnCompleted();
+                    ForwardOnNext(_lastValue);
+                    ForwardOnCompleted();
                 }
-
-                base.Dispose();
             }
         }
     }
@@ -360,7 +320,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<int>, IObserver<int>
+        internal sealed class _ : IdentitySink<int>
         {
             private bool _hasValue;
             private int _lastValue;
@@ -372,7 +332,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _lastValue = default(int);
             }
 
-            public void OnNext(int value)
+            public override void OnNext(int value)
             {
                 if (_hasValue)
                 {
@@ -388,25 +348,17 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
 
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
+            public override void OnCompleted()
             {
                 if (!_hasValue)
                 {
-                    base._observer.OnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
                 }
                 else
                 {
-                    base._observer.OnNext(_lastValue);
-                    base._observer.OnCompleted();
+                    ForwardOnNext(_lastValue);
+                    ForwardOnCompleted();
                 }
-
-                base.Dispose();
             }
         }
     }
@@ -424,7 +376,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<long>, IObserver<long>
+        internal sealed class _ : IdentitySink<long>
         {
             private bool _hasValue;
             private long _lastValue;
@@ -436,7 +388,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _lastValue = default(long);
             }
 
-            public void OnNext(long value)
+            public override void OnNext(long value)
             {
                 if (_hasValue)
                 {
@@ -452,25 +404,17 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
 
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
+            public override void OnCompleted()
             {
                 if (!_hasValue)
                 {
-                    base._observer.OnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
                 }
                 else
                 {
-                    base._observer.OnNext(_lastValue);
-                    base._observer.OnCompleted();
+                    ForwardOnNext(_lastValue);
+                    ForwardOnCompleted();
                 }
-
-                base.Dispose();
             }
         }
     }
@@ -488,7 +432,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<double?>, IObserver<double?>
+        internal sealed class _ : IdentitySink<double?>
         {
             private double? _lastValue;
 
@@ -498,7 +442,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _lastValue = default(double?);
             }
 
-            public void OnNext(double? value)
+            public override void OnNext(double? value)
             {
                 if (!value.HasValue)
                     return;
@@ -516,17 +460,10 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext(_lastValue);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_lastValue);
+                ForwardOnCompleted();
             }
         }
     }
@@ -544,7 +481,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<float?>, IObserver<float?>
+        internal sealed class _ : IdentitySink<float?>
         {
             private float? _lastValue;
 
@@ -554,7 +491,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _lastValue = default(float?);
             }
 
-            public void OnNext(float? value)
+            public override void OnNext(float? value)
             {
                 if (!value.HasValue)
                     return;
@@ -572,17 +509,10 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext(_lastValue);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_lastValue);
+                ForwardOnCompleted();
             }
         }
     }
@@ -600,7 +530,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<decimal?>, IObserver<decimal?>
+        internal sealed class _ : IdentitySink<decimal?>
         {
             private decimal? _lastValue;
 
@@ -610,7 +540,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _lastValue = default(decimal?);
             }
 
-            public void OnNext(decimal? value)
+            public override void OnNext(decimal? value)
             {
                 if (!value.HasValue)
                     return;
@@ -628,17 +558,10 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext(_lastValue);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_lastValue);
+                ForwardOnCompleted();
             }
         }
     }
@@ -656,7 +579,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<int?>, IObserver<int?>
+        internal sealed class _ : IdentitySink<int?>
         {
             private int? _lastValue;
 
@@ -666,7 +589,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _lastValue = default(int?);
             }
 
-            public void OnNext(int? value)
+            public override void OnNext(int? value)
             {
                 if (!value.HasValue)
                     return;
@@ -684,17 +607,10 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext(_lastValue);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_lastValue);
+                ForwardOnCompleted();
             }
         }
     }
@@ -712,7 +628,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<long?>, IObserver<long?>
+        internal sealed class _ : IdentitySink<long?>
         {
             private long? _lastValue;
 
@@ -722,7 +638,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _lastValue = default(long?);
             }
 
-            public void OnNext(long? value)
+            public override void OnNext(long? value)
             {
                 if (!value.HasValue)
                     return;
@@ -740,17 +656,10 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext(_lastValue);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_lastValue);
+                ForwardOnCompleted();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/MaxBy.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/MaxBy.cs
@@ -23,7 +23,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<IList<TSource>>, IObserver<TSource>
+        internal sealed class _ : Sink<TSource, IList<TSource>> 
         {
             private readonly MaxBy<TSource, TKey> _parent;
             private bool _hasValue;
@@ -40,7 +40,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _list = new List<TSource>();
             }
 
-            public void OnNext(TSource value)
+            public override void OnNext(TSource value)
             {
                 var key = default(TKey);
                 try
@@ -49,8 +49,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception ex)
                 {
-                    base._observer.OnError(ex);
-                    base.Dispose();
+                    ForwardOnError(ex);
                     return;
                 }
 
@@ -69,8 +68,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception ex)
                     {
-                        base._observer.OnError(ex);
-                        base.Dispose();
+                        ForwardOnError(ex);
                         return;
                     }
                 }
@@ -87,17 +85,10 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext(_list);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_list);
+                ForwardOnCompleted();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Min.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Min.cs
@@ -21,7 +21,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal abstract class _ : Sink<TSource>, IObserver<TSource>
+        internal abstract class _ : IdentitySink<TSource>
         {
             protected readonly IComparer<TSource> _comparer;
 
@@ -30,10 +30,6 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 _comparer = comparer;
             }
-
-            public abstract void OnCompleted();
-            public abstract void OnError(Exception error);
-            public abstract void OnNext(TSource value);
         }
 
         private sealed class NonNull : _
@@ -60,8 +56,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception ex)
                     {
-                        base._observer.OnError(ex);
-                        base.Dispose();
+                        ForwardOnError(ex);
                         return;
                     }
 
@@ -79,23 +74,20 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public override void OnError(Exception error)
             {
-                base._observer.OnError(error);
-                base.Dispose();
+                ForwardOnError(error);
             }
 
             public override void OnCompleted()
             {
                 if (!_hasValue)
                 {
-                    base._observer.OnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
                 }
                 else
                 {
-                    base._observer.OnNext(_lastValue);
-                    base._observer.OnCompleted();
+                    ForwardOnNext(_lastValue);
+                    ForwardOnCompleted();
                 }
-
-                base.Dispose();
             }
         }
 
@@ -127,8 +119,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         }
                         catch (Exception ex)
                         {
-                            base._observer.OnError(ex);
-                            base.Dispose();
+                            ForwardOnError(ex);
                             return;
                         }
 
@@ -140,17 +131,10 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
 
-            public override void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
             public override void OnCompleted()
             {
-                base._observer.OnNext(_lastValue);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_lastValue);
+                ForwardOnCompleted();
             }
         }
     }
@@ -168,7 +152,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<double>, IObserver<double>
+        internal sealed class _ : IdentitySink<double>
         {
             private bool _hasValue;
             private double _lastValue;
@@ -180,7 +164,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _lastValue = default(double);
             }
 
-            public void OnNext(double value)
+            public override void OnNext(double value)
             {
                 if (_hasValue)
                 {
@@ -196,25 +180,17 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
 
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
+            public override void OnCompleted()
             {
                 if (!_hasValue)
                 {
-                    base._observer.OnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
                 }
                 else
                 {
-                    base._observer.OnNext(_lastValue);
-                    base._observer.OnCompleted();
+                    ForwardOnNext(_lastValue);
+                    ForwardOnCompleted();
                 }
-
-                base.Dispose();
             }
         }
     }
@@ -232,7 +208,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<float>, IObserver<float>
+        internal sealed class _ : IdentitySink<float>
         {
             private bool _hasValue;
             private float _lastValue;
@@ -244,7 +220,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _lastValue = default(float);
             }
 
-            public void OnNext(float value)
+            public override void OnNext(float value)
             {
                 if (_hasValue)
                 {
@@ -260,25 +236,17 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
 
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
+            public override void OnCompleted()
             {
                 if (!_hasValue)
                 {
-                    base._observer.OnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
                 }
                 else
                 {
-                    base._observer.OnNext(_lastValue);
-                    base._observer.OnCompleted();
+                    ForwardOnNext(_lastValue);
+                    ForwardOnCompleted();
                 }
-
-                base.Dispose();
             }
         }
     }
@@ -296,7 +264,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<decimal>, IObserver<decimal>
+        internal sealed class _ : IdentitySink<decimal>
         {
             private bool _hasValue;
             private decimal _lastValue;
@@ -308,7 +276,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _lastValue = default(decimal);
             }
 
-            public void OnNext(decimal value)
+            public override void OnNext(decimal value)
             {
                 if (_hasValue)
                 {
@@ -324,25 +292,17 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
 
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
+            public override void OnCompleted()
             {
                 if (!_hasValue)
                 {
-                    base._observer.OnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
                 }
                 else
                 {
-                    base._observer.OnNext(_lastValue);
-                    base._observer.OnCompleted();
+                    ForwardOnNext(_lastValue);
+                    ForwardOnCompleted();
                 }
-
-                base.Dispose();
             }
         }
     }
@@ -360,7 +320,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<int>, IObserver<int>
+        internal sealed class _ : IdentitySink<int>
         {
             private bool _hasValue;
             private int _lastValue;
@@ -372,7 +332,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _lastValue = default(int);
             }
 
-            public void OnNext(int value)
+            public override void OnNext(int value)
             {
                 if (_hasValue)
                 {
@@ -388,25 +348,17 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
 
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
+            public override void OnCompleted()
             {
                 if (!_hasValue)
                 {
-                    base._observer.OnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
                 }
                 else
                 {
-                    base._observer.OnNext(_lastValue);
-                    base._observer.OnCompleted();
+                    ForwardOnNext(_lastValue);
+                    ForwardOnCompleted();
                 }
-
-                base.Dispose();
             }
         }
     }
@@ -424,7 +376,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<long>, IObserver<long>
+        internal sealed class _ : IdentitySink<long>
         {
             private bool _hasValue;
             private long _lastValue;
@@ -436,7 +388,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _lastValue = default(long);
             }
 
-            public void OnNext(long value)
+            public override void OnNext(long value)
             {
                 if (_hasValue)
                 {
@@ -452,25 +404,17 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
 
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
+            public override void OnCompleted()
             {
                 if (!_hasValue)
                 {
-                    base._observer.OnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
                 }
                 else
                 {
-                    base._observer.OnNext(_lastValue);
-                    base._observer.OnCompleted();
+                    ForwardOnNext(_lastValue);
+                    ForwardOnCompleted();
                 }
-
-                base.Dispose();
             }
         }
     }
@@ -488,7 +432,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<double?>, IObserver<double?>
+        internal sealed class _ : IdentitySink<double?>
         {
             private double? _lastValue;
 
@@ -498,7 +442,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _lastValue = default(double?);
             }
 
-            public void OnNext(double? value)
+            public override void OnNext(double? value)
             {
                 if (!value.HasValue)
                     return;
@@ -516,17 +460,10 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext(_lastValue);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_lastValue);
+                ForwardOnCompleted();
             }
         }
     }
@@ -544,7 +481,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<float?>, IObserver<float?>
+        internal sealed class _ : IdentitySink<float?>
         {
             private float? _lastValue;
 
@@ -554,7 +491,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _lastValue = default(float?);
             }
 
-            public void OnNext(float? value)
+            public override void OnNext(float? value)
             {
                 if (!value.HasValue)
                     return;
@@ -572,17 +509,10 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext(_lastValue);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_lastValue);
+                ForwardOnCompleted();
             }
         }
     }
@@ -600,7 +530,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<decimal?>, IObserver<decimal?>
+        internal sealed class _ : IdentitySink<decimal?>
         {
             private decimal? _lastValue;
 
@@ -610,7 +540,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _lastValue = default(decimal?);
             }
 
-            public void OnNext(decimal? value)
+            public override void OnNext(decimal? value)
             {
                 if (!value.HasValue)
                     return;
@@ -628,17 +558,10 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext(_lastValue);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_lastValue);
+                ForwardOnCompleted();
             }
         }
     }
@@ -656,7 +579,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<int?>, IObserver<int?>
+        internal sealed class _ : IdentitySink<int?>
         {
             private int? _lastValue;
 
@@ -666,7 +589,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _lastValue = default(int?);
             }
 
-            public void OnNext(int? value)
+            public override void OnNext(int? value)
             {
                 if (!value.HasValue)
                     return;
@@ -684,17 +607,10 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext(_lastValue);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_lastValue);
+                ForwardOnCompleted();
             }
         }
     }
@@ -712,7 +628,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<long?>, IObserver<long?>
+        internal sealed class _ : IdentitySink<long?>
         {
             private long? _lastValue;
 
@@ -722,7 +638,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _lastValue = default(long?);
             }
 
-            public void OnNext(long? value)
+            public override void OnNext(long? value)
             {
                 if (!value.HasValue)
                     return;
@@ -740,17 +656,10 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext(_lastValue);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_lastValue);
+                ForwardOnCompleted();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/MinBy.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/MinBy.cs
@@ -23,7 +23,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<IList<TSource>>, IObserver<TSource>
+        internal sealed class _ : Sink<TSource, IList<TSource>> 
         {
             private readonly MinBy<TSource, TKey> _parent;
             private bool _hasValue;
@@ -40,7 +40,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _list = new List<TSource>();
             }
 
-            public void OnNext(TSource value)
+            public override void OnNext(TSource value)
             {
                 var key = default(TKey);
                 try
@@ -49,8 +49,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception ex)
                 {
-                    base._observer.OnError(ex);
-                    base.Dispose();
+                    ForwardOnError(ex);
                     return;
                 }
 
@@ -69,8 +68,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception ex)
                     {
-                        base._observer.OnError(ex);
-                        base.Dispose();
+                        ForwardOnError(ex);
                         return;
                     }
                 }
@@ -87,17 +85,10 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext(_list);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_list);
+                ForwardOnCompleted();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Multicast.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Multicast.cs
@@ -24,7 +24,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => sink.Run(this);
 
-        internal sealed class _ : Sink<TResult>, IObserver<TResult>
+        internal sealed class _ : IdentitySink<TResult>
         {
             public _(IObserver<TResult> observer, IDisposable cancel)
                 : base(observer, cancel)
@@ -43,8 +43,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception exception)
                 {
-                    base._observer.OnError(exception);
-                    base.Dispose();
+                    ForwardOnError(exception);
                     return Disposable.Empty;
                 }
 
@@ -52,23 +51,6 @@ namespace System.Reactive.Linq.ObservableImpl
                 var connection = connectable.Connect();
 
                 return StableCompositeDisposable.Create(subscription, connection);
-            }
-
-            public void OnNext(TResult value)
-            {
-                base._observer.OnNext(value);
-            }
-
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnCompleted();
-                base.Dispose();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/OfType.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/OfType.cs
@@ -17,31 +17,19 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<TResult>, IObserver<TSource>
+        internal sealed class _ : Sink<TSource, TResult> 
         {
             public _(IObserver<TResult> observer, IDisposable cancel)
                 : base(observer, cancel)
             {
             }
 
-            public void OnNext(TSource value)
+            public override void OnNext(TSource value)
             {
                 if (value is TResult)
                 {
-                    base._observer.OnNext((TResult)(object)value);
+                    ForwardOnNext((TResult)(object)value);
                 }
-            }
-
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnCompleted();
-                base.Dispose();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/OnErrorResumeNext.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/OnErrorResumeNext.cs
@@ -34,11 +34,6 @@ namespace System.Reactive.Linq.ObservableImpl
                 return null;
             }
 
-            public override void OnNext(TSource value)
-            {
-                base._observer.OnNext(value);
-            }
-
             public override void OnError(Exception error)
             {
                 Recurse();

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Range.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Range.cs
@@ -24,7 +24,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => sink.Run(_scheduler);
 
-        internal sealed class _ : Sink<int>
+        internal sealed class _ : IdentitySink<int>
         {
             private readonly int _start;
             private readonly int _count;
@@ -53,27 +53,24 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 while (!cancel.IsDisposed && i < _count)
                 {
-                    base._observer.OnNext(_start + i);
+                    ForwardOnNext(_start + i);
                     i++;
                 }
 
                 if (!cancel.IsDisposed)
-                    base._observer.OnCompleted();
-
-                base.Dispose();
+                    ForwardOnCompleted();
             }
 
             private void LoopRec(int i, Action<int> recurse)
             {
                 if (i < _count)
                 {
-                    base._observer.OnNext(_start + i);
+                    ForwardOnNext(_start + i);
                     recurse(i + 1);
                 }
                 else
                 {
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnCompleted();
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/RefCount.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/RefCount.cs
@@ -27,7 +27,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => sink.Run(this);
 
-        internal sealed class _ : Sink<TSource>, IObserver<TSource>
+        internal sealed class _ : IdentitySink<TSource>
         {
             public _(IObserver<TSource> observer, IDisposable cancel)
                 : base(observer, cancel)
@@ -58,23 +58,6 @@ namespace System.Reactive.Linq.ObservableImpl
                         }
                     }
                 });
-            }
-
-            public void OnNext(TSource value)
-            {
-                base._observer.OnNext(value);
-            }
-
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnCompleted();
-                base.Dispose();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Repeat.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Repeat.cs
@@ -24,7 +24,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => sink.Run(this);
 
-            internal sealed class _ : Sink<TResult>
+            internal sealed class _ : IdentitySink<TResult>
             {
                 private readonly TResult _value;
 
@@ -49,7 +49,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 private void LoopRecInf(Action recurse)
                 {
-                    base._observer.OnNext(_value);
+                    ForwardOnNext(_value);
                     recurse();
                 }
 
@@ -57,7 +57,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     var value = _value;
                     while (!cancel.IsDisposed)
-                        base._observer.OnNext(value);
+                        ForwardOnNext(value);
 
                     base.Dispose();
                 }
@@ -81,7 +81,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => sink.Run(this);
 
-            internal sealed class _ : Sink<TResult>
+            internal sealed class _ : IdentitySink<TResult>
             {
                 private readonly TResult _value;
 
@@ -108,14 +108,13 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (n > 0)
                     {
-                        base._observer.OnNext(_value);
+                        ForwardOnNext(_value);
                         n--;
                     }
 
                     if (n == 0)
                     {
-                        base._observer.OnCompleted();
-                        base.Dispose();
+                        ForwardOnCompleted();
                         return;
                     }
 
@@ -127,14 +126,12 @@ namespace System.Reactive.Linq.ObservableImpl
                     var value = _value;
                     while (n > 0 && !cancel.IsDisposed)
                     {
-                        base._observer.OnNext(value);
+                        ForwardOnNext(value);
                         n--;
                     }
 
                     if (!cancel.IsDisposed)
-                        base._observer.OnCompleted();
-
-                    base.Dispose();
+                        ForwardOnCompleted();
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Return.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Return.cs
@@ -21,7 +21,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => sink.Run(_scheduler);
 
-        internal sealed class _ : Sink<TResult>
+        internal sealed class _ : IdentitySink<TResult>
         {
             private readonly TResult _value;
 
@@ -38,9 +38,8 @@ namespace System.Reactive.Linq.ObservableImpl
 
             private void Invoke()
             {
-                base._observer.OnNext(_value);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_value);
+                ForwardOnCompleted();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Scan.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Scan.cs
@@ -21,7 +21,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<TAccumulate>, IObserver<TSource>
+        internal sealed class _ : Sink<TSource, TAccumulate> 
         {
             private readonly Func<TAccumulate, TSource, TAccumulate> _accumulator;
             private TAccumulate _accumulation;
@@ -33,7 +33,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _accumulation = parent._seed;
             }
 
-            public void OnNext(TSource value)
+            public override void OnNext(TSource value)
             {
                 try
                 {
@@ -41,24 +41,11 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception exception)
                 {
-                    base._observer.OnError(exception);
-                    base.Dispose();
+                    ForwardOnError(exception);
                     return;
                 }
 
-                base._observer.OnNext(_accumulation);
-            }
-
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_accumulation);
             }
         }
     }
@@ -78,7 +65,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<TSource>, IObserver<TSource>
+        internal sealed class _ : IdentitySink<TSource>
         {
             private readonly Func<TSource, TSource, TSource> _accumulator;
             private TSource _accumulation;
@@ -92,7 +79,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _hasAccumulation = false;
             }
 
-            public void OnNext(TSource value)
+            public override void OnNext(TSource value)
             {
                 try
                 {
@@ -108,24 +95,11 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception exception)
                 {
-                    base._observer.OnError(exception);
-                    base.Dispose();
+                    ForwardOnError(exception);
                     return;
                 }
 
-                base._observer.OnNext(_accumulation);
-            }
-
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_accumulation);
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Select.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Select.cs
@@ -21,7 +21,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TResult>, IObserver<TSource>
+            internal sealed class _ : Sink<TSource, TResult> 
             {
                 private readonly Func<TSource, TResult> _selector;
 
@@ -31,7 +31,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     _selector = selector;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     var result = default(TResult);
                     try
@@ -40,24 +40,11 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception exception)
                     {
-                        base._observer.OnError(exception);
-                        base.Dispose();
+                        ForwardOnError(exception);
                         return;
                     }
 
-                    base._observer.OnNext(result);
-                }
-
-                public void OnError(Exception error)
-                {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnNext(result);
                 }
             }
         }
@@ -77,7 +64,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TResult>, IObserver<TSource>
+            internal sealed class _ : Sink<TSource, TResult> 
             {
                 private readonly Func<TSource, int, TResult> _selector;
                 private int _index;
@@ -89,7 +76,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     _index = 0;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     var result = default(TResult);
                     try
@@ -98,24 +85,11 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception exception)
                     {
-                        base._observer.OnError(exception);
-                        base.Dispose();
+                        ForwardOnError(exception);
                         return;
                     }
 
-                    base._observer.OnNext(result);
-                }
-
-                public void OnError(Exception error)
-                {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnNext(result);
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/SelectMany.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/SelectMany.cs
@@ -28,7 +28,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => sink.Run(_source);
 
-            internal sealed class _ : Sink<TResult>, IObserver<TSource>
+            internal sealed class _ : Sink<TSource, TResult> 
             {
                 private readonly object _gate = new object();
                 private readonly SingleAssignmentDisposable _sourceSubscription = new SingleAssignmentDisposable();
@@ -57,7 +57,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     return _group;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     var collection = default(IObservable<TCollection>);
 
@@ -69,8 +69,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     {
                         lock (_gate)
                         {
-                            base._observer.OnError(ex);
-                            base.Dispose();
+                            ForwardOnError(ex);
                         }
                         return;
                     }
@@ -80,16 +79,15 @@ namespace System.Reactive.Linq.ObservableImpl
                     innerSubscription.Disposable = collection.SubscribeSafe(new InnerObserver(this, value, innerSubscription));
                 }
 
-                public void OnError(Exception error)
+                public override void OnError(Exception error)
                 {
                     lock (_gate)
                     {
-                        base._observer.OnError(error);
-                        base.Dispose();
+                        ForwardOnError(error);
                     }
                 }
 
-                public void OnCompleted()
+                public override void OnCompleted()
                 {
                     _isStopped = true;
                     if (_group.Count == 1)
@@ -103,8 +101,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         //
                         lock (_gate)
                         {
-                            base._observer.OnCompleted();
-                            base.Dispose();
+                            ForwardOnCompleted();
                         }
                     }
                     else
@@ -138,22 +135,20 @@ namespace System.Reactive.Linq.ObservableImpl
                         {
                             lock (_parent._gate)
                             {
-                                _parent._observer.OnError(ex);
-                                _parent.Dispose();
+                                _parent.ForwardOnError(ex);
                             }
                             return;
                         }
 
                         lock (_parent._gate)
-                            _parent._observer.OnNext(res);
+                            _parent.ForwardOnNext(res);
                     }
 
                     public void OnError(Exception error)
                     {
                         lock (_parent._gate)
                         {
-                            _parent._observer.OnError(error);
-                            _parent.Dispose();
+                            _parent.ForwardOnError(error);
                         }
                     }
 
@@ -171,8 +166,7 @@ namespace System.Reactive.Linq.ObservableImpl
                             //
                             lock (_parent._gate)
                             {
-                                _parent._observer.OnCompleted();
-                                _parent.Dispose();
+                                _parent.ForwardOnCompleted();
                             }
                         }
                     }
@@ -197,7 +191,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => sink.Run(_source);
 
-            internal sealed class _ : Sink<TResult>, IObserver<TSource>
+            internal sealed class _ : Sink<TSource, TResult> 
             {
                 private readonly object _gate = new object();
                 private readonly SingleAssignmentDisposable _sourceSubscription = new SingleAssignmentDisposable();
@@ -227,7 +221,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     return _group;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     var index = checked(_index++);
                     var collection = default(IObservable<TCollection>);
@@ -240,8 +234,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     {
                         lock (_gate)
                         {
-                            base._observer.OnError(ex);
-                            base.Dispose();
+                            ForwardOnError(ex);
                         }
                         return;
                     }
@@ -251,16 +244,15 @@ namespace System.Reactive.Linq.ObservableImpl
                     innerSubscription.Disposable = collection.SubscribeSafe(new InnerObserver(this, value, index, innerSubscription));
                 }
 
-                public void OnError(Exception error)
+                public override void OnError(Exception error)
                 {
                     lock (_gate)
                     {
-                        base._observer.OnError(error);
-                        base.Dispose();
+                        ForwardOnError(error);
                     }
                 }
 
-                public void OnCompleted()
+                public override void OnCompleted()
                 {
                     _isStopped = true;
                     if (_group.Count == 1)
@@ -274,8 +266,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         //
                         lock (_gate)
                         {
-                            base._observer.OnCompleted();
-                            base.Dispose();
+                            ForwardOnCompleted();
                         }
                     }
                     else
@@ -313,22 +304,20 @@ namespace System.Reactive.Linq.ObservableImpl
                         {
                             lock (_parent._gate)
                             {
-                                _parent._observer.OnError(ex);
-                                _parent.Dispose();
+                                _parent.ForwardOnError(ex);
                             }
                             return;
                         }
 
                         lock (_parent._gate)
-                            _parent._observer.OnNext(res);
+                            _parent.ForwardOnNext(res);
                     }
 
                     public void OnError(Exception error)
                     {
                         lock (_parent._gate)
                         {
-                            _parent._observer.OnError(error);
-                            _parent.Dispose();
+                            _parent.ForwardOnError(error);
                         }
                     }
 
@@ -346,8 +335,7 @@ namespace System.Reactive.Linq.ObservableImpl
                             //
                             lock (_parent._gate)
                             {
-                                _parent._observer.OnCompleted();
-                                _parent.Dispose();
+                                _parent.ForwardOnCompleted();
                             }
                         }
                     }
@@ -372,7 +360,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TResult>, IObserver<TSource>
+            internal sealed class _ : Sink<TSource, TResult> 
             {
                 private readonly Func<TSource, IEnumerable<TCollection>> _collectionSelector;
                 private readonly Func<TSource, TCollection, TResult> _resultSelector;
@@ -384,7 +372,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     _resultSelector = parent._resultSelector;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     var xs = default(IEnumerable<TCollection>);
                     try
@@ -393,8 +381,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception exception)
                     {
-                        base._observer.OnError(exception);
-                        base.Dispose();
+                        ForwardOnError(exception);
                         return;
                     }
 
@@ -405,8 +392,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception exception)
                     {
-                        base._observer.OnError(exception);
-                        base.Dispose();
+                        ForwardOnError(exception);
                         return;
                     }
 
@@ -426,13 +412,12 @@ namespace System.Reactive.Linq.ObservableImpl
                             }
                             catch (Exception exception)
                             {
-                                base._observer.OnError(exception);
-                                base.Dispose();
+                                ForwardOnError(exception);
                                 return;
                             }
 
                             if (hasNext)
-                                base._observer.OnNext(current);
+                                ForwardOnNext(current);
                         }
                     }
                     finally
@@ -440,18 +425,6 @@ namespace System.Reactive.Linq.ObservableImpl
                         if (e != null)
                             e.Dispose();
                     }
-                }
-
-                public void OnError(Exception error)
-                {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnCompleted();
-                    base.Dispose();
                 }
             }
         }
@@ -473,7 +446,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TResult>, IObserver<TSource>
+            internal sealed class _ : Sink<TSource, TResult> 
             {
                 private readonly Func<TSource, int, IEnumerable<TCollection>> _collectionSelector;
                 private readonly Func<TSource, int, TCollection, int, TResult> _resultSelector;
@@ -487,7 +460,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 private int _index;
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     var index = checked(_index++);
 
@@ -498,8 +471,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception exception)
                     {
-                        base._observer.OnError(exception);
-                        base.Dispose();
+                        ForwardOnError(exception);
                         return;
                     }
 
@@ -510,8 +482,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception exception)
                     {
-                        base._observer.OnError(exception);
-                        base.Dispose();
+                        ForwardOnError(exception);
                         return;
                     }
 
@@ -532,13 +503,12 @@ namespace System.Reactive.Linq.ObservableImpl
                             }
                             catch (Exception exception)
                             {
-                                base._observer.OnError(exception);
-                                base.Dispose();
+                                ForwardOnError(exception);
                                 return;
                             }
 
                             if (hasNext)
-                                base._observer.OnNext(current);
+                                ForwardOnNext(current);
                         }
                     }
                     finally
@@ -546,18 +516,6 @@ namespace System.Reactive.Linq.ObservableImpl
                         if (e != null)
                             e.Dispose();
                     }
-                }
-
-                public void OnError(Exception error)
-                {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnCompleted();
-                    base.Dispose();
                 }
             }
         }
@@ -579,7 +537,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => sink.Run(_source);
 
-            internal sealed class _ : Sink<TResult>, IObserver<TSource>
+            internal sealed class _ : Sink<TSource, TResult> 
             {
                 private readonly object _gate = new object();
                 private readonly CancellationDisposable _cancel = new CancellationDisposable();
@@ -603,7 +561,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     return StableCompositeDisposable.Create(source.SubscribeSafe(this), _cancel);
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     var task = default(Task<TCollection>);
                     try
@@ -615,8 +573,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     {
                         lock (_gate)
                         {
-                            base._observer.OnError(ex);
-                            base.Dispose();
+                            ForwardOnError(ex);
                         }
 
                         return;
@@ -655,15 +612,14 @@ namespace System.Reactive.Linq.ObservableImpl
                                 {
                                     lock (_gate)
                                     {
-                                        base._observer.OnError(ex);
-                                        base.Dispose();
+                                        ForwardOnError(ex);
                                     }
 
                                     return;
                                 }
 
                                 lock (_gate)
-                                    base._observer.OnNext(res);
+                                    ForwardOnNext(res);
 
                                 OnCompleted();
                             }
@@ -672,8 +628,7 @@ namespace System.Reactive.Linq.ObservableImpl
                             {
                                 lock (_gate)
                                 {
-                                    base._observer.OnError(task.Exception.InnerException);
-                                    base.Dispose();
+                                    ForwardOnError(task.Exception.InnerException);
                                 }
                             }
                             break;
@@ -683,8 +638,7 @@ namespace System.Reactive.Linq.ObservableImpl
                                 {
                                     lock (_gate)
                                     {
-                                        base._observer.OnError(new TaskCanceledException(task));
-                                        base.Dispose();
+                                        ForwardOnError(new TaskCanceledException(task));
                                     }
                                 }
                             }
@@ -692,23 +646,21 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                 }
 
-                public void OnError(Exception error)
+                public override void OnError(Exception error)
                 {
                     lock (_gate)
                     {
-                        base._observer.OnError(error);
-                        base.Dispose();
+                        ForwardOnError(error);
                     }
                 }
 
-                public void OnCompleted()
+                public override void OnCompleted()
                 {
                     if (Interlocked.Decrement(ref _count) == 0)
                     {
                         lock (_gate)
                         {
-                            base._observer.OnCompleted();
-                            base.Dispose();
+                            ForwardOnCompleted();
                         }
                     }
                 }
@@ -732,7 +684,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => sink.Run(_source);
 
-            internal sealed class _ : Sink<TResult>, IObserver<TSource>
+            internal sealed class _ : Sink<TSource, TResult> 
             {
                 private readonly object _gate = new object();
                 private readonly CancellationDisposable _cancel = new CancellationDisposable();
@@ -757,7 +709,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     return StableCompositeDisposable.Create(source.SubscribeSafe(this), _cancel);
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     var index = checked(_index++);
 
@@ -771,8 +723,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     {
                         lock (_gate)
                         {
-                            base._observer.OnError(ex);
-                            base.Dispose();
+                            ForwardOnError(ex);
                         }
 
                         return;
@@ -811,15 +762,14 @@ namespace System.Reactive.Linq.ObservableImpl
                                 {
                                     lock (_gate)
                                     {
-                                        base._observer.OnError(ex);
-                                        base.Dispose();
+                                        ForwardOnError(ex);
                                     }
 
                                     return;
                                 }
 
                                 lock (_gate)
-                                    base._observer.OnNext(res);
+                                    ForwardOnNext(res);
 
                                 OnCompleted();
                             }
@@ -828,8 +778,7 @@ namespace System.Reactive.Linq.ObservableImpl
                             {
                                 lock (_gate)
                                 {
-                                    base._observer.OnError(task.Exception.InnerException);
-                                    base.Dispose();
+                                    ForwardOnError(task.Exception.InnerException);
                                 }
                             }
                             break;
@@ -839,8 +788,7 @@ namespace System.Reactive.Linq.ObservableImpl
                                 {
                                     lock (_gate)
                                     {
-                                        base._observer.OnError(new TaskCanceledException(task));
-                                        base.Dispose();
+                                        ForwardOnError(new TaskCanceledException(task));
                                     }
                                 }
                             }
@@ -848,23 +796,21 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                 }
 
-                public void OnError(Exception error)
+                public override void OnError(Exception error)
                 {
                     lock (_gate)
                     {
-                        base._observer.OnError(error);
-                        base.Dispose();
+                        ForwardOnError(error);
                     }
                 }
 
-                public void OnCompleted()
+                public override void OnCompleted()
                 {
                     if (Interlocked.Decrement(ref _count) == 0)
                     {
                         lock (_gate)
                         {
-                            base._observer.OnCompleted();
-                            base.Dispose();
+                            ForwardOnCompleted();
                         }
                     }
                 }
@@ -889,7 +835,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => sink.Run(_source);
 
-            internal class _ : Sink<TResult>, IObserver<TSource>
+            internal class _ : Sink<TSource, TResult> 
             {
                 protected readonly object _gate = new object();
                 private readonly SingleAssignmentDisposable _sourceSubscription = new SingleAssignmentDisposable();
@@ -916,7 +862,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     return _group;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     var inner = default(IObservable<TResult>);
 
@@ -928,8 +874,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     {
                         lock (_gate)
                         {
-                            base._observer.OnError(ex);
-                            base.Dispose();
+                            ForwardOnError(ex);
                         }
                         return;
                     }
@@ -937,16 +882,15 @@ namespace System.Reactive.Linq.ObservableImpl
                     SubscribeInner(inner);
                 }
 
-                public virtual void OnError(Exception error)
+                public override void OnError(Exception error)
                 {
                     lock (_gate)
                     {
-                        base._observer.OnError(error);
-                        base.Dispose();
+                        ForwardOnError(error);
                     }
                 }
 
-                public virtual void OnCompleted()
+                public override void OnCompleted()
                 {
                     Final();
                 }
@@ -965,8 +909,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         //
                         lock (_gate)
                         {
-                            base._observer.OnCompleted();
-                            base.Dispose();
+                            ForwardOnCompleted();
                         }
                     }
                     else
@@ -996,15 +939,14 @@ namespace System.Reactive.Linq.ObservableImpl
                     public void OnNext(TResult value)
                     {
                         lock (_parent._gate)
-                            _parent._observer.OnNext(value);
+                            _parent.ForwardOnNext(value);
                     }
 
                     public void OnError(Exception error)
                     {
                         lock (_parent._gate)
                         {
-                            _parent._observer.OnError(error);
-                            _parent.Dispose();
+                            _parent.ForwardOnError(error);
                         }
                     }
 
@@ -1022,8 +964,7 @@ namespace System.Reactive.Linq.ObservableImpl
                             //
                             lock (_parent._gate)
                             {
-                                _parent._observer.OnCompleted();
-                                _parent.Dispose();
+                                _parent.ForwardOnCompleted();
                             }
                         }
                     }
@@ -1071,8 +1012,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         {
                             lock (_gate)
                             {
-                                base._observer.OnError(ex);
-                                base.Dispose();
+                                ForwardOnError(ex);
                             }
                             return;
                         }
@@ -1101,8 +1041,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         {
                             lock (_gate)
                             {
-                                base._observer.OnError(ex);
-                                base.Dispose();
+                                ForwardOnError(ex);
                             }
                             return;
                         }
@@ -1130,7 +1069,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => sink.Run(_source);
 
-            internal class _ : Sink<TResult>, IObserver<TSource>
+            internal class _ : Sink<TSource, TResult> 
             {
                 private readonly object _gate = new object();
                 private readonly SingleAssignmentDisposable _sourceSubscription = new SingleAssignmentDisposable();
@@ -1158,7 +1097,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     return _group;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     var inner = default(IObservable<TResult>);
 
@@ -1170,8 +1109,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     {
                         lock (_gate)
                         {
-                            base._observer.OnError(ex);
-                            base.Dispose();
+                            ForwardOnError(ex);
                         }
                         return;
                     }
@@ -1179,16 +1117,15 @@ namespace System.Reactive.Linq.ObservableImpl
                     SubscribeInner(inner);
                 }
 
-                public virtual void OnError(Exception error)
+                public override void OnError(Exception error)
                 {
                     lock (_gate)
                     {
-                        base._observer.OnError(error);
-                        base.Dispose();
+                        ForwardOnError(error);
                     }
                 }
 
-                public virtual void OnCompleted()
+                public override void OnCompleted()
                 {
                     Final();
                 }
@@ -1207,8 +1144,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         //
                         lock (_gate)
                         {
-                            base._observer.OnCompleted();
-                            base.Dispose();
+                            ForwardOnCompleted();
                         }
                     }
                     else
@@ -1238,15 +1174,14 @@ namespace System.Reactive.Linq.ObservableImpl
                     public void OnNext(TResult value)
                     {
                         lock (_parent._gate)
-                            _parent._observer.OnNext(value);
+                            _parent.ForwardOnNext(value);
                     }
 
                     public void OnError(Exception error)
                     {
                         lock (_parent._gate)
                         {
-                            _parent._observer.OnError(error);
-                            _parent.Dispose();
+                            _parent.ForwardOnError(error);
                         }
                     }
 
@@ -1264,8 +1199,7 @@ namespace System.Reactive.Linq.ObservableImpl
                             //
                             lock (_parent._gate)
                             {
-                                _parent._observer.OnCompleted();
-                                _parent.Dispose();
+                                _parent.ForwardOnCompleted();
                             }
                         }
                     }
@@ -1319,8 +1253,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         {
                             lock (_gate)
                             {
-                                base._observer.OnError(ex);
-                                base.Dispose();
+                                ForwardOnError(ex);
                             }
                             return;
                         }
@@ -1349,8 +1282,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         {
                             lock (_gate)
                             {
-                                base._observer.OnError(ex);
-                                base.Dispose();
+                                ForwardOnError(ex);
                             }
                             return;
                         }
@@ -1378,7 +1310,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TResult>, IObserver<TSource>
+            internal sealed class _ : Sink<TSource, TResult> 
             {
                 private readonly Func<TSource, IEnumerable<TResult>> _selector;
 
@@ -1388,7 +1320,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     _selector = parent._selector;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     var xs = default(IEnumerable<TResult>);
                     try
@@ -1397,8 +1329,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception exception)
                     {
-                        base._observer.OnError(exception);
-                        base.Dispose();
+                        ForwardOnError(exception);
                         return;
                     }
 
@@ -1409,8 +1340,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception exception)
                     {
-                        base._observer.OnError(exception);
-                        base.Dispose();
+                        ForwardOnError(exception);
                         return;
                     }
 
@@ -1430,13 +1360,12 @@ namespace System.Reactive.Linq.ObservableImpl
                             }
                             catch (Exception exception)
                             {
-                                base._observer.OnError(exception);
-                                base.Dispose();
+                                ForwardOnError(exception);
                                 return;
                             }
 
                             if (hasNext)
-                                base._observer.OnNext(current);
+                                ForwardOnNext(current);
                         }
                     }
                     finally
@@ -1444,18 +1373,6 @@ namespace System.Reactive.Linq.ObservableImpl
                         if (e != null)
                             e.Dispose();
                     }
-                }
-
-                public void OnError(Exception error)
-                {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnCompleted();
-                    base.Dispose();
                 }
             }
         }
@@ -1475,7 +1392,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TResult>, IObserver<TSource>
+            internal sealed class _ : Sink<TSource, TResult> 
             {
                 private readonly Func<TSource, int, IEnumerable<TResult>> _selector;
 
@@ -1487,7 +1404,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 private int _index;
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     var xs = default(IEnumerable<TResult>);
                     try
@@ -1496,8 +1413,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception exception)
                     {
-                        base._observer.OnError(exception);
-                        base.Dispose();
+                        ForwardOnError(exception);
                         return;
                     }
 
@@ -1508,8 +1424,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception exception)
                     {
-                        base._observer.OnError(exception);
-                        base.Dispose();
+                        ForwardOnError(exception);
                         return;
                     }
 
@@ -1529,13 +1444,12 @@ namespace System.Reactive.Linq.ObservableImpl
                             }
                             catch (Exception exception)
                             {
-                                base._observer.OnError(exception);
-                                base.Dispose();
+                                ForwardOnError(exception);
                                 return;
                             }
 
                             if (hasNext)
-                                base._observer.OnNext(current);
+                                ForwardOnNext(current);
                         }
                     }
                     finally
@@ -1543,18 +1457,6 @@ namespace System.Reactive.Linq.ObservableImpl
                         if (e != null)
                             e.Dispose();
                     }
-                }
-
-                public void OnError(Exception error)
-                {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnCompleted();
-                    base.Dispose();
                 }
             }
         }
@@ -1574,7 +1476,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => sink.Run(_source);
 
-            internal sealed class _ : Sink<TResult>, IObserver<TSource>
+            internal sealed class _ : Sink<TSource, TResult> 
             {
                 private readonly object _gate = new object();
                 private readonly CancellationDisposable _cancel = new CancellationDisposable();
@@ -1596,7 +1498,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     return StableCompositeDisposable.Create(source.SubscribeSafe(this), _cancel);
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     var task = default(Task<TResult>);
                     try
@@ -1608,8 +1510,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     {
                         lock (_gate)
                         {
-                            base._observer.OnError(ex);
-                            base.Dispose();
+                            ForwardOnError(ex);
                         }
 
                         return;
@@ -1632,7 +1533,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         case TaskStatus.RanToCompletion:
                             {
                                 lock (_gate)
-                                    base._observer.OnNext(task.Result);
+                                    ForwardOnNext(task.Result);
 
                                 OnCompleted();
                             }
@@ -1641,8 +1542,7 @@ namespace System.Reactive.Linq.ObservableImpl
                             {
                                 lock (_gate)
                                 {
-                                    base._observer.OnError(task.Exception.InnerException);
-                                    base.Dispose();
+                                    ForwardOnError(task.Exception.InnerException);
                                 }
                             }
                             break;
@@ -1652,8 +1552,7 @@ namespace System.Reactive.Linq.ObservableImpl
                                 {
                                     lock (_gate)
                                     {
-                                        base._observer.OnError(new TaskCanceledException(task));
-                                        base.Dispose();
+                                        ForwardOnError(new TaskCanceledException(task));
                                     }
                                 }
                             }
@@ -1661,23 +1560,21 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                 }
 
-                public void OnError(Exception error)
+                public override void OnError(Exception error)
                 {
                     lock (_gate)
                     {
-                        base._observer.OnError(error);
-                        base.Dispose();
+                        ForwardOnError(error);
                     }
                 }
 
-                public void OnCompleted()
+                public override void OnCompleted()
                 {
                     if (Interlocked.Decrement(ref _count) == 0)
                     {
                         lock (_gate)
                         {
-                            base._observer.OnCompleted();
-                            base.Dispose();
+                            ForwardOnCompleted();
                         }
                     }
                 }
@@ -1699,7 +1596,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => sink.Run(_source);
 
-            internal sealed class _ : Sink<TResult>, IObserver<TSource>
+            internal sealed class _ : Sink<TSource, TResult> 
             {
                 private readonly object _gate = new object();
                 private readonly CancellationDisposable _cancel = new CancellationDisposable();
@@ -1722,7 +1619,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     return StableCompositeDisposable.Create(source.SubscribeSafe(this), _cancel);
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     var task = default(Task<TResult>);
                     try
@@ -1734,8 +1631,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     {
                         lock (_gate)
                         {
-                            base._observer.OnError(ex);
-                            base.Dispose();
+                            ForwardOnError(ex);
                         }
 
                         return;
@@ -1758,7 +1654,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         case TaskStatus.RanToCompletion:
                             {
                                 lock (_gate)
-                                    base._observer.OnNext(task.Result);
+                                    ForwardOnNext(task.Result);
 
                                 OnCompleted();
                             }
@@ -1767,8 +1663,7 @@ namespace System.Reactive.Linq.ObservableImpl
                             {
                                 lock (_gate)
                                 {
-                                    base._observer.OnError(task.Exception.InnerException);
-                                    base.Dispose();
+                                    ForwardOnError(task.Exception.InnerException);
                                 }
                             }
                             break;
@@ -1778,8 +1673,7 @@ namespace System.Reactive.Linq.ObservableImpl
                                 {
                                     lock (_gate)
                                     {
-                                        base._observer.OnError(new TaskCanceledException(task));
-                                        base.Dispose();
+                                        ForwardOnError(new TaskCanceledException(task));
                                     }
                                 }
                             }
@@ -1787,23 +1681,21 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                 }
 
-                public void OnError(Exception error)
+                public override void OnError(Exception error)
                 {
                     lock (_gate)
                     {
-                        base._observer.OnError(error);
-                        base.Dispose();
+                        ForwardOnError(error);
                     }
                 }
 
-                public void OnCompleted()
+                public override void OnCompleted()
                 {
                     if (Interlocked.Decrement(ref _count) == 0)
                     {
                         lock (_gate)
                         {
-                            base._observer.OnCompleted();
-                            base.Dispose();
+                            ForwardOnCompleted();
                         }
                     }
                 }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/SequenceEqual.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/SequenceEqual.cs
@@ -26,7 +26,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => sink.Run(this);
 
-            internal sealed class _ : Sink<bool>
+            internal sealed class _ : IdentitySink<bool>
             {
                 private readonly IEqualityComparer<TSource> _comparer;
 
@@ -80,22 +80,19 @@ namespace System.Reactive.Linq.ObservableImpl
                                 }
                                 catch (Exception exception)
                                 {
-                                    _parent._observer.OnError(exception);
-                                    _parent.Dispose();
+                                    _parent.ForwardOnError(exception);
                                     return;
                                 }
                                 if (!equal)
                                 {
-                                    _parent._observer.OnNext(false);
-                                    _parent._observer.OnCompleted();
-                                    _parent.Dispose();
+                                    _parent.ForwardOnNext(false);
+                                    _parent.ForwardOnCompleted();
                                 }
                             }
                             else if (_parent._doner)
                             {
-                                _parent._observer.OnNext(false);
-                                _parent._observer.OnCompleted();
-                                _parent.Dispose();
+                                _parent.ForwardOnNext(false);
+                                _parent.ForwardOnCompleted();
                             }
                             else
                                 _parent._ql.Enqueue(value);
@@ -106,8 +103,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     {
                         lock (_parent._gate)
                         {
-                            _parent._observer.OnError(error);
-                            _parent.Dispose();
+                            _parent.ForwardOnError(error);
                         }
                     }
 
@@ -120,15 +116,13 @@ namespace System.Reactive.Linq.ObservableImpl
                             {
                                 if (_parent._qr.Count > 0)
                                 {
-                                    _parent._observer.OnNext(false);
-                                    _parent._observer.OnCompleted();
-                                    _parent.Dispose();
+                                    _parent.ForwardOnNext(false);
+                                    _parent.ForwardOnCompleted();
                                 }
                                 else if (_parent._doner)
                                 {
-                                    _parent._observer.OnNext(true);
-                                    _parent._observer.OnCompleted();
-                                    _parent.Dispose();
+                                    _parent.ForwardOnNext(true);
+                                    _parent.ForwardOnCompleted();
                                 }
                             }
                         }
@@ -158,22 +152,19 @@ namespace System.Reactive.Linq.ObservableImpl
                                 }
                                 catch (Exception exception)
                                 {
-                                    _parent._observer.OnError(exception);
-                                    _parent.Dispose();
+                                    _parent.ForwardOnError(exception);
                                     return;
                                 }
                                 if (!equal)
                                 {
-                                    _parent._observer.OnNext(false);
-                                    _parent._observer.OnCompleted();
-                                    _parent.Dispose();
+                                    _parent.ForwardOnNext(false);
+                                    _parent.ForwardOnCompleted();
                                 }
                             }
                             else if (_parent._donel)
                             {
-                                _parent._observer.OnNext(false);
-                                _parent._observer.OnCompleted();
-                                _parent.Dispose();
+                                _parent.ForwardOnNext(false);
+                                _parent.ForwardOnCompleted();
                             }
                             else
                                 _parent._qr.Enqueue(value);
@@ -184,8 +175,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     {
                         lock (_parent._gate)
                         {
-                            _parent._observer.OnError(error);
-                            _parent.Dispose();
+                            _parent.ForwardOnError(error);
                         }
                     }
 
@@ -198,15 +188,13 @@ namespace System.Reactive.Linq.ObservableImpl
                             {
                                 if (_parent._ql.Count > 0)
                                 {
-                                    _parent._observer.OnNext(false);
-                                    _parent._observer.OnCompleted();
-                                    _parent.Dispose();
+                                    _parent.ForwardOnNext(false);
+                                    _parent.ForwardOnCompleted();
                                 }
                                 else if (_parent._donel)
                                 {
-                                    _parent._observer.OnNext(true);
-                                    _parent._observer.OnCompleted();
-                                    _parent.Dispose();
+                                    _parent.ForwardOnNext(true);
+                                    _parent.ForwardOnCompleted();
                                 }
                             }
                         }
@@ -232,7 +220,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => sink.Run(this);
 
-            internal sealed class _ : Sink<bool>, IObserver<TSource>
+            internal sealed class _ : Sink<TSource, bool> 
             {
                 private readonly IEqualityComparer<TSource> _comparer;
 
@@ -259,8 +247,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception exception)
                     {
-                        base._observer.OnError(exception);
-                        base.Dispose();
+                        ForwardOnError(exception);
                         return Disposable.Empty;
                     }
 
@@ -270,7 +257,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     );
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     var equal = false;
 
@@ -284,26 +271,18 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception exception)
                     {
-                        base._observer.OnError(exception);
-                        base.Dispose();
+                        ForwardOnError(exception);
                         return;
                     }
 
                     if (!equal)
                     {
-                        base._observer.OnNext(false);
-                        base._observer.OnCompleted();
-                        base.Dispose();
+                        ForwardOnNext(false);
+                        ForwardOnCompleted();
                     }
                 }
 
-                public void OnError(Exception error)
-                {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
+                public override void OnCompleted()
                 {
                     var hasNext = false;
 
@@ -313,14 +292,12 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception exception)
                     {
-                        base._observer.OnError(exception);
-                        base.Dispose();
+                        ForwardOnError(exception);
                         return;
                     }
 
-                    base._observer.OnNext(!hasNext);
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnNext(!hasNext);
+                    ForwardOnCompleted();
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/SingleAsync.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/SingleAsync.cs
@@ -19,7 +19,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TSource>, IObserver<TSource>
+            internal sealed class _ : IdentitySink<TSource>
             {
                 private TSource _value;
                 private bool _seenValue;
@@ -31,12 +31,11 @@ namespace System.Reactive.Linq.ObservableImpl
                     _seenValue = false;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     if (_seenValue)
                     {
-                        base._observer.OnError(new InvalidOperationException(Strings_Linq.MORE_THAN_ONE_ELEMENT));
-                        base.Dispose();
+                        ForwardOnError(new InvalidOperationException(Strings_Linq.MORE_THAN_ONE_ELEMENT));
                         return;
                     }
 
@@ -44,25 +43,17 @@ namespace System.Reactive.Linq.ObservableImpl
                     _seenValue = true;
                 }
 
-                public void OnError(Exception error)
-                {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
+                public override void OnCompleted()
                 {
                     if (!_seenValue)
                     {
-                        base._observer.OnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                        ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
                     }
                     else
                     {
-                        base._observer.OnNext(_value);
-                        base._observer.OnCompleted();
+                        ForwardOnNext(_value);
+                        ForwardOnCompleted();
                     }
-
-                    base.Dispose();
                 }
             }
         }
@@ -82,7 +73,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TSource>, IObserver<TSource>
+            internal sealed class _ : IdentitySink<TSource>
             {
                 private readonly Func<TSource, bool> _predicate;
                 private TSource _value;
@@ -97,7 +88,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     _seenValue = false;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     var b = false;
 
@@ -107,8 +98,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception ex)
                     {
-                        base._observer.OnError(ex);
-                        base.Dispose();
+                        ForwardOnError(ex);
                         return;
                     }
 
@@ -116,8 +106,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     {
                         if (_seenValue)
                         {
-                            base._observer.OnError(new InvalidOperationException(Strings_Linq.MORE_THAN_ONE_MATCHING_ELEMENT));
-                            base.Dispose();
+                            ForwardOnError(new InvalidOperationException(Strings_Linq.MORE_THAN_ONE_MATCHING_ELEMENT));
                             return;
                         }
 
@@ -126,25 +115,17 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                 }
 
-                public void OnError(Exception error)
-                {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
+                public override void OnCompleted()
                 {
                     if (!_seenValue)
                     {
-                        base._observer.OnError(new InvalidOperationException(Strings_Linq.NO_MATCHING_ELEMENTS));
+                        ForwardOnError(new InvalidOperationException(Strings_Linq.NO_MATCHING_ELEMENTS));
                     }
                     else
                     {
-                        base._observer.OnNext(_value);
-                        base._observer.OnCompleted();
+                        ForwardOnNext(_value);
+                        ForwardOnCompleted();
                     }
-
-                    base.Dispose();
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/SingleOrDefaultAsync.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/SingleOrDefaultAsync.cs
@@ -19,7 +19,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TSource>, IObserver<TSource>
+            internal sealed class _ : IdentitySink<TSource>
             {
                 private TSource _value;
                 private bool _seenValue;
@@ -31,12 +31,11 @@ namespace System.Reactive.Linq.ObservableImpl
                     _seenValue = false;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     if (_seenValue)
                     {
-                        base._observer.OnError(new InvalidOperationException(Strings_Linq.MORE_THAN_ONE_ELEMENT));
-                        base.Dispose();
+                        ForwardOnError(new InvalidOperationException(Strings_Linq.MORE_THAN_ONE_ELEMENT));
                         return;
                     }
 
@@ -44,17 +43,10 @@ namespace System.Reactive.Linq.ObservableImpl
                     _seenValue = true;
                 }
 
-                public void OnError(Exception error)
+                public override void OnCompleted()
                 {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnNext(_value);
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnNext(_value);
+                    ForwardOnCompleted();
                 }
             }
         }
@@ -74,7 +66,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TSource>, IObserver<TSource>
+            internal sealed class _ : IdentitySink<TSource>
             {
                 private readonly Func<TSource, bool> _predicate;
                 private TSource _value;
@@ -89,7 +81,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     _seenValue = false;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     var b = false;
 
@@ -99,8 +91,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception ex)
                     {
-                        base._observer.OnError(ex);
-                        base.Dispose();
+                        ForwardOnError(ex);
                         return;
                     }
 
@@ -108,8 +99,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     {
                         if (_seenValue)
                         {
-                            base._observer.OnError(new InvalidOperationException(Strings_Linq.MORE_THAN_ONE_MATCHING_ELEMENT));
-                            base.Dispose();
+                            ForwardOnError(new InvalidOperationException(Strings_Linq.MORE_THAN_ONE_MATCHING_ELEMENT));
                             return;
                         }
 
@@ -118,17 +108,10 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                 }
 
-                public void OnError(Exception error)
+                public override void OnCompleted()
                 {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnNext(_value);
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnNext(_value);
+                    ForwardOnCompleted();
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Skip.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Skip.cs
@@ -36,7 +36,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TSource>, IObserver<TSource>
+            internal sealed class _ : IdentitySink<TSource>
             {
                 private int _remaining;
 
@@ -46,24 +46,12 @@ namespace System.Reactive.Linq.ObservableImpl
                     _remaining = count;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     if (_remaining <= 0)
-                        base._observer.OnNext(value);
+                        ForwardOnNext(value);
                     else
                         _remaining--;
-                }
-
-                public void OnError(Exception error)
-                {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnCompleted();
-                    base.Dispose();
                 }
             }
         }
@@ -102,7 +90,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => sink.Run(this);
 
-            internal sealed class _ : Sink<TSource>, IObserver<TSource>
+            internal sealed class _ : IdentitySink<TSource>
             {
                 private volatile bool _open;
 
@@ -123,22 +111,10 @@ namespace System.Reactive.Linq.ObservableImpl
                     _open = true;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     if (_open)
-                        base._observer.OnNext(value);
-                }
-
-                public void OnError(Exception error)
-                {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                        ForwardOnNext(value);
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/SkipLast.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/SkipLast.cs
@@ -24,7 +24,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TSource>, IObserver<TSource>
+            internal sealed class _ : IdentitySink<TSource>
             {
                 private int _count;
                 private Queue<TSource> _queue;
@@ -36,23 +36,11 @@ namespace System.Reactive.Linq.ObservableImpl
                     _queue = new Queue<TSource>();
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     _queue.Enqueue(value);
                     if (_queue.Count > _count)
-                        base._observer.OnNext(_queue.Dequeue());
-                }
-
-                public void OnError(Exception error)
-                {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                        ForwardOnNext(_queue.Dequeue());
                 }
             }
         }
@@ -74,7 +62,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => sink.Run(this);
 
-            internal sealed class _ : Sink<TSource>, IObserver<TSource>
+            internal sealed class _ : IdentitySink<TSource>
             {
                 private readonly TimeSpan _duration;
                 private Queue<System.Reactive.TimeInterval<TSource>> _queue;
@@ -95,28 +83,21 @@ namespace System.Reactive.Linq.ObservableImpl
                     return parent._source.SubscribeSafe(this);
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     var now = _watch.Elapsed;
                     _queue.Enqueue(new System.Reactive.TimeInterval<TSource>(value, now));
                     while (_queue.Count > 0 && now - _queue.Peek().Interval >= _duration)
-                        base._observer.OnNext(_queue.Dequeue().Value);
+                        ForwardOnNext(_queue.Dequeue().Value);
                 }
 
-                public void OnError(Exception error)
-                {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
+                public override void OnCompleted()
                 {
                     var now = _watch.Elapsed;
                     while (_queue.Count > 0 && now - _queue.Peek().Interval >= _duration)
-                        base._observer.OnNext(_queue.Dequeue().Value);
+                        ForwardOnNext(_queue.Dequeue().Value);
 
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnCompleted();
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/SkipUntil.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/SkipUntil.cs
@@ -22,7 +22,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => sink.Run(this);
 
-        internal sealed class _ : Sink<TSource>
+        internal sealed class _ : IdentitySink<TSource>
         {
             public _(IObserver<TSource> observer, IDisposable cancel)
                 : base(observer, cancel)
@@ -49,13 +49,12 @@ namespace System.Reactive.Linq.ObservableImpl
             private sealed class SourceObserver : IObserver<TSource>
             {
                 private readonly _ _parent;
-                public volatile IObserver<TSource> _observer;
+                public volatile bool _forward;
                 private readonly SingleAssignmentDisposable _subscription;
 
                 public SourceObserver(_ parent)
                 {
                     _parent = parent;
-                    _observer = NopObserver<TSource>.Instance;
                     _subscription = new SingleAssignmentDisposable();
                 }
 
@@ -66,18 +65,20 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public void OnNext(TSource value)
                 {
-                    _observer.OnNext(value);
+                    if (_forward)
+                        _parent.ForwardOnNext(value);
                 }
 
                 public void OnError(Exception error)
                 {
-                    _parent._observer.OnError(error);
-                    _parent.Dispose();
+                    _parent.ForwardOnError(error);
                 }
 
                 public void OnCompleted()
                 {
-                    _observer.OnCompleted();
+                    if (_forward)
+                        _parent.ForwardOnCompleted();
+
                     _subscription.Dispose(); // We can't cancel the other stream yet, it may be on its way to dispatch an OnError message and we don't want to have a race.
                 }
             }
@@ -102,14 +103,13 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public void OnNext(TOther value)
                 {
-                    _sourceObserver._observer = _parent._observer;
+                    _sourceObserver._forward = true;
                     _subscription.Dispose();
                 }
 
                 public void OnError(Exception error)
                 {
-                    _parent._observer.OnError(error);
-                    _parent.Dispose();
+                    _parent.ForwardOnError(error);
                 }
 
                 public void OnCompleted()
@@ -154,7 +154,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => sink.Run(this);
 
-        internal sealed class _ : Sink<TSource>, IObserver<TSource>
+        internal sealed class _ : IdentitySink<TSource>
         {
             private volatile bool _open;
 
@@ -175,22 +175,10 @@ namespace System.Reactive.Linq.ObservableImpl
                 _open = true;
             }
 
-            public void OnNext(TSource value)
+            public override void OnNext(TSource value)
             {
                 if (_open)
-                    base._observer.OnNext(value);
-            }
-
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnCompleted();
-                base.Dispose();
+                    ForwardOnNext(value);
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/SkipWhile.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/SkipWhile.cs
@@ -21,7 +21,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TSource>, IObserver<TSource>
+            internal sealed class _ : IdentitySink<TSource>
             {
                 private Func<TSource, bool> _predicate;
 
@@ -31,7 +31,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     _predicate = predicate;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     if (_predicate != null)
                     {
@@ -42,8 +42,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         }
                         catch (Exception exception)
                         {
-                            base._observer.OnError(exception);
-                            base.Dispose();
+                            ForwardOnError(exception);
                             return;
                         }
 
@@ -51,25 +50,13 @@ namespace System.Reactive.Linq.ObservableImpl
                         {
                             _predicate = null;
 
-                            base._observer.OnNext(value);
+                            ForwardOnNext(value);
                         }
                     }
                     else
                     {
-                        base._observer.OnNext(value);
+                        ForwardOnNext(value);
                     }
-                }
-
-                public void OnError(Exception error)
-                {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnCompleted();
-                    base.Dispose();
                 }
             }
         }
@@ -89,7 +76,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TSource>, IObserver<TSource>
+            internal sealed class _ : IdentitySink<TSource>
             {
                 private Func<TSource, int, bool> _predicate;
                 private int _index;
@@ -101,7 +88,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     _index = 0;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     if (_predicate != null)
                     {
@@ -112,8 +99,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         }
                         catch (Exception exception)
                         {
-                            base._observer.OnError(exception);
-                            base.Dispose();
+                            ForwardOnError(exception);
                             return;
                         }
 
@@ -121,25 +107,13 @@ namespace System.Reactive.Linq.ObservableImpl
                         {
                             _predicate = null;
 
-                            base._observer.OnNext(value);
+                            ForwardOnNext(value);
                         }
                     }
                     else
                     {
-                        base._observer.OnNext(value);
+                        ForwardOnNext(value);
                     }
-                }
-
-                public void OnError(Exception error)
-                {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnCompleted();
-                    base.Dispose();
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Sum.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Sum.cs
@@ -17,7 +17,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<double>, IObserver<double>
+        internal sealed class _ : IdentitySink<double>
         {
             private double _sum;
 
@@ -27,22 +27,15 @@ namespace System.Reactive.Linq.ObservableImpl
                 _sum = 0.0;
             }
 
-            public void OnNext(double value)
+            public override void OnNext(double value)
             {
                 _sum += value;
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext(_sum);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_sum);
+                ForwardOnCompleted();
             }
         }
     }
@@ -60,7 +53,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<float>, IObserver<float>
+        internal sealed class _ : IdentitySink<float>
         {
             private double _sum; // This is what LINQ to Objects does!
 
@@ -70,22 +63,15 @@ namespace System.Reactive.Linq.ObservableImpl
                 _sum = 0.0; // This is what LINQ to Objects does!
             }
 
-            public void OnNext(float value)
+            public override void OnNext(float value)
             {
                 _sum += value; // This is what LINQ to Objects does!
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext((float)_sum); // This is what LINQ to Objects does!
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext((float)_sum); // This is what LINQ to Objects does!
+                ForwardOnCompleted();
             }
         }
     }
@@ -103,7 +89,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<decimal>, IObserver<decimal>
+        internal sealed class _ : IdentitySink<decimal>
         {
             private decimal _sum;
 
@@ -113,22 +99,15 @@ namespace System.Reactive.Linq.ObservableImpl
                 _sum = 0M;
             }
 
-            public void OnNext(decimal value)
+            public override void OnNext(decimal value)
             {
                 _sum += value;
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext(_sum);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_sum);
+                ForwardOnCompleted();
             }
         }
     }
@@ -146,7 +125,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<int>, IObserver<int>
+        internal sealed class _ : IdentitySink<int>
         {
             private int _sum;
 
@@ -156,7 +135,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _sum = 0;
             }
 
-            public void OnNext(int value)
+            public override void OnNext(int value)
             {
                 try
                 {
@@ -167,22 +146,14 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception exception)
                 {
-                    base._observer.OnError(exception);
-                    base.Dispose();
+                    ForwardOnError(exception);
                 }
             }
-
-            public void OnError(Exception error)
+            
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext(_sum);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_sum);
+                ForwardOnCompleted();
             }
         }
     }
@@ -200,7 +171,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<long>, IObserver<long>
+        internal sealed class _ : IdentitySink<long>
         {
             private long _sum;
 
@@ -210,7 +181,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _sum = 0L;
             }
 
-            public void OnNext(long value)
+            public override void OnNext(long value)
             {
                 try
                 {
@@ -221,22 +192,14 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception exception)
                 {
-                    base._observer.OnError(exception);
-                    base.Dispose();
+                    ForwardOnError(exception);
                 }
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext(_sum);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_sum);
+                ForwardOnCompleted();
             }
         }
     }
@@ -254,7 +217,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<double?>, IObserver<double?>
+        internal sealed class _ : IdentitySink<double?>
         {
             private double _sum;
 
@@ -264,23 +227,16 @@ namespace System.Reactive.Linq.ObservableImpl
                 _sum = 0.0;
             }
 
-            public void OnNext(double? value)
+            public override void OnNext(double? value)
             {
                 if (value != null)
                     _sum += value.Value;
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext(_sum);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_sum);
+                ForwardOnCompleted();
             }
         }
     }
@@ -298,7 +254,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<float?>, IObserver<float?>
+        internal sealed class _ : IdentitySink<float?>
         {
             private double _sum; // This is what LINQ to Objects does!
 
@@ -308,23 +264,16 @@ namespace System.Reactive.Linq.ObservableImpl
                 _sum = 0.0; // This is what LINQ to Objects does!
             }
 
-            public void OnNext(float? value)
+            public override void OnNext(float? value)
             {
                 if (value != null)
                     _sum += value.Value; // This is what LINQ to Objects does!
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext((float)_sum); // This is what LINQ to Objects does!
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext((float)_sum); // This is what LINQ to Objects does!
+                ForwardOnCompleted();
             }
         }
     }
@@ -342,7 +291,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<decimal?>, IObserver<decimal?>
+        internal sealed class _ : IdentitySink<decimal?>
         {
             private decimal _sum;
 
@@ -352,23 +301,16 @@ namespace System.Reactive.Linq.ObservableImpl
                 _sum = 0M;
             }
 
-            public void OnNext(decimal? value)
+            public override void OnNext(decimal? value)
             {
                 if (value != null)
                     _sum += value.Value;
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext(_sum);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_sum);
+                ForwardOnCompleted();
             }
         }
     }
@@ -386,7 +328,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<int?>, IObserver<int?>
+        internal sealed class _ : IdentitySink<int?>
         {
             private int _sum;
 
@@ -396,7 +338,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _sum = 0;
             }
 
-            public void OnNext(int? value)
+            public override void OnNext(int? value)
             {
                 try
                 {
@@ -408,22 +350,14 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception exception)
                 {
-                    base._observer.OnError(exception);
-                    base.Dispose();
+                    ForwardOnError(exception);
                 }
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext(_sum);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_sum);
+                ForwardOnCompleted();
             }
         }
     }
@@ -441,7 +375,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<long?>, IObserver<long?>
+        internal sealed class _ : IdentitySink<long?>
         {
             private long _sum;
 
@@ -451,7 +385,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _sum = 0L;
             }
 
-            public void OnNext(long? value)
+            public override void OnNext(long? value)
             {
                 try
                 {
@@ -463,22 +397,14 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception exception)
                 {
-                    base._observer.OnError(exception);
-                    base.Dispose();
+                    ForwardOnError(exception);
                 }
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext(_sum);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_sum);
+                ForwardOnCompleted();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Synchronize.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Synchronize.cs
@@ -24,7 +24,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.Subscribe(sink);
 
-        internal sealed class _ : Sink<TSource>, IObserver<TSource>
+        internal sealed class _ : IdentitySink<TSource>
         {
             private readonly object _gate;
 
@@ -34,29 +34,27 @@ namespace System.Reactive.Linq.ObservableImpl
                 _gate = gate ?? new object();
             }
 
-            public void OnNext(TSource value)
+            public override void OnNext(TSource value)
             {
                 lock (_gate)
                 {
-                    base._observer.OnNext(value);
+                    ForwardOnNext(value);
                 }
             }
 
-            public void OnError(Exception error)
+            public override void OnError(Exception error)
             {
                 lock (_gate)
                 {
-                    base._observer.OnError(error);
-                    base.Dispose();
+                    ForwardOnError(error);
                 }
             }
 
-            public void OnCompleted()
+            public override void OnCompleted()
             {
                 lock (_gate)
                 {
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnCompleted();
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Take.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Take.cs
@@ -39,7 +39,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TSource>, IObserver<TSource>
+            internal sealed class _ : IdentitySink<TSource>
             {
                 private int _remaining;
 
@@ -49,31 +49,18 @@ namespace System.Reactive.Linq.ObservableImpl
                     _remaining = count;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     if (_remaining > 0)
                     {
                         --_remaining;
-                        base._observer.OnNext(value);
+                        ForwardOnNext(value);
 
                         if (_remaining == 0)
                         {
-                            base._observer.OnCompleted();
-                            base.Dispose();
+                            ForwardOnCompleted();
                         }
                     }
-                }
-
-                public void OnError(Exception error)
-                {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnCompleted();
-                    base.Dispose();
                 }
             }
         }
@@ -112,7 +99,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => sink.Run(this);
 
-            internal sealed class _ : Sink<TSource>, IObserver<TSource>
+            internal sealed class _ : IdentitySink<TSource> 
             {
                 public _(IObserver<TSource> observer, IDisposable cancel)
                     : base(observer, cancel)
@@ -134,34 +121,31 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     lock (_gate)
                     {
-                        base._observer.OnCompleted();
-                        base.Dispose();
+                        ForwardOnCompleted();
                     }
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     lock (_gate)
                     {
-                        base._observer.OnNext(value);
+                        ForwardOnNext(value);
                     }
                 }
 
-                public void OnError(Exception error)
+                public override void OnError(Exception error)
                 {
                     lock (_gate)
                     {
-                        base._observer.OnError(error);
-                        base.Dispose();
+                        ForwardOnError(error);
                     }
                 }
 
-                public void OnCompleted()
+                public override void OnCompleted()
                 {
                     lock (_gate)
                     {
-                        base._observer.OnCompleted();
-                        base.Dispose();
+                        ForwardOnCompleted();
                     }
                 }
             }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/TakeLastBuffer.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/TakeLastBuffer.cs
@@ -24,7 +24,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<IList<TSource>>, IObserver<TSource>
+            internal sealed class _ : Sink<TSource, IList<TSource>> 
             {
                 private readonly int _count;
                 private Queue<TSource> _queue;
@@ -36,28 +36,21 @@ namespace System.Reactive.Linq.ObservableImpl
                     _queue = new Queue<TSource>();
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     _queue.Enqueue(value);
                     if (_queue.Count > _count)
                         _queue.Dequeue();
                 }
 
-                public void OnError(Exception error)
-                {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
+                public override void OnCompleted()
                 {
                     var res = new List<TSource>(_queue.Count);
                     while (_queue.Count > 0)
                         res.Add(_queue.Dequeue());
 
-                    base._observer.OnNext(res);
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnNext(res);
+                    ForwardOnCompleted();
                 }
             }
         }
@@ -79,7 +72,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => sink.Run(this);
 
-            internal sealed class _ : Sink<IList<TSource>>, IObserver<TSource>
+            internal sealed class _ : Sink<TSource, IList<TSource>> 
             {
                 private readonly TimeSpan _duration;
                 private Queue<System.Reactive.TimeInterval<TSource>> _queue;
@@ -100,20 +93,14 @@ namespace System.Reactive.Linq.ObservableImpl
                     return parent._source.SubscribeSafe(this);
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     var now = _watch.Elapsed;
                     _queue.Enqueue(new System.Reactive.TimeInterval<TSource>(value, now));
                     Trim(now);
                 }
 
-                public void OnError(Exception error)
-                {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
+                public override void OnCompleted()
                 {
                     var now = _watch.Elapsed;
                     Trim(now);
@@ -122,9 +109,8 @@ namespace System.Reactive.Linq.ObservableImpl
                     while (_queue.Count > 0)
                         res.Add(_queue.Dequeue().Value);
 
-                    base._observer.OnNext(res);
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnNext(res);
+                    ForwardOnCompleted();
                 }
 
                 private void Trim(TimeSpan now)

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/TakeUntil.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/TakeUntil.cs
@@ -22,7 +22,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => sink.Run(this);
 
-        internal sealed class _ : Sink<TSource>
+        internal sealed class _ : IdentitySink<TSource>
         {
             public _(IObserver<TSource> observer, IDisposable cancel)
                 : base(observer, cancel)
@@ -75,13 +75,13 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (_open)
                     {
-                        _parent._observer.OnNext(value);
+                        _parent.ForwardOnNext(value);
                     }
                     else
                     {
                         lock (_parent)
                         {
-                            _parent._observer.OnNext(value);
+                            _parent.ForwardOnNext(value);
                         }
                     }
                 }
@@ -90,8 +90,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     lock (_parent)
                     {
-                        _parent._observer.OnError(error);
-                        _parent.Dispose();
+                        _parent.ForwardOnError(error);
                     }
                 }
 
@@ -99,8 +98,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     lock (_parent)
                     {
-                        _parent._observer.OnCompleted();
-                        _parent.Dispose();
+                        _parent.ForwardOnCompleted();
                     }
                 }
             }
@@ -127,8 +125,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     lock (_parent)
                     {
-                        _parent._observer.OnCompleted();
-                        _parent.Dispose();
+                        _parent.ForwardOnCompleted();
                     }
                 }
 
@@ -136,8 +133,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     lock (_parent)
                     {
-                        _parent._observer.OnError(error);
-                        _parent.Dispose();
+                        _parent.ForwardOnError(error);
                     }
                 }
 
@@ -187,7 +183,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => sink.Run(this);
 
-        internal sealed class _ : Sink<TSource>, IObserver<TSource>
+        internal sealed class _ : IdentitySink<TSource>
         {
             private readonly object _gate = new object();
 
@@ -207,34 +203,31 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 lock (_gate)
                 {
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnCompleted();
                 }
             }
 
-            public void OnNext(TSource value)
+            public override void OnNext(TSource value)
             {
                 lock (_gate)
                 {
-                    base._observer.OnNext(value);
+                    ForwardOnNext(value);
                 }
             }
 
-            public void OnError(Exception error)
+            public override void OnError(Exception error)
             {
                 lock (_gate)
                 {
-                    base._observer.OnError(error);
-                    base.Dispose();
+                    ForwardOnError(error);
                 }
             }
 
-            public void OnCompleted()
+            public override void OnCompleted()
             {
                 lock (_gate)
                 {
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnCompleted();
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/TakeWhile.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/TakeWhile.cs
@@ -21,7 +21,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TSource>, IObserver<TSource>
+            internal sealed class _ : IdentitySink<TSource>
             {
                 private readonly Func<TSource, bool> _predicate;
                 private bool _running;
@@ -33,7 +33,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     _running = true;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     if (_running)
                     {
@@ -43,33 +43,19 @@ namespace System.Reactive.Linq.ObservableImpl
                         }
                         catch (Exception exception)
                         {
-                            base._observer.OnError(exception);
-                            base.Dispose();
+                            ForwardOnError(exception);
                             return;
                         }
 
                         if (_running)
                         {
-                            base._observer.OnNext(value);
+                            ForwardOnNext(value);
                         }
                         else
                         {
-                            base._observer.OnCompleted();
-                            base.Dispose();
+                            ForwardOnCompleted();
                         }
                     }
-                }
-
-                public void OnError(Exception error)
-                {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnCompleted();
-                    base.Dispose();
                 }
             }
         }
@@ -89,7 +75,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TSource>, IObserver<TSource>
+            internal sealed class _ : IdentitySink<TSource>
             {
                 private readonly Func<TSource, int, bool> _predicate;
                 private bool _running;
@@ -103,7 +89,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     _index = 0;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     if (_running)
                     {
@@ -113,33 +99,19 @@ namespace System.Reactive.Linq.ObservableImpl
                         }
                         catch (Exception exception)
                         {
-                            base._observer.OnError(exception);
-                            base.Dispose();
+                            ForwardOnError(exception);
                             return;
                         }
 
                         if (_running)
                         {
-                            base._observer.OnNext(value);
+                            ForwardOnNext(value);
                         }
                         else
                         {
-                            base._observer.OnCompleted();
-                            base.Dispose();
+                            ForwardOnCompleted();
                         }
                     }
-                }
-
-                public void OnError(Exception error)
-                {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnCompleted();
-                    base.Dispose();
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Throw.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Throw.cs
@@ -21,7 +21,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => sink.Run(_scheduler);
 
-        internal sealed class _ : Sink<TResult>
+        internal sealed class _ : IdentitySink<TResult>
         {
             private readonly Exception _exception;
 
@@ -38,8 +38,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             private void Invoke()
             {
-                base._observer.OnError(_exception);
-                base.Dispose();
+                ForwardOnError(_exception);
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/TimeInterval.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/TimeInterval.cs
@@ -21,7 +21,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => sink.Run(this);
 
-        internal sealed class _ : Sink<System.Reactive.TimeInterval<TSource>>, IObserver<TSource>
+        internal sealed class _ : Sink<TSource, System.Reactive.TimeInterval<TSource>> 
         {
             public _(IObserver<System.Reactive.TimeInterval<TSource>> observer, IDisposable cancel)
                 : base(observer, cancel)
@@ -39,24 +39,12 @@ namespace System.Reactive.Linq.ObservableImpl
                 return parent._source.Subscribe(this);
             }
 
-            public void OnNext(TSource value)
+            public override void OnNext(TSource value)
             {
                 var now = _watch.Elapsed;
                 var span = now.Subtract(_last);
                 _last = now;
-                base._observer.OnNext(new System.Reactive.TimeInterval<TSource>(value, span));
-            }
-
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnCompleted();
-                Dispose();
+                ForwardOnNext(new System.Reactive.TimeInterval<TSource>(value, span));
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Timer.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Timer.cs
@@ -49,7 +49,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 protected override IDisposable Run(_ sink) => sink.Run(this, _dueTime);
             }
 
-            internal sealed class _ : Sink<long>
+            internal sealed class _ : IdentitySink<long>
             {
                 public _(IObserver<long> observer, IDisposable cancel)
                     : base(observer, cancel)
@@ -68,9 +68,8 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 private void Invoke()
                 {
-                    base._observer.OnNext(0);
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnNext(0);
+                    ForwardOnCompleted();
                 }
             }
         }
@@ -116,7 +115,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 protected override IDisposable Run(_ sink) => sink.Run(this, _dueTime);
             }
 
-            internal sealed class _ : Sink<long>
+            internal sealed class _ : IdentitySink<long>
             {
                 private readonly TimeSpan _period;
 
@@ -160,7 +159,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 //
                 private long Tick(long count)
                 {
-                    base._observer.OnNext(count);
+                    ForwardOnNext(count);
                     return unchecked(count + 1);
                 }
 
@@ -224,7 +223,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                     try
                     {
-                        base._observer.OnNext(0L);
+                        ForwardOnNext(0L);
                     }
                     catch (Exception e)
                     {
@@ -263,7 +262,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     //
                     if (Interlocked.Increment(ref _pendingTickCount) == 1)
                     {
-                        base._observer.OnNext(count);
+                        ForwardOnNext(count);
                         Interlocked.Decrement(ref _pendingTickCount);
                     }
 
@@ -274,7 +273,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     try
                     {
-                        base._observer.OnNext(count);
+                        ForwardOnNext(count);
                     }
                     catch (Exception e)
                     {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Timestamp.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Timestamp.cs
@@ -21,7 +21,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<Timestamped<TSource>>, IObserver<TSource>
+        internal sealed class _ : Sink<TSource, Timestamped<TSource>> 
         {
             private readonly IScheduler _scheduler;
 
@@ -31,21 +31,9 @@ namespace System.Reactive.Linq.ObservableImpl
                 _scheduler = scheduler;
             }
 
-            public void OnNext(TSource value)
+            public override void OnNext(TSource value)
             {
-                base._observer.OnNext(new Timestamped<TSource>(value, _scheduler.Now));
-            }
-
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(new Timestamped<TSource>(value, _scheduler.Now));
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/ToArray.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/ToArray.cs
@@ -19,7 +19,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<TSource[]>, IObserver<TSource>
+        internal sealed class _ : Sink<TSource, TSource[]> 
         {
             private readonly List<TSource> _list;
 
@@ -29,22 +29,15 @@ namespace System.Reactive.Linq.ObservableImpl
                 _list = new List<TSource>();
             }
 
-            public void OnNext(TSource value)
+            public override void OnNext(TSource value)
             {
                 _list.Add(value);
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext(_list.ToArray());
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_list.ToArray());
+                ForwardOnCompleted();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/ToDictionary.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/ToDictionary.cs
@@ -25,7 +25,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<IDictionary<TKey, TElement>>, IObserver<TSource>
+        internal sealed class _ : Sink<TSource, IDictionary<TKey, TElement>> 
         {
             private readonly Func<TSource, TKey> _keySelector;
             private readonly Func<TSource, TElement> _elementSelector;
@@ -39,7 +39,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _dictionary = new Dictionary<TKey, TElement>(parent._comparer);
             }
 
-            public void OnNext(TSource value)
+            public override void OnNext(TSource value)
             {
                 try
                 {
@@ -47,22 +47,14 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception ex)
                 {
-                    base._observer.OnError(ex);
-                    base.Dispose();
+                    ForwardOnError(ex);
                 }
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext(_dictionary);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_dictionary);
+                ForwardOnCompleted();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/ToList.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/ToList.cs
@@ -19,7 +19,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<IList<TSource>>, IObserver<TSource>
+        internal sealed class _ : Sink<TSource, IList<TSource>> 
         {
             private readonly List<TSource> _list;
 
@@ -29,22 +29,15 @@ namespace System.Reactive.Linq.ObservableImpl
                 _list = new List<TSource>();
             }
 
-            public void OnNext(TSource value)
+            public override void OnNext(TSource value)
             {
                 _list.Add(value);
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext(_list);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_list);
+                ForwardOnCompleted();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/ToLookup.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/ToLookup.cs
@@ -26,7 +26,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-        internal sealed class _ : Sink<ILookup<TKey, TElement>>, IObserver<TSource>
+        internal sealed class _ : Sink<TSource, ILookup<TKey, TElement>> 
         {
             private readonly Func<TSource, TKey> _keySelector;
             private readonly Func<TSource, TElement> _elementSelector;
@@ -40,7 +40,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _lookup = new Lookup<TKey, TElement>(parent._comparer);
             }
 
-            public void OnNext(TSource value)
+            public override void OnNext(TSource value)
             {
                 try
                 {
@@ -48,22 +48,14 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception ex)
                 {
-                    base._observer.OnError(ex);
-                    base.Dispose();
+                    ForwardOnError(ex);
                 }
             }
 
-            public void OnError(Exception error)
+            public override void OnCompleted()
             {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnNext(_lookup);
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnNext(_lookup);
+                ForwardOnCompleted();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/ToObservable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/ToObservable.cs
@@ -23,7 +23,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => sink.Run(this);
 
-        internal sealed class _ : Sink<TSource>
+        internal sealed class _ : IdentitySink<TSource>
         {
             public _(IObserver<TSource> observer, IDisposable cancel)
                 : base(observer, cancel)
@@ -39,8 +39,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception exception)
                 {
-                    base._observer.OnError(exception);
-                    base.Dispose();
+                    ForwardOnError(exception);
                     return Disposable.Empty;
                 }
 
@@ -107,8 +106,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     state.enumerator.Dispose();
 
-                    base._observer.OnError(ex);
-                    base.Dispose();
+                    ForwardOnError(ex);
                     return;
                 }
 
@@ -116,12 +114,11 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     state.enumerator.Dispose();
 
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnCompleted();
                     return;
                 }
 
-                base._observer.OnNext(current);
+                ForwardOnNext(current);
                 recurse(state);
             }
 
@@ -146,17 +143,17 @@ namespace System.Reactive.Linq.ObservableImpl
 
                     if (ex != null)
                     {
-                        base._observer.OnError(ex);
+                        ForwardOnError(ex);
                         break;
                     }
 
                     if (!hasNext)
                     {
-                        base._observer.OnCompleted();
+                        ForwardOnCompleted();
                         break;
                     }
 
-                    base._observer.OnNext(current);
+                    ForwardOnNext(current);
                 }
 
                 enumerator.Dispose();

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Using.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Using.cs
@@ -22,7 +22,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => sink.Run(this);
 
-        internal sealed class _ : Sink<TSource>, IObserver<TSource>
+        internal sealed class _ : IdentitySink<TSource>
         {
             public _(IObserver<TSource> observer, IDisposable cancel)
                 : base(observer, cancel)
@@ -46,23 +46,6 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
 
                 return StableCompositeDisposable.Create(source.SubscribeSafe(this), disposable);
-            }
-
-            public void OnNext(TSource value)
-            {
-                base._observer.OnNext(value);
-            }
-
-            public void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
-
-            public void OnCompleted()
-            {
-                base._observer.OnCompleted();
-                base.Dispose();
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Where.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Where.cs
@@ -26,7 +26,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TSource>, IObserver<TSource>
+            internal sealed class _ : IdentitySink<TSource>
             {
                 private readonly Func<TSource, bool> _predicate;
 
@@ -36,7 +36,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     _predicate = predicate;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     var shouldRun = default(bool);
                     try
@@ -45,27 +45,14 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception exception)
                     {
-                        base._observer.OnError(exception);
-                        base.Dispose();
+                        ForwardOnError(exception);
                         return;
                     }
 
                     if (shouldRun)
                     {
-                        base._observer.OnNext(value);
+                        ForwardOnNext(value);
                     }
-                }
-
-                public void OnError(Exception error)
-                {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnCompleted();
-                    base.Dispose();
                 }
             }
         }
@@ -85,7 +72,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => _source.SubscribeSafe(sink);
 
-            internal sealed class _ : Sink<TSource>, IObserver<TSource>
+            internal sealed class _ : IdentitySink<TSource>
             {
                 private readonly Func<TSource, int, bool> _predicate;
                 private int _index;
@@ -97,7 +84,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     _index = 0;
                 }
 
-                public void OnNext(TSource value)
+                public override void OnNext(TSource value)
                 {
                     var shouldRun = default(bool);
                     try
@@ -106,27 +93,13 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception exception)
                     {
-                        base._observer.OnError(exception);
-                        base.Dispose();
-                        return;
+                        ForwardOnError(exception);
                     }
 
                     if (shouldRun)
                     {
-                        base._observer.OnNext(value);
+                        ForwardOnNext(value);
                     }
-                }
-
-                public void OnError(Exception error)
-                {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnCompleted();
-                    base.Dispose();
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/While.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/While.cs
@@ -33,17 +33,6 @@ namespace System.Reactive.Linq.ObservableImpl
                 : base(observer, cancel)
             {
             }
-
-            public override void OnNext(TSource value)
-            {
-                base._observer.OnNext(value);
-            }
-
-            public override void OnError(Exception error)
-            {
-                base._observer.OnError(error);
-                base.Dispose();
-            }
         }
     }
 }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/WithLatestFrom.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/WithLatestFrom.cs
@@ -23,7 +23,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => sink.Run(_first, _second);
 
-        internal sealed class _ : Sink<TResult>
+        internal sealed class _ : IdentitySink<TResult>
         {
             private readonly Func<TFirst, TSecond, TResult> _resultSelector;
 
@@ -68,8 +68,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     lock (_parent._gate)
                     {
-                        _parent._observer.OnCompleted();
-                        _parent.Dispose();
+                        _parent.ForwardOnCompleted();
                     }
                 }
 
@@ -77,8 +76,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     lock (_parent._gate)
                     {
-                        _parent._observer.OnError(error);
-                        _parent.Dispose();
+                        _parent.ForwardOnError(error);
                     }
                 }
 
@@ -104,8 +102,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         {
                             lock (_parent._gate)
                             {
-                                _parent._observer.OnError(ex);
-                                _parent.Dispose();
+                                _parent.ForwardOnError(ex);
                             }
 
                             return;
@@ -113,7 +110,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                         lock (_parent._gate)
                         {
-                            _parent._observer.OnNext(res);
+                            _parent.ForwardOnNext(res);
                         }
                     }
                 }
@@ -139,8 +136,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     lock (_parent._gate)
                     {
-                        _parent._observer.OnError(error);
-                        _parent.Dispose();
+                        _parent.ForwardOnError(error);
                     }
                 }
 

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Zip.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Zip.cs
@@ -30,7 +30,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => sink.Run(_first, _second);
 
-            internal sealed class _ : Sink<TResult>
+            internal sealed class _ : IdentitySink<TResult>
             {
                 private readonly Func<TFirst, TSecond, TResult> _resultSelector;
 
@@ -95,19 +95,17 @@ namespace System.Reactive.Linq.ObservableImpl
                                 }
                                 catch (Exception ex)
                                 {
-                                    _parent._observer.OnError(ex);
-                                    _parent.Dispose();
+                                    _parent.ForwardOnError(ex);
                                     return;
                                 }
 
-                                _parent._observer.OnNext(res);
+                                _parent.ForwardOnNext(res);
                             }
                             else
                             {
                                 if (_other.Done)
                                 {
-                                    _parent._observer.OnCompleted();
-                                    _parent.Dispose();
+                                    _parent.ForwardOnCompleted();
                                     return;
                                 }
 
@@ -120,8 +118,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     {
                         lock (_parent._gate)
                         {
-                            _parent._observer.OnError(error);
-                            _parent.Dispose();
+                            _parent.ForwardOnError(error);
                         }
                     }
 
@@ -133,8 +130,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                             if (_other.Done)
                             {
-                                _parent._observer.OnCompleted();
-                                _parent.Dispose();
+                                _parent.ForwardOnCompleted();
                                 return;
                             }
                             else
@@ -184,19 +180,17 @@ namespace System.Reactive.Linq.ObservableImpl
                                 }
                                 catch (Exception ex)
                                 {
-                                    _parent._observer.OnError(ex);
-                                    _parent.Dispose();
+                                    _parent.ForwardOnError(ex);
                                     return;
                                 }
 
-                                _parent._observer.OnNext(res);
+                                _parent.ForwardOnNext(res);
                             }
                             else
                             {
                                 if (_other.Done)
                                 {
-                                    _parent._observer.OnCompleted();
-                                    _parent.Dispose();
+                                    _parent.ForwardOnCompleted();
                                     return;
                                 }
 
@@ -209,8 +203,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     {
                         lock (_parent._gate)
                         {
-                            _parent._observer.OnError(error);
-                            _parent.Dispose();
+                            _parent.ForwardOnError(error);
                         }
                     }
 
@@ -222,8 +215,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                             if (_other.Done)
                             {
-                                _parent._observer.OnCompleted();
-                                _parent.Dispose();
+                                _parent.ForwardOnCompleted();
                                 return;
                             }
                             else
@@ -258,7 +250,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable Run(_ sink) => sink.Run(_first, _second);
 
-            internal sealed class _ : Sink<TResult>, IObserver<TFirst>
+            internal sealed class _ : Sink<TFirst, TResult> 
             {
                 private readonly Func<TFirst, TSecond, TResult> _resultSelector;
 
@@ -285,8 +277,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception exception)
                     {
-                        base._observer.OnError(exception);
-                        base.Dispose();
+                        ForwardOnError(exception);
                         return Disposable.Empty;
                     }
 
@@ -295,7 +286,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     return StableCompositeDisposable.Create(leftSubscription, _rightEnumerator);
                 }
 
-                public void OnNext(TFirst value)
+                public override void OnNext(TFirst value)
                 {
                     var hasNext = false;
                     try
@@ -304,8 +295,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception ex)
                     {
-                        base._observer.OnError(ex);
-                        base.Dispose();
+                        ForwardOnError(ex);
                         return;
                     }
 
@@ -318,8 +308,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         }
                         catch (Exception ex)
                         {
-                            base._observer.OnError(ex);
-                            base.Dispose();
+                            ForwardOnError(ex);
                             return;
                         }
 
@@ -330,30 +319,16 @@ namespace System.Reactive.Linq.ObservableImpl
                         }
                         catch (Exception ex)
                         {
-                            base._observer.OnError(ex);
-                            base.Dispose();
+                            ForwardOnError(ex);
                             return;
                         }
 
-                        base._observer.OnNext(result);
+                        ForwardOnNext(result);
                     }
                     else
                     {
-                        base._observer.OnCompleted();
-                        base.Dispose();
+                        ForwardOnCompleted();
                     }
-                }
-
-                public void OnError(Exception error)
-                {
-                    base._observer.OnError(error);
-                    base.Dispose();
-                }
-
-                public void OnCompleted()
-                {
-                    base._observer.OnCompleted();
-                    base.Dispose();
                 }
             }
         }
@@ -372,7 +347,7 @@ namespace System.Reactive.Linq.ObservableImpl
         void Done(int index);
     }
 
-    internal abstract class ZipSink<TResult> : Sink<TResult>, IZip
+    internal abstract class ZipSink<TResult> : IdentitySink<TResult>, IZip
     {
         protected readonly object _gate;
 
@@ -411,12 +386,11 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception ex)
                 {
-                    base._observer.OnError(ex);
-                    base.Dispose();
+                    ForwardOnError(ex);
                     return;
                 }
 
-                base._observer.OnNext(res);
+                ForwardOnNext(res);
             }
             else
             {
@@ -432,8 +406,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 if (allOthersDone)
                 {
-                    base._observer.OnCompleted();
-                    base.Dispose();
+                    ForwardOnCompleted();
                 }
             }
         }
@@ -442,8 +415,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         public void Fail(Exception error)
         {
-            base._observer.OnError(error);
-            base.Dispose();
+            ForwardOnError(error);
         }
 
         public void Done(int index)
@@ -462,8 +434,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             if (allDone)
             {
-                base._observer.OnCompleted();
-                base.Dispose();
+                ForwardOnCompleted();
                 return;
             }
         }
@@ -537,7 +508,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(_ sink) => sink.Run();
 
-        internal sealed class _ : Sink<IList<TSource>>
+        internal sealed class _ : IdentitySink<IList<TSource>>
         {
             private readonly Zip<TSource> _parent;
 
@@ -598,23 +569,21 @@ namespace System.Reactive.Linq.ObservableImpl
                             res.Add(_queues[i].Dequeue());
                         }
 
-                        base._observer.OnNext(res);
+                        ForwardOnNext(res);
                     }
                     else if (_isDone.AllExcept(index))
                     {
-                        base._observer.OnCompleted();
-                        base.Dispose();
+                        ForwardOnCompleted();
                         return;
                     }
                 }
             }
 
-            private void OnError(Exception error)
+            private new void OnError(Exception error)
             {
                 lock (_gate)
                 {
-                    base._observer.OnError(error);
-                    base.Dispose();
+                    ForwardOnError(error);
                 }
             }
 
@@ -626,8 +595,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                     if (_isDone.All())
                     {
-                        base._observer.OnCompleted();
-                        base.Dispose();
+                        ForwardOnCompleted();
                         return;
                     }
                     else


### PR DESCRIPTION
The main objective of this PR is to strengthen the concept of the Sink class. Before, it would wrap, yet
still internally expose an observer. Inheriting classes would access it directly and the pattern of disposing the Sink after calling OnCompleted/OnError on the wrapped observer would be on them and repeat throughout the code. This commit encapsulates the observer and exposes Forward*-methods, taking care of disposing at the right places. The result is a lot of saved duplicated code. Moreover, we find that almost all classes inheriting from Sink also implement an IObserver of some kind by themselves, so we establish a base class Sink<TSource, TTarget>. The concept of a Sink is now more obvious, i.e. it serves as the logic between the source-stream and the emitted target stream. At last, we introduce IdentitySink which will just relay events, again, this will save a lot of duplicated code.