### PR TITLE
Reverse subscription order in SkipUntil

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable.Multiple.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable.Multiple.cs
@@ -1365,6 +1365,8 @@ namespace System.Reactive.Linq
 
         /// <summary>
         /// Returns the elements from the source observable sequence only after the other observable sequence produces an element.
+        /// Starting from Rx.NET 4.0, this will subscribe to <paramref name="other"/> before subscribing to <paramref name="source" />
+        /// so in case <paramref name="other" /> emits an element right away, elements from <paramref name="source" /> are not missed.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
         /// <typeparam name="TOther">The type of the elements in the other sequence that indicates the end of skip behavior.</typeparam>

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/SkipUntil.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/SkipUntil.cs
@@ -34,9 +34,9 @@ namespace System.Reactive.Linq.ObservableImpl
                 var sourceObserver = new SourceObserver(this);
                 var otherObserver = new OtherObserver(this, sourceObserver);
 
-                var sourceSubscription = parent._source.SubscribeSafe(sourceObserver);
                 var otherSubscription = parent._other.SubscribeSafe(otherObserver);
-
+                var sourceSubscription = parent._source.SubscribeSafe(sourceObserver);
+                
                 sourceObserver.Disposable = sourceSubscription;
                 otherObserver.Disposable = otherSubscription;
 

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/ObservableMultipleTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/ObservableMultipleTest.cs
@@ -9662,6 +9662,24 @@ namespace ReactiveTests.Tests
             Assert.True(disposed, "disposed");
         }
 
+        [Fact]
+        public void SkipUntil_Immediate()
+        {
+            var scheduler = new TestScheduler();
+
+            var xs = Observable.Return(1);
+            var ys = Observable.Return("bar");
+
+            var res = scheduler.Start(() =>
+                xs.SkipUntil(ys)
+            );
+
+            res.Messages.AssertEqual(
+                OnNext(200, 1),
+                OnCompleted<int>(200)
+            );
+        }
+
         #endregion
 
         #region + Switch +


### PR DESCRIPTION
In case source and other emit elements right away, the first element of source is not missed out.