### PR TITLE
Fix compiler directive in ImmutableListTest

### DIFF
--- a/Rx.NET/Source/tests/Tests.System.Reactive.Uwp.DeviceRunner/Tests.System.Reactive.Uwp.DeviceRunner.csproj
+++ b/Rx.NET/Source/tests/Tests.System.Reactive.Uwp.DeviceRunner/Tests.System.Reactive.Uwp.DeviceRunner.csproj
@@ -156,6 +156,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
+    <DefineConstants Condition="$(SignAssembly) == 'true'">$(DefineConstants);SIGNED</DefineConstants>
     <UpdateAssemblyInfo>false</UpdateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup>

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/ImmutableListTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/ImmutableListTest.cs
@@ -4,7 +4,7 @@ using System.Reactive;
 
 namespace ReactiveTests.Tests
 {
-#if !SIGNED
+#if SIGNED
     
     public class ImmutableListTest
     {


### PR DESCRIPTION
The code should be tested when System.Reactive is visible to the test assembly which is exactly when it is signed (and not vice versa). The SIGNED-directive is thus added to the Uwp-DeviceRunner project.