### PR TITLE
Reduce allocations for anonymous observables

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/AnonymousObservable.cs
+++ b/Rx.NET/Source/src/System.Reactive/AnonymousObservable.cs
@@ -36,5 +36,46 @@ namespace System.Reactive
         {
             return _subscribe(observer) ?? Disposable.Empty;
         }
+
+        public static StatefulAnonymousObservable<T, TState> CreateStateful<TState>(Func<IObserver<T>, TState, IDisposable> subscribe, TState state)
+        {
+            return new StatefulAnonymousObservable<T, TState>(subscribe, state);
+        }
+    }
+
+    /// <summary>
+    /// Class to create an <see cref="IObservable{T}"/> instance from a delegate-based implementation of the <see cref="IObservable{T}.Subscribe(IObserver{T})"/> method.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in the sequence.</typeparam>
+    /// <typeparam name="TState">The type of the state that is passed to the subscription function.</typeparam>
+    public sealed class StatefulAnonymousObservable<T, TState> : ObservableBase<T>
+    {
+        private readonly TState _state;
+        private readonly Func<IObserver<T>, TState, IDisposable> _subscribe;
+
+        /// <summary>
+        /// Creates an observable sequence object from the specified subscription function.
+        /// </summary>
+        /// <param name="subscribe"><see cref="IObservable{T}.Subscribe(IObserver{T})"/> method implementation.</param>
+        /// <param name="state">The state to pass to the subscription function.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="subscribe"/> is <c>null</c>.</exception>
+        public StatefulAnonymousObservable(Func<IObserver<T>, TState, IDisposable> subscribe, TState state)
+        {
+            if (subscribe == null)
+                throw new ArgumentNullException(nameof(subscribe));
+
+            _state = state;
+            _subscribe = subscribe;
+        }
+
+        /// <summary>
+        /// Calls the subscription function that was supplied to the constructor.
+        /// </summary>
+        /// <param name="observer">Observer to send notifications to.</param>
+        /// <returns>Disposable object representing an observer's subscription to the observable sequence.</returns>
+        protected override IDisposable SubscribeCore(IObserver<T> observer)
+        {
+            return _subscribe(observer, this._state) ?? Disposable.Empty;
+        }
     }
 }

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/Scheduler.Simple.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/Scheduler.Simple.cs
@@ -26,6 +26,30 @@ namespace System.Reactive.Concurrency
         }
 
         /// <summary>
+        /// Schedules an action to be executed.
+        /// </summary>
+        /// <param name="scheduler">Scheduler to execute the action on.</param>
+        /// <param name="action">Action to execute.</param>
+        /// <param name="state">A state object to be passed to <paramref name="action"/>.</param>
+        /// <returns>The disposable object used to cancel the scheduled action (best effort).</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="scheduler"/> or <paramref name="action"/> is <c>null</c>.</exception>
+        internal static IDisposable Schedule<TState>(this IScheduler scheduler, Action<TState> action, TState state)
+        {
+            if (scheduler == null)
+                throw new ArgumentNullException(nameof(scheduler));
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+
+            return scheduler.Schedule(
+                (action, state), 
+                (_, tuple) =>
+                {
+                    tuple.action(tuple.state);
+                    return Disposable.Empty;
+                });
+        }
+
+        /// <summary>
         /// Schedules an action to be executed after the specified relative due time.
         /// </summary>
         /// <param name="scheduler">Scheduler to execute the action on.</param>

--- a/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Async.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Async.cs
@@ -725,14 +725,16 @@ namespace System.Reactive.Linq
                 result = task.ToObservable();
             }
 
-            return new AnonymousObservable<TSource>(observer =>
-            {
-                //
-                // [OK] Use of unsafe Subscribe: result is an AsyncSubject<TSource>.
-                //
-                var subscription = result.Subscribe/*Unsafe*/(observer);
-                return StableCompositeDisposable.Create(cancellable, subscription);
-            });
+            return AnonymousObservable<TSource>.CreateStateful(
+                (observer, closureTuple) =>
+                {
+                    //
+                    // [OK] Use of unsafe Subscribe: result is an AsyncSubject<TSource>.
+                    //
+                    var subscription = closureTuple.result.Subscribe/*Unsafe*/(observer);
+                    return StableCompositeDisposable.Create(closureTuple.cancellable, subscription);
+                },
+                (result, cancellable));
         }
 
         #endregion
@@ -816,14 +818,16 @@ namespace System.Reactive.Linq
                 result = task.ToObservable();
             }
 
-            return new AnonymousObservable<Unit>(observer =>
-            {
-                //
-                // [OK] Use of unsafe Subscribe: result is an AsyncSubject<TSource>.
-                //
-                var subscription = result.Subscribe/*Unsafe*/(observer);
-                return StableCompositeDisposable.Create(cancellable, subscription);
-            });
+            return AnonymousObservable<Unit>.CreateStateful(
+                (observer, closureTuple) =>
+                {
+                    //
+                    // [OK] Use of unsafe Subscribe: result is an AsyncSubject<TSource>.
+                    //
+                    var subscription = closureTuple.result.Subscribe/*Unsafe*/(observer);
+                    return StableCompositeDisposable.Create(closureTuple.cancellable, subscription);
+                },
+                (cancellable, result));
         }
 
         #endregion

--- a/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguageEx.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguageEx.cs
@@ -16,14 +16,16 @@ namespace System.Reactive.Linq
 
         public virtual IObservable<TResult> Create<TResult>(Func<IObserver<TResult>, IEnumerable<IObservable<object>>> iteratorMethod)
         {
-            return new AnonymousObservable<TResult>(observer =>
-                iteratorMethod(observer).Concat().Subscribe(_ => { }, observer.OnError, observer.OnCompleted));
+            return AnonymousObservable<TResult>.CreateStateful(
+                (observer, closureIteratorMethod) => closureIteratorMethod(observer).Concat().Subscribe(_ => { }, observer.OnError, observer.OnCompleted),
+                iteratorMethod);
         }
 
         public virtual IObservable<Unit> Create(Func<IEnumerable<IObservable<object>>> iteratorMethod)
         {
-            return new AnonymousObservable<Unit>(observer =>
-                iteratorMethod().Concat().Subscribe(_ => { }, observer.OnError, observer.OnCompleted));
+            return AnonymousObservable<Unit>.CreateStateful(
+                (observer, closureIteratorMethod) => closureIteratorMethod().Concat().Subscribe(_ => { }, observer.OnError, observer.OnCompleted),
+                iteratorMethod);
         }
 
         #endregion
@@ -32,108 +34,110 @@ namespace System.Reactive.Linq
 
         public virtual IObservable<TSource> Expand<TSource>(IObservable<TSource> source, Func<TSource, IObservable<TSource>> selector, IScheduler scheduler)
         {
-            return new AnonymousObservable<TSource>(observer =>
-            {
-                var outGate = new object();
-                var q = new Queue<IObservable<TSource>>();
-                var m = new SerialDisposable();
-                var d = new CompositeDisposable { m };
-                var activeCount = 0;
-                var isAcquired = false;
-
-                var ensureActive = default(Action);
-
-                ensureActive = () =>
+            return AnonymousObservable<TSource>.CreateStateful(
+                (observer, tuple) =>
                 {
-                    var isOwner = false;
+                    var outGate = new object();
+                    var q = new Queue<IObservable<TSource>>();
+                    var m = new SerialDisposable();
+                    var d = new CompositeDisposable { m };
+                    var activeCount = 0;
+                    var isAcquired = false;
 
-                    lock (q)
+                    var ensureActive = default(Action);
+
+                    ensureActive = () =>
                     {
-                        if (q.Count > 0)
-                        {
-                            isOwner = !isAcquired;
-                            isAcquired = true;
-                        }
-                    }
+                        var isOwner = false;
 
-                    if (isOwner)
-                    {
-                        m.Disposable = scheduler.Schedule(self =>
+                        lock (q)
                         {
-                            var work = default(IObservable<TSource>);
-
-                            lock (q)
+                            if (q.Count > 0)
                             {
-                                if (q.Count > 0)
-                                    work = q.Dequeue();
-                                else
-                                {
-                                    isAcquired = false;
-                                    return;
-                                }
+                                isOwner = !isAcquired;
+                                isAcquired = true;
                             }
+                        }
 
-                            var m1 = new SingleAssignmentDisposable();
-                            d.Add(m1);
-                            m1.Disposable = work.Subscribe(
-                                x =>
+                        if (isOwner)
+                        {
+                            m.Disposable = tuple.scheduler.Schedule(self =>
+                            {
+                                var work = default(IObservable<TSource>);
+
+                                lock (q)
                                 {
-                                    lock (outGate)
-                                        observer.OnNext(x);
-
-                                    var result = default(IObservable<TSource>);
-                                    try
+                                    if (q.Count > 0)
+                                        work = q.Dequeue();
+                                    else
                                     {
-                                        result = selector(x);
+                                        isAcquired = false;
+                                        return;
                                     }
-                                    catch (Exception exception)
+                                }
+
+                                var m1 = new SingleAssignmentDisposable();
+                                d.Add(m1);
+                                m1.Disposable = work.Subscribe(
+                                    x =>
+                                    {
+                                        lock (outGate)
+                                            observer.OnNext(x);
+
+                                        var result = default(IObservable<TSource>);
+                                        try
+                                        {
+                                            result = tuple.selector(x);
+                                        }
+                                        catch (Exception exception)
+                                        {
+                                            lock (outGate)
+                                                observer.OnError(exception);
+                                        }
+
+                                        lock (q)
+                                        {
+                                            q.Enqueue(result);
+                                            activeCount++;
+                                        }
+
+                                        ensureActive();
+                                    },
+                                    exception =>
                                     {
                                         lock (outGate)
                                             observer.OnError(exception);
-                                    }
-
-                                    lock (q)
+                                    },
+                                    () =>
                                     {
-                                        q.Enqueue(result);
-                                        activeCount++;
-                                    }
+                                        d.Remove(m1);
 
-                                    ensureActive();
-                                },
-                                exception =>
-                                {
-                                    lock (outGate)
-                                        observer.OnError(exception);
-                                },
-                                () =>
-                                {
-                                    d.Remove(m1);
+                                        var done = false;
+                                        lock (q)
+                                        {
+                                            activeCount--;
+                                            if (activeCount == 0)
+                                                done = true;
+                                        }
+                                        if (done)
+                                            lock (outGate)
+                                                observer.OnCompleted();
+                                    });
+                                self();
+                            });
+                        }
+                    };
 
-                                    var done = false;
-                                    lock (q)
-                                    {
-                                        activeCount--;
-                                        if (activeCount == 0)
-                                            done = true;
-                                    }
-                                    if (done)
-                                        lock (outGate)
-                                            observer.OnCompleted();
-                                });
-                            self();
-                        });
+                    lock (q)
+                    {
+                        q.Enqueue(tuple.source);
+                        activeCount++;
                     }
-                };
+                    ensureActive();
 
-                lock (q)
-                {
-                    q.Enqueue(source);
-                    activeCount++;
-                }
-                ensureActive();
-
-                return d;
-            });
+                    return d;
+                },
+                (source, selector, scheduler));
         }
 
         public virtual IObservable<TSource> Expand<TSource>(IObservable<TSource> source, Func<TSource, IObservable<TSource>> selector)
@@ -245,80 +249,82 @@ namespace System.Reactive.Linq
 
         public virtual IObservable<TSource[]> ForkJoin<TSource>(IEnumerable<IObservable<TSource>> sources)
         {
-            return new AnonymousObservable<TSource[]>(subscriber =>
-            {
-                var allSources = sources.ToArray();
-                var count = allSources.Length;
-
-                if (count == 0)
+            return AnonymousObservable<TSource[]>.CreateStateful(
+                (subscriber, closureSources) =>
                 {
-                    subscriber.OnCompleted();
-                    return Disposable.Empty;
-                }
+                    var allSources = closureSources.ToArray();
+                    var count = allSources.Length;
 
-                var group = new CompositeDisposable(allSources.Length);
-                var gate = new object();
-
-                var finished = false;
-                var hasResults = new bool[count];
-                var hasCompleted = new bool[count];
-                var results = new List<TSource>(count);
-
-                lock (gate)
-                {
-                    for (var index = 0; index < count; index++)
+                    if (count == 0)
                     {
-                        var currentIndex = index;
-                        var source = allSources[index];
-                        results.Add(default(TSource));
-                        group.Add(source.Subscribe(
-                            value =>
-                            {
-                                lock (gate)
-                                {
-                                    if (!finished)
-                                    {
-                                        hasResults[currentIndex] = true;
-                                        results[currentIndex] = value;
-                                    }
-                                }
-                            },
-                            error =>
-                            {
-                                lock (gate)
-                                {
-                                    finished = true;
-                                    subscriber.OnError(error);
-                                    group.Dispose();
-                                }
-                            },
-                            () =>
-                            {
-                                lock (gate)
-                                {
-                                    if (!finished)
-                                    {
-                                        if (!hasResults[currentIndex])
-                                        {
-                                            subscriber.OnCompleted();
-                                            return;
-                                        }
-                                        hasCompleted[currentIndex] = true;
-                                        foreach (var completed in hasCompleted)
-                                        {
-                                            if (!completed)
-                                                return;
-                                        }
-                                        finished = true;
-                                        subscriber.OnNext(results.ToArray());
-                                        subscriber.OnCompleted();
-                                    }
-                                }
-                            }));
+                        subscriber.OnCompleted();
+                        return Disposable.Empty;
                     }
-                }
-                return group;
-            });
+
+                    var group = new CompositeDisposable(allSources.Length);
+                    var gate = new object();
+
+                    var finished = false;
+                    var hasResults = new bool[count];
+                    var hasCompleted = new bool[count];
+                    var results = new List<TSource>(count);
+
+                    lock (gate)
+                    {
+                        for (var index = 0; index < count; index++)
+                        {
+                            var currentIndex = index;
+                            var source = allSources[index];
+                            results.Add(default(TSource));
+                            group.Add(source.Subscribe(
+                                value =>
+                                {
+                                    lock (gate)
+                                    {
+                                        if (!finished)
+                                        {
+                                            hasResults[currentIndex] = true;
+                                            results[currentIndex] = value;
+                                        }
+                                    }
+                                },
+                                error =>
+                                {
+                                    lock (gate)
+                                    {
+                                        finished = true;
+                                        subscriber.OnError(error);
+                                        group.Dispose();
+                                    }
+                                },
+                                () =>
+                                {
+                                    lock (gate)
+                                    {
+                                        if (!finished)
+                                        {
+                                            if (!hasResults[currentIndex])
+                                            {
+                                                subscriber.OnCompleted();
+                                                return;
+                                            }
+                                            hasCompleted[currentIndex] = true;
+                                            foreach (var completed in hasCompleted)
+                                            {
+                                                if (!completed)
+                                                    return;
+                                            }
+                                            finished = true;
+                                            subscriber.OnNext(results.ToArray());
+                                            subscriber.OnCompleted();
+                                        }
+                                    }
+                                }));
+                        }
+                    }
+                    return group;
+                },
+                sources);
         }
 
         #endregion
@@ -427,19 +433,21 @@ namespace System.Reactive.Linq
 
         private static IObservable<TResult> Combine<TLeft, TRight, TResult>(IObservable<TLeft> leftSource, IObservable<TRight> rightSource, Func<IObserver<TResult>, IDisposable, IDisposable, IObserver<Either<Notification<TLeft>, Notification<TRight>>>> combinerSelector)
         {
-            return new AnonymousObservable<TResult>(observer =>
-            {
-                var leftSubscription = new SingleAssignmentDisposable();
-                var rightSubscription = new SingleAssignmentDisposable();
+            return AnonymousObservable<TResult>.CreateStateful(
+                (observer, tuple) =>
+                {
+                    var leftSubscription = new SingleAssignmentDisposable();
+                    var rightSubscription = new SingleAssignmentDisposable();
 
-                var combiner = combinerSelector(observer, leftSubscription, rightSubscription);
-                var gate = new object();
+                    var combiner = tuple.combinerSelector(observer, leftSubscription, rightSubscription);
+                    var gate = new object();
 
-                leftSubscription.Disposable = leftSource.Materialize().Select(x => Either<Notification<TLeft>, Notification<TRight>>.CreateLeft(x)).Synchronize(gate).Subscribe(combiner);
-                rightSubscription.Disposable = rightSource.Materialize().Select(x => Either<Notification<TLeft>, Notification<TRight>>.CreateRight(x)).Synchronize(gate).Subscribe(combiner);
+                    leftSubscription.Disposable = tuple.leftSource.Materialize().Select(x => Either<Notification<TLeft>, Notification<TRight>>.CreateLeft(x)).Synchronize(gate).Subscribe(combiner);
+                    rightSubscription.Disposable = tuple.rightSource.Materialize().Select(x => Either<Notification<TLeft>, Notification<TRight>>.CreateRight(x)).Synchronize(gate).Subscribe(combiner);
 
-                return StableCompositeDisposable.Create(leftSubscription, rightSubscription);
-            });
+                    return StableCompositeDisposable.Create(leftSubscription, rightSubscription);
+                },
+                (leftSource, rightSource, combinerSelector));
         }
 
         #endregion

--- a/Rx.NET/Source/src/System.Reactive/Notification.cs
+++ b/Rx.NET/Source/src/System.Reactive/Notification.cs
@@ -555,15 +555,19 @@ namespace System.Reactive
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return new AnonymousObservable<T>(observer => scheduler.Schedule(() =>
-            {
-                Accept(observer);
+            return AnonymousObservable<T>.CreateStateful(
+                (observer, closureTuple1) => closureTuple1.scheduler.Schedule(
+                    closureTuple2 =>
+                    {
+                        closureTuple2.@this.Accept(closureTuple2.observer);
 
-                if (Kind == NotificationKind.OnNext)
-                {
-                    observer.OnCompleted();
-                }
-            }));
+                        if (closureTuple2.@this.Kind == NotificationKind.OnNext)
+                        {
+                            closureTuple2.observer.OnCompleted();
+                        }
+                    },
+                    (closureTuple1.@this, closureTuple1.scheduler, observer)),
+                (@this: this, scheduler));
         }
     }
 

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Concurrency/SchedulerTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Concurrency/SchedulerTest.cs
@@ -34,6 +34,7 @@ namespace ReactiveTests.Tests
             var ms = new MyScheduler();
             ReactiveAssert.Throws<ArgumentNullException>(() => Scheduler.Schedule(default(IScheduler), a => { }));
             ReactiveAssert.Throws<ArgumentNullException>(() => Scheduler.Schedule(default(IScheduler), () => { }));
+            ReactiveAssert.Throws<ArgumentNullException>(() => Scheduler.Schedule(default(IScheduler), state => { }, new object()));
             ReactiveAssert.Throws<ArgumentNullException>(() => Scheduler.Schedule(default(IScheduler), 1, (a, s) => { }));
             ReactiveAssert.Throws<ArgumentNullException>(() => Scheduler.Schedule(ms, default(Action<Action>)));
             ReactiveAssert.Throws<ArgumentNullException>(() => Scheduler.Schedule(ms, 1, default(Action<int, Action<int>>)));
@@ -53,23 +54,29 @@ namespace ReactiveTests.Tests
         public void Schedulers_ArgumentChecks()
         {
             ReactiveAssert.Throws<ArgumentNullException>(() => Scheduler.CurrentThread.Schedule(default(Action)));
+            ReactiveAssert.Throws<ArgumentNullException>(() => Scheduler.CurrentThread.Schedule(default(Action<object>), new object()));
             ReactiveAssert.Throws<ArgumentNullException>(() => Scheduler.CurrentThread.Schedule(TimeSpan.Zero, default(Action)));
             ReactiveAssert.Throws<ArgumentNullException>(() => Scheduler.CurrentThread.Schedule(DateTimeOffset.MaxValue, default(Action)));
 #if DESKTOPCLR
             ReactiveAssert.Throws<ArgumentNullException>(() => DispatcherScheduler.Instance.Schedule(default(Action)));
+            ReactiveAssert.Throws<ArgumentNullException>(() => DispatcherScheduler.Instance.Schedule(default(Action<object>), new object()));
             ReactiveAssert.Throws<ArgumentNullException>(() => DispatcherScheduler.Instance.Schedule(TimeSpan.Zero, default(Action)));
             ReactiveAssert.Throws<ArgumentNullException>(() => DispatcherScheduler.Instance.Schedule(DateTimeOffset.MaxValue, default(Action)));
 #endif
             ReactiveAssert.Throws<ArgumentNullException>(() => Scheduler.Immediate.Schedule(default(Action)));
+            ReactiveAssert.Throws<ArgumentNullException>(() => Scheduler.Immediate.Schedule(default(Action<object>), new object()));
             ReactiveAssert.Throws<ArgumentNullException>(() => Scheduler.Immediate.Schedule(TimeSpan.Zero, default(Action)));
             ReactiveAssert.Throws<ArgumentNullException>(() => Scheduler.Immediate.Schedule(DateTimeOffset.MaxValue, default(Action)));
             ReactiveAssert.Throws<ArgumentNullException>(() => NewThreadScheduler.Default.Schedule(default(Action)));
+            ReactiveAssert.Throws<ArgumentNullException>(() => NewThreadScheduler.Default.Schedule(default(Action<object>), new object()));
             ReactiveAssert.Throws<ArgumentNullException>(() => NewThreadScheduler.Default.Schedule(TimeSpan.Zero, default(Action)));
             ReactiveAssert.Throws<ArgumentNullException>(() => NewThreadScheduler.Default.Schedule(DateTimeOffset.MaxValue, default(Action)));
             ReactiveAssert.Throws<ArgumentNullException>(() => TaskPoolScheduler.Default.Schedule(default(Action)));
+            ReactiveAssert.Throws<ArgumentNullException>(() => TaskPoolScheduler.Default.Schedule(default(Action<object>), new object()));
             ReactiveAssert.Throws<ArgumentNullException>(() => TaskPoolScheduler.Default.Schedule(TimeSpan.Zero, default(Action)));
             ReactiveAssert.Throws<ArgumentNullException>(() => TaskPoolScheduler.Default.Schedule(DateTimeOffset.MaxValue, default(Action)));
             ReactiveAssert.Throws<ArgumentNullException>(() => DefaultScheduler.Instance.Schedule(default(Action)));
+            ReactiveAssert.Throws<ArgumentNullException>(() => DefaultScheduler.Instance.Schedule(default(Action<object>), new object()));
             ReactiveAssert.Throws<ArgumentNullException>(() => DefaultScheduler.Instance.Schedule(TimeSpan.Zero, default(Action)));
             ReactiveAssert.Throws<ArgumentNullException>(() => DefaultScheduler.Instance.Schedule(DateTimeOffset.MaxValue, default(Action)));
             ReactiveAssert.Throws<ArgumentNullException>(() => DefaultScheduler.Instance.SchedulePeriodic(42, TimeSpan.FromSeconds(1), default(Func<int, int>)));
@@ -77,11 +84,13 @@ namespace ReactiveTests.Tests
 #if HAS_WINFORMS
             var lbl = new Label();
             ReactiveAssert.Throws<ArgumentNullException>(() => new ControlScheduler(lbl).Schedule(default(Action)));
+            ReactiveAssert.Throws<ArgumentNullException>(() => new ControlScheduler(lbl).Schedule(default(Action<object>), new object()));
             ReactiveAssert.Throws<ArgumentNullException>(() => new ControlScheduler(lbl).Schedule(TimeSpan.Zero, default(Action)));
             ReactiveAssert.Throws<ArgumentNullException>(() => new ControlScheduler(lbl).Schedule(DateTimeOffset.MaxValue, default(Action)));
 #endif
             var ctx = new SynchronizationContext();
             ReactiveAssert.Throws<ArgumentNullException>(() => new SynchronizationContextScheduler(ctx).Schedule(default(Action)));
+            ReactiveAssert.Throws<ArgumentNullException>(() => new SynchronizationContextScheduler(ctx).Schedule(default(Action<object>), new object()));
             ReactiveAssert.Throws<ArgumentNullException>(() => new SynchronizationContextScheduler(ctx).Schedule(TimeSpan.Zero, default(Action)));
             ReactiveAssert.Throws<ArgumentNullException>(() => new SynchronizationContextScheduler(ctx).Schedule(DateTimeOffset.MaxValue, default(Action)));
         }
@@ -102,6 +111,15 @@ namespace ReactiveTests.Tests
             var i = 0;
             Scheduler.Schedule(ms, a => { if (++i < 10) a(); });
             Assert.Equal(10, i);
+        }
+
+        [Fact]
+        public void Scheduler_Schedule_With_State()
+        {
+            var ms = new MyScheduler();
+            var res = false;
+            Scheduler.Schedule(ms, state => { Assert.Equal("state", state); res = true; }, "state");
+            Assert.True(res);
         }
 
         [Fact]


### PR DESCRIPTION
Almost every use of AnonymousObservable captures some variables in a closure and creates a delegate. This PR works around that by passing state.

Note: This is based on https://github.com/dotnet/reactive/pull/515 and https://github.com/dotnet/reactive/pull/518. These should be merged before this PR.