### PR TITLE
4.x: Fix PriorityQueue to not share a item ordering helper index

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Internal/PriorityQueue.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/PriorityQueue.cs
@@ -9,7 +9,7 @@ namespace System.Reactive
 {
     internal sealed class PriorityQueue<T> where T : IComparable<T>
     {
-        private static long _count = long.MinValue;
+        private long _count = long.MinValue;
         private IndexedItem[] _items;
         private int _size;
 
@@ -125,7 +125,7 @@ namespace System.Reactive
             }
 
             var index = _size++;
-            _items[index] = new IndexedItem { Value = item, Id = Interlocked.Increment(ref _count) };
+            _items[index] = new IndexedItem { Value = item, Id = ++_count };
             Percolate(index);
         }
 


### PR DESCRIPTION
The `PriorityQueue._count` field was a static field shared between all instances the `PriorityQueue` of the same type argument. I can only assume this was thought as a tradeoff between having 8 more bytes per priority queue or trashing everybody else's cache who happen to be prioritizing on the same type argument.

This PR simply changes it to a per instance counter and also removes the `Interlocked.Increment` as the class itself is by no means thread-safe so it makes no sense to have the creation of a fresh index atomic in `Enqueue`.