### PR TITLE
4.x: Fix race condition in UsingAsync_Simple unit test

### DIFF
--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/UsingAsyncTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/UsingAsyncTest.cs
@@ -33,17 +33,17 @@ namespace ReactiveTests.Tests
         [Fact]
         public void UsingAsync_Simple()
         {
-            var done = false;
+            var done = new CountdownEvent(1);
 
             var xs = Observable.Using<int, IDisposable>(
-                ct => Task.Factory.StartNew<IDisposable>(() => Disposable.Create(() => done = true)),
+                ct => Task.Factory.StartNew<IDisposable>(() => Disposable.Create(() => done.Signal())),
                 (_, ct) => Task.Factory.StartNew<IObservable<int>>(() => Observable.Return(42))
             );
 
             var res = xs.ToEnumerable().ToList();
 
-            Assert.True(new[] { 42 }.SequenceEqual(res));
-            Assert.True(done);
+            Assert.Equal(new List<int> { 42 }, res);
+            Assert.True(done.Wait(5000), "done.Wait(5000)");
         }
 
         [Fact]


### PR DESCRIPTION
This PR fixes the race condition in the `UsingAsyncTest.UsingAsync_Simple` on the `done` flag which is not guaranteed to be set just after when the elements become available to the test thread.

Fixes: #414