### PR TITLE
4.x: Fix ActivePlan crashing with self-joins

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Joins/ActivePlan.cs
+++ b/Rx.NET/Source/src/System.Reactive/Joins/ActivePlan.cs
@@ -14,7 +14,10 @@ namespace System.Reactive.Joins
 
         protected void AddJoinObserver(IJoinObserver joinObserver)
         {
-            joinObservers.Add(joinObserver, joinObserver);
+            if (!joinObservers.ContainsKey(joinObserver))
+            {
+                joinObservers.Add(joinObserver, joinObserver);
+            }
         }
 
         protected void Dequeue()

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/WhenTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/WhenTest.cs
@@ -223,5 +223,15 @@ namespace ReactiveTests.Tests
             yield break;
         }
 
+        [Fact]
+        public void SameSource()
+        {
+            var source = Observable.Range(1, 5);
+
+            var list = Observable.When(source.And(source).Then((a, b) => a + b))
+                .ToList().First();
+
+            Assert.Equal(new List<int>() { 2, 4, 6, 8, 10 }, list);
+        }
     }
 }


### PR DESCRIPTION
This PR fixes a crash due to key reuse in `ActivePlan` that prevents self-joins such as this:

```cs
var source = Observable.Range(1, 5);
Observable.When(
    source.And(source).Then((a, b) => a + b)
)
.Subscribe(Console.WriteLine);
```

Without the fix, there is a crash:
```
System.ThrowHelper.ThrowArgumentException(ExceptionResource resource)
System.Collections.Generic.Dictionary`2.Insert(TKey key, TValue value, Boolean add)
System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
System.Reactive.Joins.ActivePlan.AddJoinObserver(IJoinObserver joinObserver)
System.Reactive.Joins.ActivePlan`2..ctor(JoinObserver`1 first, JoinObserver`1 second, Action`2 onNext, Action onCompleted)
System.Reactive.Joins.Plan`3.Activate(Dictionary`2 externalSubscriptions, IObserver`1 observer, Action`1 deactivate)
System.Reactive.Linq.QueryLanguage.<>c__DisplayClass421_0`1.<When>b__0(IObserver`1 observer)
```

Note that I have generally little understanding of the Join Patterns so I'm not sure if this fix is actually legitimate in the context of the intended behavior of the Join Patterns beyond the fact that existing unit tests pass with the modification (locally).