### PR TITLE
Ix.Async: Dispose an AsyncEnumerator once.

### DIFF
--- a/Ix.NET/Source/System.Interactive.Async.Tests/AsyncTests.Creation.cs
+++ b/Ix.NET/Source/System.Interactive.Async.Tests/AsyncTests.Creation.cs
@@ -452,6 +452,27 @@ namespace Tests
             await SequenceIdentity(xs);
         }
 
+        [Fact]
+        public async Task CreateEnumerator_DisposeOnce()
+        {
+            var count = 0;
+            var dispose = 0;
+
+            var en = AsyncEnumerable.CreateEnumerable(() =>
+                AsyncEnumerable.CreateEnumerator(async ct =>
+                {
+                    return ++count < 3;
+                }
+                , () => 1,
+                () => dispose++
+            ));
+
+            Assert.Equal(1, await en.Last());
+
+            Assert.Equal(3, count);
+            Assert.Equal(1, dispose);
+        }
+
         class MyD : IDisposable
         {
             private readonly Action _dispose;

--- a/Ix.NET/Source/System.Interactive.Async/Create.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Create.cs
@@ -97,16 +97,8 @@ namespace System.Linq
 
             public override void Dispose()
             {
-                var dispose = Volatile.Read(ref this.dispose);
-                if (dispose != null)
-                {
-                    dispose = Interlocked.Exchange(ref this.dispose, null);
-                    if (dispose != null)
-                    {
-                        dispose();
-                        base.Dispose();
-                    }
-                }
+                Interlocked.Exchange(ref this.dispose, null)?.Invoke();
+                base.Dispose();
             }
 
             protected override async Task<bool> MoveNextCore(CancellationToken cancellationToken)


### PR DESCRIPTION
Make sure the dispose action executes at most once in `AsyncEnumeble.CreateEnumerator`.

Fixes: #471