### PR TITLE
4.x: Fix timed delay hangs with dotCover and the DefaultScheduler

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Concurrency/ConcurrencyAbstractionLayerImpl.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/ConcurrencyAbstractionLayerImpl.cs
@@ -161,16 +161,7 @@ namespace System.Reactive.Concurrency
                 _state = state;
                 _action = action;
 
-                // Don't want the spin wait in Tick to get stuck if this thread gets aborted.
-                try { }
-                finally
-                {
-                    //
-                    // Rooting of the timer happens through the Timer's state
-                    // which is the current instance and has a field to store the Timer instance.
-                    //
-                    Disposable.SetSingle(ref _timer, new System.Threading.Timer(_ => Tick(_), this, dueTime, TimeSpan.FromMilliseconds(System.Threading.Timeout.Infinite)));
-                }
+                Disposable.SetSingle(ref _timer, new System.Threading.Timer(_ => Tick(_), this, dueTime, TimeSpan.FromMilliseconds(System.Threading.Timeout.Infinite)));
             }
 
             private static void Tick(object state)

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/ConcurrencyAbstractionLayerImpl.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/ConcurrencyAbstractionLayerImpl.cs
@@ -182,6 +182,7 @@ namespace System.Reactive.Concurrency
             {
                 if (Disposable.TryDispose(ref _timer))
                 {
+                    _action = Stubs<object>.Ignore;
                     _state = null;
                 }
             }

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/DelayTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/DelayTest.cs
@@ -705,15 +705,6 @@ namespace ReactiveTests.Tests
         }
 
         [Fact]
-        public void Task_Loop()
-        {
-            for (int i = 0; i < 1000; i++)
-            {
-                Observable.Return(1).Delay(TimeSpan.FromMilliseconds(1), DefaultScheduler.Instance).Wait();
-            }
-        }
-
-        [Fact]
         public void Delay_DateTimeOffset_DefaultScheduler()
         {
             Assert.True(Observable.Return(1).Delay(DateTimeOffset.UtcNow + TimeSpan.FromMilliseconds(1)).ToEnumerable().SequenceEqual(new[] { 1 }));

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/DelayTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/DelayTest.cs
@@ -705,6 +705,15 @@ namespace ReactiveTests.Tests
         }
 
         [Fact]
+        public void Task_Loop()
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                Observable.Return(1).Delay(TimeSpan.FromMilliseconds(1), DefaultScheduler.Instance).Wait();
+            }
+        }
+
+        [Fact]
         public void Delay_DateTimeOffset_DefaultScheduler()
         {
             Assert.True(Observable.Return(1).Delay(DateTimeOffset.UtcNow + TimeSpan.FromMilliseconds(1)).ToEnumerable().SequenceEqual(new[] { 1 }));


### PR DESCRIPTION
For some reason, dotCover would hang in various timed test which use the `DefaultScheduler`. I don't know why, but removing that empty `try-catch` along with the atomic dispose management solves the issue. 

In addition, the `Virtual_ThreadSafety()` was running extremely slow in its original form (more than 5 minutes). The reduced time amount and a more close thread-synchronization should be faster now while preserving the behavior under test.