### PR TITLE
Use HalfSerializer extensions

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Internal/Sink.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/Sink.cs
@@ -7,7 +7,14 @@ using System.Threading;
 
 namespace System.Reactive
 {
-    internal abstract class Sink<TTarget> : IDisposable
+    internal interface ISink<in TTarget>
+    {
+        void ForwardOnNext(TTarget value);
+        void ForwardOnCompleted();
+        void ForwardOnError(Exception error);
+    }
+
+    internal abstract class Sink<TTarget> : ISink<TTarget>, IDisposable
     {
         private IDisposable _cancel;
         private volatile IObserver<TTarget> _observer;
@@ -29,18 +36,18 @@ namespace System.Reactive
             Disposable.TryDispose(ref _cancel);
         }
 
-        protected void ForwardOnNext(TTarget value)
+        public void ForwardOnNext(TTarget value)
         {
             _observer.OnNext(value);
         }
 
-        protected void ForwardOnCompleted()
+        public void ForwardOnCompleted()
         {
             _observer.OnCompleted();
             Dispose();
         }
 
-        protected void ForwardOnError(Exception error)
+        public void ForwardOnError(Exception error)
         {
             _observer.OnError(error);
             Dispose();


### PR DESCRIPTION
The new HalfSerializer extensions should be used where applicable to reduce code repetition. The extensions have been changed to work on ISink instead of IObserver, a new base interface for Sinks.