### PR TITLE
4.x: Move AutoConnectTest and RetryWhenTest to correct location.

### DIFF
--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/AutoConnectTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/AutoConnectTest.cs
@@ -16,7 +16,7 @@ using System.Reactive.Subjects;
 
 namespace ReactiveTests.Tests
 {
-    public class ObservableAutoConnectTest : ReactiveTest
+    public class AutoConnectTest : ReactiveTest
     {
         [Fact]
         public void AutoConnect_Basic()

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/RetryWhenTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/RetryWhenTest.cs
@@ -14,7 +14,7 @@ using ReactiveTests.Dummies;
 
 namespace ReactiveTests.Tests
 {
-    public class ObservableRetryWhenTest : ReactiveTest
+    public class RetryWhenTest : ReactiveTest
     {
         [Fact]
         public void RetryWhen_Observable_ArgumentChecking()


### PR DESCRIPTION
Rename and move `ObservableAutoConnectTest` and `ObservableRetryWhenTest` to the new test files directory.