### PR TITLE
4.x: Make TailRecursiveSink lock-free and have less allocations

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Internal/ConcatSink.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/ConcatSink.cs
@@ -15,6 +15,6 @@ namespace System.Reactive
 
         protected override IEnumerable<IObservable<TSource>> Extract(IObservable<TSource> source) => (source as IConcatenatable<TSource>)?.GetSources();
 
-        public override void OnCompleted() => _recurse();
+        public override void OnCompleted() => Recurse();
     }
 }

--- a/Rx.NET/Source/src/System.Reactive/Internal/TailRecursiveSink.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/TailRecursiveSink.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
+using System.Threading;
 
 namespace System.Reactive
 {
@@ -15,163 +16,175 @@ namespace System.Reactive
         {
         }
 
-        private bool _isDisposed;
-        private SerialDisposable _subscription;
-        private AsyncLock _gate;
-        private Stack<IEnumerator<IObservable<TSource>>> _stack;
-        private Stack<int?> _length;
-        protected Action _recurse;
+        bool _isDisposed;
+
+        int trampoline;
+
+        IDisposable currentSubscription;
+
+        Stack<IEnumerator<IObservable<TSource>>> stack;
 
         public IDisposable Run(IEnumerable<IObservable<TSource>> sources)
         {
-            _isDisposed = false;
-            _subscription = new SerialDisposable();
-            _gate = new AsyncLock();
-            _stack = new Stack<IEnumerator<IObservable<TSource>>>();
-            _length = new Stack<int?>();
-
-            if (!TryGetEnumerator(sources, out var e))
+            if (!TryGetEnumerator(sources, out var current))
                 return Disposable.Empty;
 
-            _stack.Push(e);
-            _length.Push(Helpers.GetLength(sources));
+            stack = new Stack<IEnumerator<IObservable<TSource>>>();
+            stack.Push(current);
 
-            var cancelable = SchedulerDefaults.TailRecursion.Schedule(self =>
-            {
-                _recurse = self;
-                _gate.Wait(MoveNext);
-            });
+            Drain();
 
-            return StableCompositeDisposable.Create(_subscription, cancelable, Disposable.Create(() => _gate.Wait(Dispose)));
+            return new RecursiveSinkDisposable(this);
         }
 
-        protected abstract IEnumerable<IObservable<TSource>> Extract(IObservable<TSource> source);
-
-        private void MoveNext()
+        sealed class RecursiveSinkDisposable : IDisposable
         {
-            var hasNext = false;
-            var next = default(IObservable<TSource>);
+            readonly TailRecursiveSink<TSource> parent;
 
-            do
+            public RecursiveSinkDisposable(TailRecursiveSink<TSource> parent)
             {
-                if (_stack.Count == 0)
-                    break;
+                this.parent = parent;
+            }
 
-                if (_isDisposed)
-                    return;
-
-                var e = _stack.Peek();
-                var l = _length.Peek();
-
-                var current = default(IObservable<TSource>);
-                try
-                {
-                    hasNext = e.MoveNext();
-                    if (hasNext)
-                    {
-                        current = e.Current;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    e.Dispose();
-
-                    //
-                    // Failure to enumerate the sequence cannot be handled, even by
-                    // operators like Catch, because it'd lead to another attempt at
-                    // enumerating to find the next observable sequence. Therefore,
-                    // we feed those errors directly to the observer.
-                    //
-                    _observer.OnError(ex);
-                    base.Dispose();
-                    return;
-                }
-
-                if (!hasNext)
-                {
-                    e.Dispose();
-
-                    _stack.Pop();
-                    _length.Pop();
-                }
-                else
-                {
-                    var r = l - 1;
-                    _length.Pop();
-                    _length.Push(r);
-
-                    try
-                    {
-                        next = Helpers.Unpack(current);
-                    }
-                    catch (Exception exception)
-                    {
-                        //
-                        // Errors from unpacking may produce side-effects that normally
-                        // would occur during a SubscribeSafe operation. Those would feed
-                        // back into the observer and be subject to the operator's error
-                        // handling behavior. For example, Catch would allow to handle
-                        // the error using a handler function.
-                        //
-                        if (!Fail(exception))
-                        {
-                            e.Dispose();
-                        }
-
-                        return;
-                    }
-
-                    //
-                    // Tail recursive case; drop the current frame.
-                    //
-                    if (r == 0)
-                    {
-                        e.Dispose();
-
-                        _stack.Pop();
-                        _length.Pop();
-                    }
-
-                    //
-                    // Flattening of nested sequences. Prevents stack overflow in observers.
-                    //
-                    var nextSeq = Extract(next);
-                    if (nextSeq != null)
-                    {
-                        if (!TryGetEnumerator(nextSeq, out var nextEnumerator))
-                            return;
-
-                        _stack.Push(nextEnumerator);
-                        _length.Push(Helpers.GetLength(nextSeq));
-
-                        hasNext = false;
-                    }
-                }
-            } while (!hasNext);
-
-            if (!hasNext)
+            public void Dispose()
             {
-                Done();
+                parent.DisposeAll();
+            }
+        }
+
+        void Drain()
+        {
+            if (Interlocked.Increment(ref trampoline) != 1)
+            {
                 return;
             }
 
-            var d = new SingleAssignmentDisposable();
-            _subscription.Disposable = d;
-            d.Disposable = next.SubscribeSafe(this);
-        }
-
-        private new void Dispose()
-        {
-            while (_stack.Count > 0)
+            for (; ; )
             {
-                var e = _stack.Pop();
-                _length.Pop();
+                if (Volatile.Read(ref _isDisposed))
+                {
+                    while (stack.Count != 0)
+                    {
+                        var enumerator = stack.Pop();
+                        enumerator.Dispose();
+                    }
+                    if (Volatile.Read(ref currentSubscription) != BooleanDisposable.True)
+                    {
+                        Interlocked.Exchange(ref currentSubscription, BooleanDisposable.True)?.Dispose();
+                    }
+                }
+                else
+                {
+                    if (stack.Count != 0)
+                    {
+                        var currentEnumerator = stack.Peek();
 
-                e.Dispose();
+                        var currentObservable = default(IObservable<TSource>);
+                        var next = default(IObservable<TSource>);
+
+                        try
+                        {
+                            if (currentEnumerator.MoveNext())
+                            {
+                                currentObservable = currentEnumerator.Current;
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            currentEnumerator.Dispose();
+                            _observer.OnError(ex);
+                            base.Dispose();
+                            Volatile.Write(ref _isDisposed, true);
+                            continue;
+                        }
+
+                        try
+                        {
+                            next = Helpers.Unpack(currentObservable);
+
+                        }
+                        catch (Exception ex)
+                        {
+                            next = null;
+                            if (!Fail(ex))
+                            {
+                                Volatile.Write(ref _isDisposed, true);
+                            }
+                            continue;
+                        }
+
+                        if (next != null)
+                        {
+                            var nextSeq = Extract(next);
+                            if (nextSeq != null)
+                            {
+                                if (TryGetEnumerator(nextSeq, out var nextEnumerator))
+                                {
+                                    stack.Push(nextEnumerator);
+                                    continue;
+                                }
+                                else
+                                {
+                                    Volatile.Write(ref _isDisposed, true);
+                                    continue;
+                                }
+                            }
+                            else
+                            {
+                                var sad = new SingleAssignmentDisposable();
+                                if (Interlocked.CompareExchange(ref currentSubscription, sad, null) == null)
+                                {
+                                    sad.Disposable = next.SubscribeSafe(this);
+                                }
+                                else
+                                {
+                                    continue;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            stack.Pop();
+                            currentEnumerator.Dispose();
+                            continue;
+                        }
+                    }
+                    else
+                    {
+                        Volatile.Write(ref _isDisposed, true);
+                        Done();
+                    }
+                }
+
+                if (Interlocked.Decrement(ref trampoline) == 0)
+                {
+                    break;
+                }
             }
-
-            _isDisposed = true;
         }
+
+        void DisposeAll()
+        {
+            Volatile.Write(ref _isDisposed, true);
+            // the disposing of currentSubscription is deferred to drain due to some ObservableExTest.Iterate_Complete()
+            // Interlocked.Exchange(ref currentSubscription, BooleanDisposable.True)?.Dispose();
+            Drain();
+        }
+
+        protected void Recurse()
+        {
+            var d = Volatile.Read(ref currentSubscription);
+            if (d != BooleanDisposable.True)
+            {
+                d?.Dispose();
+                if (Interlocked.CompareExchange(ref currentSubscription, null, d) == d)
+                {
+                    Drain();
+                }
+            }
+        }
+
+        protected abstract IEnumerable<IObservable<TSource>> Extract(IObservable<TSource> source);
 
         private bool TryGetEnumerator(IEnumerable<IObservable<TSource>> sources, out IEnumerator<IObservable<TSource>> result)
         {
@@ -182,12 +195,6 @@ namespace System.Reactive
             }
             catch (Exception exception)
             {
-                //
-                // Failure to enumerate the sequence cannot be handled, even by
-                // operators like Catch, because it'd lead to another attempt at
-                // enumerating to find the next observable sequence. Therefore,
-                // we feed those errors directly to the observer.
-                //
                 _observer.OnError(exception);
                 base.Dispose();
 

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Catch.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Catch.cs
@@ -45,7 +45,7 @@ namespace System.Reactive.Linq.ObservableImpl
             public override void OnError(Exception error)
             {
                 _lastException = error;
-                _recurse();
+                Recurse();
             }
 
             public override void OnCompleted()

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/OnErrorResumeNext.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/OnErrorResumeNext.cs
@@ -41,12 +41,12 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public override void OnError(Exception error)
             {
-                _recurse();
+                Recurse();
             }
 
             public override void OnCompleted()
             {
-                _recurse();
+                Recurse();
             }
 
             protected override bool Fail(Exception error)


### PR DESCRIPTION
This PR changes `TailRecursiveSink` to a lock-free algorithm as well as reduces the allocations in the class by inlining various `IDisposable` fields.

The aim of the class is to make sure `OnComplete` or `OnError` in `Concat`, `Catch` and various other operators don't trigger an infinite recursion but stay on the level. 

This could have been solved with a straightforward trampoline [like this `Concat` implementation](https://github.com/dotnet/reactive/pull/491/files), however, there is a small complication. The recursion may be not only on the termination side, but on the existence of the inner `IObservable`s. 

For example, to avoid yet another level of recursion due to graphs like `Concat(Concat(a, b), Concat(c, d))`, the `Extract` method can get another level of `IEnumerable<IObservable<TSource>>` on the current level, and the concatenation should resume on the inner `Concat`. 

The `Stack` is there to allow returning to an outer enumeration and resume it. I don't know what the length stack was supposed to do; the algorithm doesn't have to know how long each `IEnumerator` is. Was it some kind of optimization for Lists and arrays avoiding `MoveNext() == false` and thus `IEnumerator.Dispose()`? The former should be as costly as an index comparison and the latter should be no-op anyway.