### PR TITLE
Update API approvals to report a small diff on failure

### DIFF
--- a/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Api/ApiApprovalTests.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Api/ApiApprovalTests.cs
@@ -9,13 +9,23 @@ using System;
 using System.Linq;
 using System.Reflection;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace ReactiveTests.Tests.Api
 {
+#if DEBUG
     [UseReporter(typeof(DiffReporter))]
+#else
+    [UseReporter(typeof(DiffPlexReporter))]
+#endif
     [IgnoreLineEndings(true)]
     public class ApiApprovalTests
     {
+        public ApiApprovalTests(ITestOutputHelper output)
+        {
+            DiffPlexReporter.INSTANCE.Output = output;
+        }
+
         [Fact]
         public void Core()
         {

--- a/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/DiffPlexReporter.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/DiffPlexReporter.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information. 
+
+using ApprovalTests.Core;
+using DiffPlex;
+using DiffPlex.DiffBuilder;
+using DiffPlex.DiffBuilder.Model;
+using System.IO;
+using Xunit.Abstractions;
+
+namespace ReactiveTests.Tests
+{
+    public class DiffPlexReporter : IApprovalFailureReporter
+    {
+        public static DiffPlexReporter INSTANCE = new DiffPlexReporter();
+
+        public ITestOutputHelper Output { get; set; }
+
+        public void Report(string approved, string received)
+        {
+            var approvedText = File.Exists(approved) ? File.ReadAllText(approved) : string.Empty;
+            var receivedText = File.ReadAllText(received);
+
+            var diffBuilder = new InlineDiffBuilder(new Differ());
+            var diff = diffBuilder.BuildDiffModel(approvedText, receivedText);
+
+            foreach (var line in diff.Lines)
+            {
+                if (line.Type == ChangeType.Unchanged) continue;
+
+                var prefix = "  ";
+                switch (line.Type)
+                {
+                    case ChangeType.Inserted:
+                        prefix = "+ ";
+                        break;
+                    case ChangeType.Deleted:
+                        prefix = "- ";
+                        break;
+                }
+
+                Output.WriteLine("{0}{1}", prefix, line.Text);
+            }
+        }
+    }
+}

--- a/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Tests.System.Reactive.ApiApprovals.csproj
+++ b/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Tests.System.Reactive.ApiApprovals.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="xunit" Version="2.4.0-beta.2.build4010" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0-beta.2.build4010" />
     <PackageReference Include="ApprovalTests" Version="3.0.14" />
+    <PackageReference Include="DiffPlex" Version="1.4.1" />
     <PackageReference Include="PublicApiGenerator" Version="7.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Currently, the VSTS CI runs of the build that contain API approval failures are poorly communicated due to ApprovalTests appearing to favor UI oriented diffing tools. I spent a bit of time investigating why it wasn't falling back to the Xunit2 "reporter" but, even if it used that correctly, it only points out a character position of where it deviated which still wasn't very useful.

Instead, I looked at adding a new reporter that would produce a minimal diff should the tests fail. This is what I have implemented in this PR.

Example output from build script:
```
      Stack Trace:
           at ApprovalTests.Approvers.FileApprover.Fail()
           at ApprovalTests.Core.Approver.Verify(IApprovalApprover approver, IApprovalFailureReporter reporter)
           at ApprovalTests.Approvals.Verify(IApprovalApprover approver, IApprovalFailureReporter reporter)
           at ApprovalTests.Approvals.Verify(IApprovalWriter writer, IApprovalNamer namer, IApprovalFailureReporter reporter)
           at ApprovalTests.Approvals.Verify(IApprovalWriter writer)
           at ApprovalTests.Approvals.Verify(String text)
        tests\Tests.System.Reactive.ApiApprovals\Api\ApiApprovalTests.cs(26,0): at ReactiveTests.Tests.Api.ApiApprovalTests.Core()
      Output:
        -         public bool Equals(System.Reactive.Unit other) { }
        +         public bool Equals(System.Reactive.Unit foobar) { }
```

~~I'm marking this as a WIP as I can't seem to find a good way to tell we're running the tests from within the Powershell build script. This is needed so I can make it always use the `DiffPlexReporter` when in those circumstances but fall back to the GUI diff tools if running from within an IDE. It is also possible that we just leave it as-is and document how to swap out the reporter for local dev/debugging (I can certainly look to updating the wiki with some documentation). I'd appreciate any input on a direction to pursue here.~~