### PR TITLE
Fix T4-templates for CombineLatest and Zip

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/CombineLatest.Generated.tt
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/CombineLatest.Generated.tt
@@ -51,7 +51,7 @@ for (var j = 1; j <= i; j++)
             _resultSelector = resultSelector;
         }
 
-        protected override _ CreateSink2(IObserver<TResult> observer, IDisposable cancel) => new _(_resultSelector, observer, cancel);
+        protected override _ CreateSink(IObserver<TResult> observer, IDisposable cancel) => new _(_resultSelector, observer, cancel);
 
         protected override IDisposable Run(_ sink) => sink.Run(<#=ss#>);
 

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Zip.Generated.tt
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Zip.Generated.tt
@@ -51,7 +51,7 @@ for (var j = 1; j <= i; j++)
             _resultSelector = resultSelector;
         }
 
-        protected override _ CreateSink2(IObserver<TResult> observer, IDisposable cancel) => new _(_resultSelector, observer, cancel);
+        protected override _ CreateSink(IObserver<TResult> observer, IDisposable cancel) => new _(_resultSelector, observer, cancel);
 
         protected override IDisposable Run(_ sink) => sink.Run(<#=ss#>);
 


### PR DESCRIPTION
Fix for #458: The T4-templates for CombineLatest and Zip should override the correct method.