### PR TITLE
4.x: Replace ObserveOn(IScheduler) with a newer lock-free algorithm

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Concurrency/Synchronization.ObserveOn.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/Synchronization.ObserveOn.cs
@@ -26,6 +26,26 @@ namespace System.Reactive.Concurrency
             protected override IDisposable Run(ObserveOnObserver<TSource> sink) => _source.SubscribeSafe(sink);
         }
 
+        /// <summary>
+        /// The new ObserveOn operator run with an IScheduler in a lock-free manner.
+        /// </summary>
+        internal sealed class SchedulerNew : Producer<TSource, ObserveOnObserverNew<TSource>>
+        {
+            private readonly IObservable<TSource> _source;
+            private readonly IScheduler _scheduler;
+
+            public SchedulerNew(IObservable<TSource> source, IScheduler scheduler)
+            {
+                _source = source;
+                _scheduler = scheduler;
+            }
+
+            protected override ObserveOnObserverNew<TSource> CreateSink(IObserver<TSource> observer, IDisposable cancel) => new ObserveOnObserverNew<TSource>(_scheduler, observer, cancel);
+
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "2", Justification = "Visibility restricted to friend assemblies. Those should be correct by inspection.")]
+            protected override IDisposable Run(ObserveOnObserverNew<TSource> sink) => _source.SubscribeSafe(sink);
+        }
+
         internal sealed class Context : Producer<TSource, Context._>
         {
             private readonly IObservable<TSource> _source;

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/Synchronization.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/Synchronization.cs
@@ -102,7 +102,7 @@ namespace System.Reactive.Concurrency
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return new ObserveOn<TSource>.Scheduler(source, scheduler);
+            return new ObserveOn<TSource>.SchedulerNew(source, scheduler);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR adds a new implementation of the `ObserveOn` operator that uses a newer lock-free algorithm and is implemented as a separate set of classes.

The reason for this is that the `SchedulerObserver` the old `ObserveOnObserver` relies upon offers some union of features required throughout the code, convoluting its internal implementation to accomodate for multiple things. Improving those would require significantly more code changes across the code base along with trying to figure out what their intent was.