### PR TITLE
Add explicit windowsbase reference

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
+++ b/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
@@ -51,6 +51,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46'">
     <Reference Include="System.Windows" />
     <Reference Include="System.Windows.Forms" />
+    <Reference Include="WindowsBase" />
     <Compile Include="Platforms\Desktop\**\*.cs" />
   </ItemGroup>
   

--- a/Rx.NET/Source/version.json
+++ b/Rx.NET/Source/version.json
@@ -2,7 +2,7 @@
   "version": "4.0.0-preview.3.build.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
-    "^refs/heads/develop$", // we release out of develop
+    "^refs/heads/rel/v\\d+\\.\\d+", // we also release tags starting with vN.N
     "^refs/tags/v\\d+\\.\\d+" // we also release tags starting with vN.N
   ],
   "nugetPackageVersion":{

--- a/Rx.NET/Source/version.json
+++ b/Rx.NET/Source/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.0.0-preview.2.build.{height}",
+  "version": "4.0.0-preview.3.build.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
     "^refs/heads/develop$", // we release out of develop


### PR DESCRIPTION
Fixes issue

`error CS0012: The type 'Dispatcher' is defined in an assembly that is not referenced. You must add a reference to assembly 'WindowsBase, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.`