### PR TITLE
4.x: Inline StableCompositeDisposable.Create into the Sinks

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Concurrency/Scheduler.Services.Emulation.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/Scheduler.Services.Emulation.cs
@@ -289,7 +289,7 @@ namespace System.Reactive.Concurrency
             }
         }
 
-        private sealed class SchedulePeriodicStopwatch<TState>
+        private sealed class SchedulePeriodicStopwatch<TState> : IDisposable
         {
             private readonly IScheduler _scheduler;
             private readonly TimeSpan _period;
@@ -341,6 +341,8 @@ namespace System.Reactive.Concurrency
             private const int SUSPENDED = 2;
             private const int DISPOSED = 3;
 
+            private IDisposable _task;
+
             public IDisposable Start()
             {
                 RegisterHostLifecycleEventHandlers();
@@ -349,11 +351,14 @@ namespace System.Reactive.Concurrency
                 _nextDue = _period;
                 _runState = RUNNING;
 
-                return StableCompositeDisposable.Create
-                (
-                    _scheduler.Schedule(_nextDue, Tick),
-                    Disposable.Create(Cancel)
-                );
+                Disposable.TrySetSingle(ref _task, _scheduler.Schedule(_nextDue, Tick));
+                return this;
+            }
+
+            void IDisposable.Dispose()
+            {
+                Disposable.TrySetSerial(ref _task, null);
+                Cancel();
             }
 
             private void Tick(Action<TimeSpan> recurse)

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/Scheduler.Services.Emulation.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/Scheduler.Services.Emulation.cs
@@ -357,7 +357,7 @@ namespace System.Reactive.Concurrency
 
             void IDisposable.Dispose()
             {
-                Disposable.TrySetSerial(ref _task, null);
+                Disposable.TryDispose(ref _task);
                 Cancel();
             }
 

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/Synchronization.ObserveOn.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/Synchronization.ObserveOn.cs
@@ -72,7 +72,7 @@ namespace System.Reactive.Concurrency
                     _context = context;
                 }
 
-                public void Run(IObservable<TSource> source)
+                public override void Run(IObservable<TSource> source)
                 {
                     //
                     // The interactions with OperationStarted/OperationCompleted below allow
@@ -83,10 +83,16 @@ namespace System.Reactive.Concurrency
                     //
                     _context.OperationStarted();
 
-                    var d = source.SubscribeSafe(this);
-                    var c = Disposable.Create(_context.OperationCompleted);
+                    SetUpstream(source.SubscribeSafe(this));
+                }
 
-                    SetUpstream(StableCompositeDisposable.Create(d, c));
+                protected override void Dispose(bool disposing)
+                {
+                    if (disposing)
+                    {
+                        _context.OperationCompleted();
+                    }
+                    base.Dispose(disposing);
                 }
 
                 public override void OnNext(TSource value)

--- a/Rx.NET/Source/src/System.Reactive/Internal/ScheduledObserver.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/ScheduledObserver.cs
@@ -363,11 +363,6 @@ namespace System.Reactive
 
         readonly ConcurrentQueue<T> queue;
 
-        /// <summary>
-        /// The disposable of the upstream source.
-        /// </summary>
-        IDisposable upstream;
-
         private IDisposable _run;
 
         /// <summary>

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Buffer.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Buffer.cs
@@ -518,7 +518,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     _buffer = new List<TSource>();
 
-                    SetUpstream(source.SubscribeSafe(this));
+                    base.Run(source);
 
                     _bufferGate.Wait(CreateBufferClose);
                 }
@@ -654,7 +654,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     _buffer = new List<TSource>();
 
-                    SetUpstream(parent._source.SubscribeSafe(this));
+                    base.Run(parent._source);
                     Disposable.SetSingle(ref _boundariesDisposable, parent._bufferBoundaries.SubscribeSafe(new BufferClosingObserver(this)));
                 }
 

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Buffer.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Buffer.cs
@@ -147,7 +147,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     CreateWindow();
                     CreateTimer();
 
-                    SetUpstream(parent._source.SubscribeSafe(this));
+                    base.Run(parent._source);
                 }
 
                 protected override void Dispose(bool disposing)

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Buffer.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Buffer.cs
@@ -297,7 +297,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     _list = new List<TSource>();
 
                     Disposable.SetSingle(ref _periodicDisposable, parent._scheduler.SchedulePeriodic(parent._timeSpan, Tick));
-                    SetUpstream(parent._source.SubscribeSafe(this));
+                    base.Run(parent._source);
                 }
 
                 protected override void Dispose(bool disposing)

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Catch.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Catch.cs
@@ -91,7 +91,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             private SerialDisposable _subscription;
 
-            public void Run(IObservable<TSource> source)
+            public override void Run(IObservable<TSource> source)
             {
                 _subscription = new SerialDisposable();
 

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Delay.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Delay.cs
@@ -642,9 +642,17 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     _atEnd = false;
 
-                    _subscription = RunCore(parent);
+                    Disposable.SetSingle(ref _subscription, RunCore(parent));
+                }
 
-                    SetUpstream(StableCompositeDisposable.Create(_subscription, _delays));
+                protected override void Dispose(bool disposing)
+                {
+                    if (disposing)
+                    {
+                        Disposable.TryDispose(ref _subscription);
+                        _delays.Dispose();
+                    }
+                    base.Dispose(disposing);
                 }
 
                 protected abstract IDisposable RunCore(TParent parent);

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/GroupBy.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/GroupBy.cs
@@ -54,7 +54,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
 
-            public void Run(IObservable<TSource> source)
+            public override void Run(IObservable<TSource> source)
             {
                 var sourceSubscription = new SingleAssignmentDisposable();
                 _refCountDisposable = new RefCountDisposable(sourceSubscription);

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/GroupByUntil.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/GroupByUntil.cs
@@ -58,7 +58,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _durationSelector = parent._durationSelector;
             }
 
-            public void Run(IObservable<TSource> source)
+            public override void Run(IObservable<TSource> source)
             {
                 _groupDisposable.Add(source.SubscribeSafe(this));
 

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Multicast.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Multicast.cs
@@ -49,7 +49,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     return;
                 }
 
-                SetUpstream(observable.SubscribeSafe(this));
+                base.Run(observable);
                 Disposable.SetSingle(ref _connection, connectable.Connect());
             }
 

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Sample.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Sample.cs
@@ -31,8 +31,8 @@ namespace System.Reactive.Linq.ObservableImpl
             {
             }
 
-            private IDisposable _sourceSubscription;
-            private IDisposable _samplerSubscription;
+            private IDisposable _sourceDisposable;
+            private IDisposable _samplerDisposable;
 
             private bool _hasValue;
             private TSource _value;
@@ -41,15 +41,19 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public void Run(Sample<TSource, TSample> parent)
             {
-                var sourceSubscription = new SingleAssignmentDisposable();
-                _sourceSubscription = sourceSubscription;
-                sourceSubscription.Disposable = parent._source.SubscribeSafe(this);
+                Disposable.SetSingle(ref _sourceDisposable, parent._source.SubscribeSafe(this));
 
-                var samplerSubscription = new SingleAssignmentDisposable();
-                _samplerSubscription = samplerSubscription;
-                samplerSubscription.Disposable = parent._sampler.SubscribeSafe(new SampleObserver(this));
+                Disposable.SetSingle(ref _samplerDisposable, parent._sampler.SubscribeSafe(new SampleObserver(this)));
+            }
 
-                SetUpstream(StableCompositeDisposable.Create(_sourceSubscription, _samplerSubscription));
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    Disposable.TryDispose(ref _sourceDisposable);
+                    Disposable.TryDispose(ref _samplerDisposable);
+                }
+                base.Dispose(disposing);
             }
 
             public override void OnNext(TSource value)
@@ -78,7 +82,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     if (_samplerAtEnd)
                         ForwardOnCompleted();
                     else
-                        _sourceSubscription.Dispose();
+                        Disposable.TryDispose(ref _sourceDisposable);
                 }
             }
 
@@ -134,7 +138,7 @@ namespace System.Reactive.Linq.ObservableImpl
                             _parent.ForwardOnCompleted();
                         }
                         else
-                            _parent._samplerSubscription.Dispose();
+                            Disposable.TryDispose(ref _parent._samplerDisposable);
                     }
                 }
             }
@@ -167,7 +171,7 @@ namespace System.Reactive.Linq.ObservableImpl
             {
             }
 
-            private IDisposable _sourceSubscription;
+            private IDisposable _sourceDisposable;
 
             private bool _hasValue;
             private TSource _value;
@@ -175,14 +179,18 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public void Run(Sample<TSource> parent)
             {
-                var sourceSubscription = new SingleAssignmentDisposable();
-                _sourceSubscription = sourceSubscription;
-                sourceSubscription.Disposable = parent._source.SubscribeSafe(this);
+                Disposable.SetSingle(ref _sourceDisposable, parent._source.SubscribeSafe(this));
 
-                SetUpstream(StableCompositeDisposable.Create(
-                    sourceSubscription,
-                    parent._scheduler.SchedulePeriodic(parent._interval, Tick)
-                ));
+                SetUpstream(parent._scheduler.SchedulePeriodic(parent._interval, Tick));
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    Disposable.TryDispose(ref _sourceDisposable);
+                }
+                base.Dispose(disposing);
             }
 
             private void Tick()
@@ -224,7 +232,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 lock (_gate)
                 {
                     _atEnd = true;
-                    _sourceSubscription.Dispose();
+                    Disposable.TryDispose(ref _sourceDisposable);
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/SelectMany.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/SelectMany.cs
@@ -558,7 +558,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     _count = 1;
 
-                    SetUpstream(source.SubscribeSafe(this));
+                    base.Run(source);
                 }
 
                 protected override void Dispose(bool disposing)
@@ -715,7 +715,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     _count = 1;
 
-                    SetUpstream(source.SubscribeSafe(this));
+                    base.Run(source);
                 }
 
                 protected override void Dispose(bool disposing)
@@ -1513,7 +1513,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     _count = 1;
 
-                    SetUpstream(source.SubscribeSafe(this));
+                    base.Run(source);
                 }
 
                 protected override void Dispose(bool disposing)
@@ -1643,7 +1643,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     _count = 1;
 
-                    SetUpstream(source.SubscribeSafe(this));
+                    base.Run(source);
                 }
 
                 protected override void Dispose(bool disposing)

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/SelectMany.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/SelectMany.cs
@@ -48,7 +48,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 private bool _isStopped;
 
-                public void Run(IObservable<TSource> source)
+                public override void Run(IObservable<TSource> source)
                 {
                     _isStopped = false;
 
@@ -212,7 +212,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 private bool _isStopped;
                 private int _index;
 
-                public void Run(IObservable<TSource> source)
+                public override void Run(IObservable<TSource> source)
                 {
                     _isStopped = false;
 
@@ -554,11 +554,20 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 private volatile int _count;
 
-                public void Run(IObservable<TSource> source)
+                public override void Run(IObservable<TSource> source)
                 {
                     _count = 1;
 
-                    SetUpstream(StableCompositeDisposable.Create(source.SubscribeSafe(this), _cancel));
+                    SetUpstream(source.SubscribeSafe(this));
+                }
+
+                protected override void Dispose(bool disposing)
+                {
+                    if (disposing)
+                    {
+                        _cancel.Dispose();
+                    }
+                    base.Dispose(disposing);
                 }
 
                 public override void OnNext(TSource value)
@@ -702,11 +711,20 @@ namespace System.Reactive.Linq.ObservableImpl
                 private volatile int _count;
                 private int _index;
 
-                public void Run(IObservable<TSource> source)
+                public override void Run(IObservable<TSource> source)
                 {
                     _count = 1;
 
-                    SetUpstream(StableCompositeDisposable.Create(source.SubscribeSafe(this), _cancel));
+                    SetUpstream(source.SubscribeSafe(this));
+                }
+
+                protected override void Dispose(bool disposing)
+                {
+                    if (disposing)
+                    {
+                        _cancel.Dispose();
+                    }
+                    base.Dispose(disposing);
                 }
 
                 public override void OnNext(TSource value)
@@ -853,7 +871,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 private bool _isStopped;
 
-                public void Run(IObservable<TSource> source)
+                public override void Run(IObservable<TSource> source)
                 {
                     _isStopped = false;
 
@@ -1088,7 +1106,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 private bool _isStopped;
                 private int _index;
 
-                public void Run(IObservable<TSource> source)
+                public override void Run(IObservable<TSource> source)
                 {
                     _isStopped = false;
 
@@ -1491,11 +1509,20 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 private volatile int _count;
 
-                public void Run(IObservable<TSource> source)
+                public override void Run(IObservable<TSource> source)
                 {
                     _count = 1;
 
-                    SetUpstream(StableCompositeDisposable.Create(source.SubscribeSafe(this), _cancel));
+                    SetUpstream(source.SubscribeSafe(this));
+                }
+
+                protected override void Dispose(bool disposing)
+                {
+                    if (disposing)
+                    {
+                        _cancel.Dispose();
+                    }
+                    base.Dispose(disposing);
                 }
 
                 public override void OnNext(TSource value)
@@ -1612,11 +1639,20 @@ namespace System.Reactive.Linq.ObservableImpl
                 private volatile int _count;
                 private int _index;
 
-                public void Run(IObservable<TSource> source)
+                public override void Run(IObservable<TSource> source)
                 {
                     _count = 1;
 
-                    SetUpstream(StableCompositeDisposable.Create(source.SubscribeSafe(this), _cancel));
+                    SetUpstream(source.SubscribeSafe(this));
+                }
+
+                protected override void Dispose(bool disposing)
+                {
+                    if (disposing)
+                    {
+                        _cancel.Dispose();
+                    }
+                    base.Dispose(disposing);
                 }
 
                 public override void OnNext(TSource value)

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Skip.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Skip.cs
@@ -99,11 +99,21 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                 }
 
+                private IDisposable _sourceDisposable;
+
                 public void Run(Time parent)
                 {
-                    var t = parent._scheduler.Schedule(this, parent._duration, (_, state) => state.Tick());
-                    var d = parent._source.SubscribeSafe(this);
-                    SetUpstream(StableCompositeDisposable.Create(t, d));
+                    SetUpstream(parent._scheduler.Schedule(this, parent._duration, (_, state) => state.Tick()));
+                    Disposable.SetSingle(ref _sourceDisposable, parent._source.SubscribeSafe(this));
+                }
+
+                protected override void Dispose(bool disposing)
+                {
+                    if (disposing)
+                    {
+                        Disposable.TryDispose(ref _sourceDisposable);
+                    }
+                    base.Dispose(disposing);
                 }
 
                 private IDisposable Tick()

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/SkipUntil.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/SkipUntil.cs
@@ -172,19 +172,19 @@ namespace System.Reactive.Linq.ObservableImpl
             {
             }
 
-            private IDisposable _sourceDisposable;
+            private IDisposable _task;
 
             public void Run(SkipUntil<TSource> parent)
             {
-                SetUpstream(parent._scheduler.Schedule(this, parent._startTime, (_, state) => state.Tick()));
-                Disposable.SetSingle(ref _sourceDisposable, parent._source.SubscribeSafe(this));
+                Disposable.SetSingle(ref _task, parent._scheduler.Schedule(this, parent._startTime, (_, state) => state.Tick()));
+                base.Run(parent._source);
             }
 
             protected override void Dispose(bool disposing)
             {
                 if (disposing)
                 {
-                    Disposable.TryDispose(ref _sourceDisposable);
+                    Disposable.TryDispose(ref _task);
                 }
                 base.Dispose(disposing);
             }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/SkipUntil.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/SkipUntil.cs
@@ -172,11 +172,21 @@ namespace System.Reactive.Linq.ObservableImpl
             {
             }
 
+            private IDisposable _sourceDisposable;
+
             public void Run(SkipUntil<TSource> parent)
             {
-                var t = parent._scheduler.Schedule(this, parent._startTime, (_, state) => state.Tick());
-                var d = parent._source.SubscribeSafe(this);
-                SetUpstream(StableCompositeDisposable.Create(t, d));
+                SetUpstream(parent._scheduler.Schedule(this, parent._startTime, (_, state) => state.Tick()));
+                Disposable.SetSingle(ref _sourceDisposable, parent._source.SubscribeSafe(this));
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    Disposable.TryDispose(ref _sourceDisposable);
+                }
+                base.Dispose(disposing);
             }
 
             private IDisposable Tick()

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Take.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Take.cs
@@ -108,21 +108,21 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 private object _gate;
 
-                private IDisposable _sourceDisposable;
+                private IDisposable _task;
 
                 public void Run(Time parent)
                 {
                     _gate = new object();
 
-                    SetUpstream(parent._scheduler.Schedule(this, parent._duration, (_, state) => state.Tick()));
-                    Disposable.SetSingle(ref _sourceDisposable, parent._source.SubscribeSafe(this));
+                    Disposable.SetSingle(ref _task, parent._scheduler.Schedule(this, parent._duration, (_, state) => state.Tick()));
+                    base.Run(parent._source);
                 }
 
                 protected override void Dispose(bool disposing)
                 {
                     if (disposing)
                     {
-                        Disposable.TryDispose(ref _sourceDisposable);
+                        Disposable.TryDispose(ref _task);
                     }
                     base.Dispose(disposing);
                 }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Throttle.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Throttle.cs
@@ -49,7 +49,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _hasValue = false;
                 _id = 0UL;
 
-                SetUpstream(source.SubscribeSafe(this));
+                base.Run(source);
             }
 
             protected override void Dispose(bool disposing)
@@ -157,7 +157,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _hasValue = false;
                 _id = 0UL;
 
-                SetUpstream(parent._source.SubscribeSafe(this));
+                base.Run(parent._source);
             }
 
             protected override void Dispose(bool disposing)

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Throttle.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Throttle.cs
@@ -39,20 +39,26 @@ namespace System.Reactive.Linq.ObservableImpl
             private object _gate;
             private TSource _value;
             private bool _hasValue;
-            private SerialDisposable _cancelable;
+            private IDisposable _serialCancelable;
             private ulong _id;
 
-            public void Run(IObservable<TSource> source)
+            public override void Run(IObservable<TSource> source)
             {
                 _gate = new object();
                 _value = default(TSource);
                 _hasValue = false;
-                _cancelable = new SerialDisposable();
                 _id = 0UL;
 
-                var subscription = source.SubscribeSafe(this);
+                SetUpstream(source.SubscribeSafe(this));
+            }
 
-                SetUpstream(StableCompositeDisposable.Create(subscription, _cancelable));
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    Disposable.TryDispose(ref _serialCancelable);
+                }
+                base.Dispose(disposing);
             }
 
             public override void OnNext(TSource value)
@@ -66,7 +72,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     currentid = _id;
                 }
                 var d = new SingleAssignmentDisposable();
-                _cancelable.Disposable = d;
+                Disposable.TrySetSerial(ref _serialCancelable, d);
                 d.Disposable = _scheduler.Schedule(currentid, _dueTime, Propagate);
             }
 
@@ -84,7 +90,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public override void OnError(Exception error)
             {
-                _cancelable.Dispose();
+                Disposable.TryDispose(ref _serialCancelable);
 
                 lock (_gate)
                 {
@@ -97,7 +103,7 @@ namespace System.Reactive.Linq.ObservableImpl
             
             public override void OnCompleted()
             {
-                _cancelable.Dispose();
+                Disposable.TryDispose(ref _serialCancelable);
 
                 lock (_gate)
                 {
@@ -141,7 +147,7 @@ namespace System.Reactive.Linq.ObservableImpl
             private object _gate;
             private TSource _value;
             private bool _hasValue;
-            private SerialDisposable _cancelable;
+            private IDisposable _serialCancelable;
             private ulong _id;
 
             public void Run(Throttle<TSource, TThrottle> parent)
@@ -149,12 +155,18 @@ namespace System.Reactive.Linq.ObservableImpl
                 _gate = new object();
                 _value = default(TSource);
                 _hasValue = false;
-                _cancelable = new SerialDisposable();
                 _id = 0UL;
 
-                var subscription = parent._source.SubscribeSafe(this);
+                SetUpstream(parent._source.SubscribeSafe(this));
+            }
 
-                SetUpstream(StableCompositeDisposable.Create(subscription, _cancelable));
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    Disposable.TryDispose(ref _serialCancelable);
+                }
+                base.Dispose(disposing);
             }
 
             public override void OnNext(TSource value)
@@ -184,13 +196,13 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
 
                 var d = new SingleAssignmentDisposable();
-                _cancelable.Disposable = d;
+                Disposable.TrySetSerial(ref _serialCancelable, d);
                 d.Disposable = throttle.SubscribeSafe(new ThrottleObserver(this, value, currentid, d));
             }
 
             public override void OnError(Exception error)
             {
-                _cancelable.Dispose();
+                Disposable.TryDispose(ref _serialCancelable);
 
                 lock (_gate)
                 {
@@ -203,7 +215,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public override void OnCompleted()
             {
-                _cancelable.Dispose();
+                Disposable.TryDispose(ref _serialCancelable);
 
                 lock (_gate)
                 {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Using.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Using.cs
@@ -48,7 +48,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     return;
                 }
 
-                SetUpstream(source.SubscribeSafe(this));
+                base.Run(source);
             }
 
             protected override void Dispose(bool disposing)

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Using.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Using.cs
@@ -29,25 +29,35 @@ namespace System.Reactive.Linq.ObservableImpl
             {
             }
 
+            private IDisposable _disposable;
+
             public void Run(Using<TSource, TResource> parent)
             {
                 var source = default(IObservable<TSource>);
-                var disposable = Disposable.Empty;
                 try
                 {
                     var resource = parent._resourceFactory();
                     if (resource != null)
-                        disposable = resource;
+                        Disposable.SetSingle(ref _disposable, resource);
                     source = parent._observableFactory(resource);
                 }
                 catch (Exception exception)
                 {
-                    SetUpstream(StableCompositeDisposable.Create(Observable.Throw<TSource>(exception).SubscribeSafe(this), disposable));
+                    SetUpstream(Observable.Throw<TSource>(exception).SubscribeSafe(this));
 
                     return;
                 }
 
-                SetUpstream(StableCompositeDisposable.Create(source.SubscribeSafe(this), disposable));
+                SetUpstream(source.SubscribeSafe(this));
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    Disposable.TryDispose(ref _disposable);
+                }
+                base.Dispose(disposing);
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Window.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Window.cs
@@ -48,7 +48,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 private int _n;
 
-                public void Run(IObservable<TSource> source)
+                public override void Run(IObservable<TSource> source)
                 {
                     _n = 0;
 
@@ -392,7 +392,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 private RefCountDisposable _refCountDisposable;
 
-                public void Run(IObservable<TSource> source)
+                public override void Run(IObservable<TSource> source)
                 {
                     _n = 0;
 
@@ -518,7 +518,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 private ISubject<TSource> _window;
                 private RefCountDisposable _refCountDisposable;
 
-                public void Run(IObservable<TSource> source)
+                public override void Run(IObservable<TSource> source)
                 {
                     _window = new Subject<TSource>();
 

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Zip.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Zip.cs
@@ -263,7 +263,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 private IEnumerator<TSecond> _rightEnumerator;
 
-                private static IEnumerator<TSecond> DisposedEnumerator = MakeDisposedEnumerator();
+                private static readonly IEnumerator<TSecond> DisposedEnumerator = MakeDisposedEnumerator();
 
                 private static IEnumerator<TSecond> MakeDisposedEnumerator()
                 {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Zip.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Zip.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Disposables;
+using System.Threading;
 
 namespace System.Reactive.Linq.ObservableImpl
 {
@@ -262,6 +263,13 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 private IEnumerator<TSecond> _rightEnumerator;
 
+                private static IEnumerator<TSecond> DisposedEnumerator = MakeDisposedEnumerator();
+
+                private static IEnumerator<TSecond> MakeDisposedEnumerator()
+                {
+                    yield break;
+                }
+
                 public void Run(IObservable<TFirst> first, IEnumerable<TSecond> second)
                 {
                     //
@@ -273,7 +281,12 @@ namespace System.Reactive.Linq.ObservableImpl
                     //
                     try
                     {
-                        _rightEnumerator = second.GetEnumerator();
+                        var enumerator = second.GetEnumerator();
+                        if (Interlocked.CompareExchange(ref _rightEnumerator, enumerator, null) != null)
+                        {
+                            enumerator.Dispose();
+                            return;
+                        }
                     }
                     catch (Exception exception)
                     {
@@ -282,9 +295,16 @@ namespace System.Reactive.Linq.ObservableImpl
                         return;
                     }
 
-                    var leftSubscription = first.SubscribeSafe(this);
+                    SetUpstream(first.SubscribeSafe(this));
+                }
 
-                    SetUpstream(StableCompositeDisposable.Create(leftSubscription, _rightEnumerator));
+                protected override void Dispose(bool disposing)
+                {
+                    if (disposing)
+                    {
+                        Interlocked.Exchange(ref _rightEnumerator, DisposedEnumerator)?.Dispose();
+                    }
+                    base.Dispose(disposing);
                 }
 
                 public override void OnNext(TFirst value)

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Zip.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Zip.cs
@@ -295,7 +295,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         return;
                     }
 
-                    SetUpstream(first.SubscribeSafe(this));
+                    base.Run(first);
                 }
 
                 protected override void Dispose(bool disposing)


### PR DESCRIPTION
This PR inlines the two argument `StableCompositeDisposable.Create()` into the various `Sink` implementation, saving on allocation and indirection.