### PR TITLE
4.x: Improve the logic of AsyncLock

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Concurrency/AsyncLock.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/AsyncLock.cs
@@ -11,7 +11,7 @@ namespace System.Reactive.Concurrency
     /// </summary>
     public sealed class AsyncLock : IDisposable
     {
-        private readonly Queue<Action> queue = new Queue<Action>();
+        private Queue<Action> queue;
         private bool isAcquired = false;
         private bool hasFaulted = false;
 
@@ -27,50 +27,72 @@ namespace System.Reactive.Concurrency
             if (action == null)
                 throw new ArgumentNullException(nameof(action));
 
-            var isOwner = false;
-            lock (queue)
+            // allow one thread to update the state
+            lock (this)
             {
-                if (!hasFaulted)
+                // if a previous action crashed, ignore any future actions
+                if (hasFaulted)
                 {
-                    queue.Enqueue(action);
-                    isOwner = !isAcquired;
-                    isAcquired = true;
+                    return;
                 }
+
+                // if the "lock" is busy, queue up the extra work
+                // otherwise there is no need to queue up "action"
+                if (isAcquired)
+                {
+                    // create the queue if necessary
+                    var q = queue;
+                    if (q == null)
+                    {
+                        q = new Queue<Action>();
+                        queue = q;
+                    }
+                    // enqueue the work
+                    q.Enqueue(action);
+                    return;
+                }
+
+                // indicate there is processing going on
+                isAcquired = true;
             }
 
-            if (isOwner)
+            // if we get here, execute the "action" first
+
+            for (; ; )
             {
-                while (true)
+                try
                 {
-                    var work = default(Action);
-                    lock (queue)
-                    {
-                        if (queue.Count > 0)
-                        {
-                            work = queue.Dequeue();
-                        }
-                        else
-                        {
-                            isAcquired = false;
-                            break;
-                        }
-                    }
-
-                    try
-                    {
-                        work();
-                    }
-                    catch
-                    {
-                        lock (queue)
-                        {
-                            queue.Clear();
-                            hasFaulted = true;
-                        }
-
-                        throw;
-                    }
+                    action();
                 }
+                catch
+                {
+                    // the execution failed, terminate this AsyncLock
+                    lock (this)
+                    {
+                        // throw away the queue
+                        queue = null;
+                        // report fault
+                        hasFaulted = true;
+                    }
+                    throw;
+                }
+
+                // execution succeeded, let's see if more work has to be done
+                lock (this)
+                {
+                    var q = queue;
+                    // either there is no queue yet or we run out of work
+                    if (q == null || q.Count == 0)
+                    {
+                        // release the lock
+                        isAcquired = false;
+                        return;
+                    }
+
+                    // get the next work action
+                    action = q.Dequeue();
+                }
+                // loop back and execute the action
             }
         }
 
@@ -79,9 +101,9 @@ namespace System.Reactive.Concurrency
         /// </summary>
         public void Dispose()
         {
-            lock (queue)
+            lock (this)
             {
-                queue.Clear();
+                queue = null;
                 hasFaulted = true;
             }
         }


### PR DESCRIPTION
This PR improves the `AsyncLock` class' logic:

- Avoid the cost of allocating a `queue` upfront in case there is no actual concurrency involved.
- Clearing that queue is more efficient by setting the reference to `null`.
- Enqueueing an `Action` when the "lock" is not held should not go through the queue because it can be executed immediately.
- Changed the lock to `this` (as `queue` can now be `null`). I've seen other places with `guard = new object()` but that's an allocation and `this` is available. Not sure what the policy is given that `AsyncLock` is public. If it was `internal` or have such copy, I'm sure such shortcuts could be safely taken.