### PR TITLE
4.x: Improve and fix CompositeDisposable

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Disposables/CompositeDisposable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/CompositeDisposable.cs
@@ -5,6 +5,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace System.Reactive.Disposables
 {
@@ -20,6 +21,10 @@ namespace System.Reactive.Disposables
         private List<IDisposable> _disposables;
         private int _count;
         private const int SHRINK_THRESHOLD = 64;
+
+        // Default initial capacity of the _disposables list in case
+        // The number of items is not known upfront
+        private const int DEFAULT_CAPACITY = 16;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CompositeDisposable"/> class with no disposables contained by it initially.
@@ -49,8 +54,13 @@ namespace System.Reactive.Disposables
         /// <exception cref="ArgumentNullException"><paramref name="disposables"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Any of the disposables in the <paramref name="disposables"/> collection is <c>null</c>.</exception>
         public CompositeDisposable(params IDisposable[] disposables)
-            : this((IEnumerable<IDisposable>)disposables)
         {
+            if (disposables == null)
+            {
+                throw new ArgumentNullException(nameof(disposables));
+            }
+
+            Init(disposables, disposables.Length);
         }
 
         /// <summary>
@@ -64,21 +74,49 @@ namespace System.Reactive.Disposables
             if (disposables == null)
                 throw new ArgumentNullException(nameof(disposables));
 
-            _disposables = new List<IDisposable>(disposables);
+            // If the disposables is a collection, get its size
+            // and use it as a capacity hint for the copy.
+            if (disposables is ICollection<IDisposable> c)
+            {
+                Init(disposables, c.Count);
+            }
+            else
+            {
+                // Unknown sized disposables, use the default capacity hint
+                Init(disposables, DEFAULT_CAPACITY);
+            }
+        }
 
-            //
-            // Doing this on the list to avoid duplicate enumeration of disposables.
-            //
-            if (_disposables.Contains(null))
-                throw new ArgumentException(Strings_Core.DISPOSABLES_CANT_CONTAIN_NULL, nameof(disposables));
+        /// <summary>
+        /// Initialize the inner disposable list and count fields.
+        /// </summary>
+        /// <param name="disposables">The enumerable sequence of disposables.</param>
+        /// <param name="capacityHint">The number of items expected from <paramref name="disposables"/></param>
+        private void Init(IEnumerable<IDisposable> disposables, int capacityHint)
+        {
+            var list = new List<IDisposable>(capacityHint);
 
-            _count = _disposables.Count;
+            // do the copy and null-check in one step to avoid a
+            // second loop for just checking for null items
+            foreach (var d in disposables)
+            {
+                if (d == null)
+                {
+                    throw new ArgumentException(Strings_Core.DISPOSABLES_CANT_CONTAIN_NULL, nameof(disposables));
+                }
+                list.Add(d);
+            }
+
+            _disposables = list;
+            // _count can be read by other threads and thus should be properly visible
+            // also releases the _disposables contents so it becomes thread-safe
+            Volatile.Write(ref _count, _disposables.Count());
         }
 
         /// <summary>
         /// Gets the number of disposables contained in the <see cref="CompositeDisposable"/>.
         /// </summary>
-        public int Count => _count;
+        public int Count => Volatile.Read(ref _count);
 
         /// <summary>
         /// Adds a disposable to the <see cref="CompositeDisposable"/> or disposes the disposable if the <see cref="CompositeDisposable"/> is disposed.
@@ -90,21 +128,20 @@ namespace System.Reactive.Disposables
             if (item == null)
                 throw new ArgumentNullException(nameof(item));
 
-            var shouldDispose = false;
             lock (_gate)
             {
-                shouldDispose = _disposed;
                 if (!_disposed)
                 {
                     _disposables.Add(item);
-                    _count++;
+                    // If read atomically outside the lock, it should be written atomically inside
+                    // the plain read on _count is fine here because manipulation always happens
+                    // from inside a lock.
+                    Volatile.Write(ref _count, _count + 1);
+                    return;
                 }
             }
 
-            if (shouldDispose)
-            {
-                item.Dispose();
-            }
+            item.Dispose();
         }
 
         /// <summary>
@@ -118,49 +155,60 @@ namespace System.Reactive.Disposables
             if (item == null)
                 throw new ArgumentNullException(nameof(item));
 
-            var shouldDispose = false;
-
             lock (_gate)
             {
-                if (!_disposed)
+                // this composite was already disposed and if the item was in there
+                // it has been already removed/disposed
+                if (_disposed)
                 {
-                    //
-                    // List<T> doesn't shrink the size of the underlying array but does collapse the array
-                    // by copying the tail one position to the left of the removal index. We don't need
-                    // index-based lookup but only ordering for sequential disposal. So, instead of spending
-                    // cycles on the Array.Copy imposed by Remove, we use a null sentinel value. We also
-                    // do manual Swiss cheese detection to shrink the list if there's a lot of holes in it.
-                    //
-                    var i = _disposables.IndexOf(item);
-                    if (i >= 0)
+                    return false;
+                }
+
+                //
+                // List<T> doesn't shrink the size of the underlying array but does collapse the array
+                // by copying the tail one position to the left of the removal index. We don't need
+                // index-based lookup but only ordering for sequential disposal. So, instead of spending
+                // cycles on the Array.Copy imposed by Remove, we use a null sentinel value. We also
+                // do manual Swiss cheese detection to shrink the list if there's a lot of holes in it.
+                //
+
+                // read fields as infrequently as possible
+                var current = _disposables;
+
+                var i = current.IndexOf(item);
+                if (i < 0)
+                {
+                    // not found, just return
+                    return false;
+                }
+
+                current[i] = null;
+
+                if (current.Capacity > SHRINK_THRESHOLD && _count < current.Capacity / 2)
+                {
+                    var fresh = new List<IDisposable>(current.Capacity / 2);
+
+                    foreach (var d in current)
                     {
-                        shouldDispose = true;
-                        _disposables[i] = null;
-                        _count--;
-
-                        if (_disposables.Capacity > SHRINK_THRESHOLD && _count < _disposables.Capacity / 2)
+                        if (d != null)
                         {
-                            var old = _disposables;
-                            _disposables = new List<IDisposable>(_disposables.Capacity / 2);
-
-                            foreach (var d in old)
-                            {
-                                if (d != null)
-                                {
-                                    _disposables.Add(d);
-                                }
-                            }
+                            fresh.Add(d);
                         }
                     }
+
+                    _disposables = fresh;
                 }
+
+                // make sure the Count property sees an atomic update
+                Volatile.Write(ref _count, _count - 1);
             }
 
-            if (shouldDispose)
-            {
-                item.Dispose();
-            }
+            // if we get here, the item was found and removed from the list
+            // just dispose it and report success
 
-            return shouldDispose;
+            item.Dispose();
+
+            return true;
         }
 
         /// <summary>
@@ -168,15 +216,19 @@ namespace System.Reactive.Disposables
         /// </summary>
         public void Dispose()
         {
-            var currentDisposables = default(IDisposable[]);
+            var currentDisposables = default(List<IDisposable>);
             lock (_gate)
             {
                 if (!_disposed)
                 {
-                    _disposed = true;
-                    currentDisposables = _disposables.ToArray();
-                    _disposables.Clear();
-                    _count = 0;
+                    currentDisposables = _disposables;
+                    // nulling out the reference is faster no risk to
+                    // future Add/Remove because _disposed will be true
+                    // and thus _disposables won't be touched again.
+                    _disposables = null;
+
+                    Volatile.Write(ref _count, 0);
+                    Volatile.Write(ref _disposed, true);
                 }
             }
 
@@ -194,15 +246,24 @@ namespace System.Reactive.Disposables
         /// </summary>
         public void Clear()
         {
-            var currentDisposables = default(IDisposable[]);
+            var previousDisposables = default(IDisposable[]);
             lock (_gate)
             {
-                currentDisposables = _disposables.ToArray();
-                _disposables.Clear();
-                _count = 0;
+                // disposed composites are always clear
+                if (_disposed)
+                {
+                    return;
+                }
+
+                var current = _disposables;
+
+                previousDisposables = current.ToArray();
+                current.Clear();
+
+                Volatile.Write(ref _count, 0);
             }
 
-            foreach (var d in currentDisposables)
+            foreach (var d in previousDisposables)
             {
                 d?.Dispose();
             }
@@ -221,6 +282,10 @@ namespace System.Reactive.Disposables
 
             lock (_gate)
             {
+                if (_disposed)
+                {
+                    return false;
+                }
                 return _disposables.Contains(item);
             }
         }
@@ -241,7 +306,26 @@ namespace System.Reactive.Disposables
 
             lock (_gate)
             {
-                Array.Copy(_disposables.Where(d => d != null).ToArray(), 0, array, arrayIndex, array.Length - arrayIndex);
+                // disposed composites are always empty
+                if (_disposed)
+                {
+                    return;
+                }
+
+                if (arrayIndex + _count > array.Length)
+                {
+                    // there is not enough space beyond arrayIndex 
+                    // to accomodate all _count disposables in this composite
+                    throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+                }
+                var i = arrayIndex;
+                foreach (var d in _disposables)
+                {
+                    if (d != null)
+                    {
+                        array[i++] = d;
+                    }
+                }
             }
         }
 
@@ -256,14 +340,16 @@ namespace System.Reactive.Disposables
         /// <returns>An enumerator to iterate over the disposables.</returns>
         public IEnumerator<IDisposable> GetEnumerator()
         {
-            var res = default(IEnumerable<IDisposable>);
-
             lock (_gate)
             {
-                res = _disposables.Where(d => d != null).ToList();
+                if (_disposed || _count == 0)
+                {
+                    return EMPTY_ENUMERATOR;
+                }
+                // the copy is unavoidable but the creation
+                // of an outer IEnumerable is avoidable
+                return new CompositeEnumerator(_disposables.ToArray());
             }
-
-            return res.GetEnumerator();
         }
 
         /// <summary>
@@ -275,6 +361,67 @@ namespace System.Reactive.Disposables
         /// <summary>
         /// Gets a value that indicates whether the object is disposed.
         /// </summary>
-        public bool IsDisposed => _disposed;
+        public bool IsDisposed => Volatile.Read(ref _disposed);
+
+        /// <summary>
+        /// An empty enumerator for the <see cref="GetEnumerator"/>
+        /// method to avoid allocation on disposed or empty composites.
+        /// </summary>
+        static readonly CompositeEnumerator EMPTY_ENUMERATOR =
+            new CompositeEnumerator(new IDisposable[0]);
+
+        /// <summary>
+        /// An enumerator for an array of disposables.
+        /// </summary>
+        sealed class CompositeEnumerator : IEnumerator<IDisposable>
+        {
+            readonly IDisposable[] disposables;
+
+            int index;
+
+            public CompositeEnumerator(IDisposable[] disposables)
+            {
+                this.disposables = disposables;
+                this.index = -1;
+            }
+
+            public IDisposable Current => disposables[index];
+
+            object IEnumerator.Current => disposables[index];
+
+            public void Dispose()
+            {
+                // Avoid retention of the referenced disposables
+                // beyond the lifecycle of the enumerator.
+                // Not sure if this happens by default to
+                // generic array enumerators though.
+                var disposables = this.disposables;
+                Array.Clear(disposables, 0, disposables.Length);
+            }
+
+            public bool MoveNext()
+            {
+                var disposables = this.disposables;
+
+                for (; ; )
+                {
+                    var idx = ++index;
+                    if (idx >= disposables.Length)
+                    {
+                        return false;
+                    }
+                    // inlined that filter for null elements
+                    if (disposables[idx] != null)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            public void Reset()
+            {
+                index = -1;
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR cleans up the internal logic of `CompositeDisposable` by avoiding some allocations and making sure publicly visible state is available in a thread-safe manner.

The main safety offender was the `IsDisposed` reading the `_disposed` plain field without a barrier. Assuming the .NET memory modell is compatible with the C++ 11/Java memory model, such reads could be cached and the reader may never see `_disposed` turn true:

```cs
var composite = new CompositeDisposable();

handOff(composite);

while (!composite.IsDisposed) Thread.SpinWait();

// resume
```

without a barrier, this could end up like this:

```cs
var isDisposed = composite.IsDisposed;
while (!isDisposed) Thread.SpinWait();
```

and never complete.