### PR TITLE
Enable ValueTuples without explicit component naming.

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
+++ b/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
@@ -4,6 +4,7 @@
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>       
     <PackageTags>Rx;Reactive;Extensions;Observable;LINQ;Events</PackageTags>
     <Description>Reactive Extensions (Rx) for .NET</Description>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
 
@@ -24,6 +25,7 @@
   
   <!-- UWP -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">      
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="System.ComponentModel" Version="4.0.1" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.0.11" />
     <PackageReference Include="System.Linq.Queryable" Version="4.0.1" />    
@@ -40,6 +42,7 @@
   
   <!-- Desktop -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46'">
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <Reference Include="System.Windows" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="WindowsBase" />


### PR DESCRIPTION
To write modern code and to reduce allocations throughout the code, reference System.ValueTuple for further reduction of allocations, use C# 7.1 to use value tuples without the need for explicit tuple component naming.