### PR TITLE
Fix compile warning (CS1711) caused by class inline documentation

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Runtime/CompilerServices/TaskObservableMethodBuilder.cs
+++ b/Rx.NET/Source/src/System.Reactive/Runtime/CompilerServices/TaskObservableMethodBuilder.cs
@@ -203,7 +203,6 @@ namespace System.Runtime.CompilerServices
         /// }
         /// </code>
         /// </remarks>
-        /// <typeparam name="T">The type of the elements in the sequence.</typeparam>
         internal sealed class TaskObservable : ITaskObservable<T>, ITaskObservableAwaiter<T>
         {
             /// <summary>


### PR DESCRIPTION
Fix the following compile warning:

      2>Runtime\CompilerServices\TaskObservableMethodBuilder.cs(206,30): warning CS1711: XML comment has a typeparam tag for 'T', but there is no type parameter by that name [D:\a\1\s\Rx.NET\Source\src\System.Reactive\System.Reactive.csproj]