### PR TITLE
The approved API of Qbservable.RetryWhen() has the wrong return type.

### DIFF
--- a/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Api/ApiApprovalTests.Core.approved.txt
+++ b/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Api/ApiApprovalTests.Core.approved.txt
@@ -1978,7 +1978,7 @@ namespace System.Reactive.Linq
         public static System.Reactive.Linq.IQbservable<TResult> Replay<TSource, TResult>(this System.Reactive.Linq.IQbservable<TSource> source, System.Linq.Expressions.Expression<System.Func<System.IObservable<TSource>, System.IObservable<TResult>>> selector, System.TimeSpan window, System.Reactive.Concurrency.IScheduler scheduler) { }
         public static System.Reactive.Linq.IQbservable<TSource> Retry<TSource>(this System.Reactive.Linq.IQbservable<TSource> source) { }
         public static System.Reactive.Linq.IQbservable<TSource> Retry<TSource>(this System.Reactive.Linq.IQbservable<TSource> source, int retryCount) { }
-        public static System.IObservable<TSource> RetryWhen<TSource, TSignal>(this System.Reactive.Linq.IQbservable<TSource> source, System.Linq.Expressions.Expression<System.Func<System.IObservable<System.Exception>, System.IObservable<TSignal>>> handler) { }
+        public static System.Reactive.Linq.IQbservable<TSource> RetryWhen<TSource, TSignal>(this System.Reactive.Linq.IQbservable<TSource> source, System.Linq.Expressions.Expression<System.Func<System.IObservable<System.Exception>, System.IObservable<TSignal>>> handler) { }
         public static System.Reactive.Linq.IQbservable<TResult> Return<TResult>(this System.Reactive.Linq.IQbservableProvider provider, TResult value) { }
         public static System.Reactive.Linq.IQbservable<TResult> Return<TResult>(this System.Reactive.Linq.IQbservableProvider provider, TResult value, System.Reactive.Concurrency.IScheduler scheduler) { }
         public static System.Reactive.Linq.IQbservable<TSource> Sample<TSource>(this System.Reactive.Linq.IQbservable<TSource> source, System.TimeSpan interval) { }


### PR DESCRIPTION
It should return an `IQbservable` instead of an `IObservable`.