### PR TITLE
4.x: Inline Disposable.Create

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Concurrency/EventLoopScheduler.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/EventLoopScheduler.cs
@@ -170,7 +170,7 @@ namespace System.Reactive.Concurrency
                 EnsureThread();
             }
 
-            return Disposable.Create(si.Cancel);
+            return si;
         }
 
         /// <summary>

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/HistoricalScheduler.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/HistoricalScheduler.cs
@@ -148,7 +148,7 @@ namespace System.Reactive.Concurrency
             si = new ScheduledItem<DateTimeOffset, TState>(this, state, run, dueTime, Comparer);
             queue.Enqueue(si);
 
-            return Disposable.Create(si.Cancel);
+            return si;
         }
     }
 }

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/VirtualTimeScheduler.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/VirtualTimeScheduler.cs
@@ -420,7 +420,7 @@ namespace System.Reactive.Concurrency
                 queue.Enqueue(si);
             }
 
-            return Disposable.Create(si.Cancel);
+            return si;
         }
     }
 }

--- a/Rx.NET/Source/src/System.Reactive/Internal/ScheduledObserver.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/ScheduledObserver.cs
@@ -39,7 +39,22 @@ namespace System.Reactive
             if (_longRunning != null)
             {
                 _dispatcherEvent = new SemaphoreSlim(0);
-                _dispatcherEventRelease = Disposable.Create(() => _dispatcherEvent.Release());
+                _dispatcherEventRelease = new SemaphoreSlimRelease(_dispatcherEvent);
+            }
+        }
+
+        sealed class SemaphoreSlimRelease : IDisposable
+        {
+            SemaphoreSlim _dispatcherEvent;
+
+            public SemaphoreSlimRelease(SemaphoreSlim dispatcherEvent)
+            {
+                Volatile.Write(ref _dispatcherEvent, dispatcherEvent);
+            }
+
+            public void Dispose()
+            {
+                Interlocked.Exchange(ref _dispatcherEvent, null)?.Release();
             }
         }
 

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Delay.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Delay.cs
@@ -318,7 +318,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 protected void ScheduleDrain()
                 {
                     _stop = new CancellationTokenSource();
-                    Disposable.TrySetSerial(ref _cancelable, Disposable.Create(_stop.Cancel));
+                    Disposable.TrySetSerial(ref _cancelable, new CancellationDisposable(_stop));
 
                     _scheduler.AsLongRunning().ScheduleLongRunning(DrainQueue);
                 }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/RefCount.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/RefCount.cs
@@ -23,41 +23,58 @@ namespace System.Reactive.Linq.ObservableImpl
             _connectableSubscription = default(IDisposable);
         }
 
-        protected override _ CreateSink(IObserver<TSource> observer) => new _(observer);
+        protected override _ CreateSink(IObserver<TSource> observer) => new _(observer, this);
 
-        protected override void Run(_ sink) => sink.Run(this);
+        protected override void Run(_ sink) => sink.Run();
 
         internal sealed class _ : IdentitySink<TSource>
         {
-            public _(IObserver<TSource> observer)
+            readonly RefCount<TSource> _parent;
+
+            public _(IObserver<TSource> observer, RefCount<TSource> parent)
                 : base(observer)
             {
+                this._parent = parent;
             }
 
-            public void Run(RefCount<TSource> parent)
+            public void Run()
             {
-                var subscription = parent._source.SubscribeSafe(this);
+                base.Run(_parent._source);
 
-                lock (parent._gate)
+                lock (_parent._gate)
                 {
-                    if (++parent._count == 1)
+                    if (++_parent._count == 1)
                     {
-                        parent._connectableSubscription = parent._source.Connect();
+                        // We need to set _connectableSubscription to something
+                        // before Connect because if Connect terminates synchronously,
+                        // Dispose(bool) gets executed and will try to dispose
+                        // _connectableSubscription of null.
+                        // ?.Dispose() is no good because the dispose action has to be
+                        // executed anyway.
+                        // We can't inline SAD either because the IDisposable of Connect
+                        // may belong to the wrong connection.
+                        var sad = new SingleAssignmentDisposable();
+                        _parent._connectableSubscription = sad;
+
+                        sad.Disposable = _parent._source.Connect();
                     }
                 }
+            }
 
-                SetUpstream(Disposable.Create(() =>
+            protected override void Dispose(bool disposing)
+            {
+                base.Dispose(disposing);
+
+                if (disposing)
                 {
-                    subscription.Dispose();
-
-                    lock (parent._gate)
+                    lock (_parent._gate)
                     {
-                        if (--parent._count == 0)
+                        if (--_parent._count == 0)
                         {
-                            parent._connectableSubscription.Dispose();
+                            _parent._connectableSubscription.Dispose();
                         }
                     }
-                }));
+                }
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Zip.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Zip.cs
@@ -548,13 +548,15 @@ namespace System.Reactive.Linq.ObservableImpl
         {
             private readonly Zip<TSource> _parent;
 
+            private readonly object _gate;
+
             public _(Zip<TSource> parent, IObserver<IList<TSource>> observer)
                 : base(observer)
             {
+                _gate = new object();
                 _parent = parent;
             }
 
-            private object _gate;
             private Queue<TSource>[] _queues;
             private bool[] _isDone;
             private IDisposable[] _subscriptions;
@@ -577,8 +579,6 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 if (Interlocked.CompareExchange(ref _subscriptions, subscriptions, null) == null)
                 {
-                    _gate = new object();
-
                     for (int i = 0; i < N; i++)
                     {
                         var o = new SourceObserver(this, i);


### PR DESCRIPTION
This PR inlines the `Disposable.Create(Action)` invocations, saving on an allocation and some indirection.