### PR TITLE
4.x: Have the ControlScheduler do more eager disposed checks

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Platforms/Desktop/Concurrency/ControlScheduler.cs
+++ b/Rx.NET/Source/src/System.Reactive/Platforms/Desktop/Concurrency/ControlScheduler.cs
@@ -52,11 +52,13 @@ namespace System.Reactive.Concurrency
             if (action == null)
                 throw new ArgumentNullException(nameof(action));
 
+            if (_control.IsDisposed) return Disposable.Empty;
+
             var d = new SingleAssignmentDisposable();
 
             _control.BeginInvoke(new Action(() =>
             {
-                if (!d.IsDisposed)
+                if (!_control.IsDisposed && !d.IsDisposed)
                     d.Disposable = action(this, state);
             }));
 
@@ -94,7 +96,10 @@ namespace System.Reactive.Concurrency
                     {
                         try
                         {
-                            d.Disposable = action(scheduler1, state1);
+                            if (!_control.IsDisposed && !d.IsDisposed)
+                            {
+                                d.Disposable = action(scheduler1, state1);
+                            }
                         }
                         finally
                         {
@@ -156,7 +161,10 @@ namespace System.Reactive.Concurrency
 
                 timer.Tick += (s, e) =>
                 {
-                    state1 = action(state1);
+                    if (!_control.IsDisposed)
+                    {
+                        state1 = action(state1);
+                    }
                 };
 
                 timer.Interval = (int)period.TotalMilliseconds;

--- a/Rx.NET/Source/src/System.Reactive/Platforms/Desktop/Concurrency/ControlScheduler.cs
+++ b/Rx.NET/Source/src/System.Reactive/Platforms/Desktop/Concurrency/ControlScheduler.cs
@@ -52,7 +52,10 @@ namespace System.Reactive.Concurrency
             if (action == null)
                 throw new ArgumentNullException(nameof(action));
 
-            if (_control.IsDisposed) return Disposable.Empty;
+            if (_control.IsDisposed)
+            {
+                return Disposable.Empty;
+            }
 
             var d = new SingleAssignmentDisposable();
 


### PR DESCRIPTION
This PR adds some additional eager dispose checks to `ControlScheduler` to see if either the `Control` object or the returned `IDisposable` has been disposed.

Fixes: #269