### PR TITLE
Save more allocations of closures and enable more delegate caching.

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Concurrency/CatchScheduler.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/CatchScheduler.cs
@@ -93,6 +93,56 @@ namespace System.Reactive.Concurrency
 
         private sealed class CatchSchedulerPeriodic : ISchedulerPeriodic
         {
+            private sealed class PeriodicallyScheduledWorkItem<TState> : IDisposable
+            {
+                private IDisposable _cancel;
+                private bool _failed = false;
+
+                private readonly Func<TState, TState> _action;
+                private readonly CatchSchedulerPeriodic _catchScheduler;
+
+                public PeriodicallyScheduledWorkItem(CatchSchedulerPeriodic scheduler, TState state, TimeSpan period, Func<TState, TState> action)
+                {
+                    _catchScheduler = scheduler;
+                    _action = action;
+
+                    Disposable.SetSingle(ref _cancel, scheduler._scheduler.SchedulePeriodic((@this: this, state), period, tuple => tuple.@this?.Tick(tuple.state) ?? default));
+                }
+
+                public void Dispose()
+                {
+                    Disposable.TryDispose(ref _cancel);
+                }
+
+                private (PeriodicallyScheduledWorkItem<TState> @this, TState state) Tick(TState state)
+                {
+                    //
+                    // Cancellation may not be granted immediately; prevent from running user
+                    // code in that case. Periodic schedulers are assumed to introduce some
+                    // degree of concurrency, so we should return from the SchedulePeriodic
+                    // call eventually, allowing the d.Dispose() call in the catch block to
+                    // take effect.
+                    //
+                    if (_failed)
+                        return default;
+
+                    try
+                    {
+                        return (this, _action(state));
+                    }
+                    catch (TException exception)
+                    {
+                        _failed = true;
+
+                        if (!_catchScheduler._handler(exception))
+                            throw;
+
+                        Disposable.TryDispose(ref _cancel);
+                        return default;
+                    }
+                }
+            }
+
             private readonly ISchedulerPeriodic _scheduler;
             private readonly Func<TException, bool> _handler;
 
@@ -104,39 +154,7 @@ namespace System.Reactive.Concurrency
 
             public IDisposable SchedulePeriodic<TState>(TState state, TimeSpan period, Func<TState, TState> action)
             {
-                var failed = false;
-
-                var d = new SingleAssignmentDisposable();
-
-                d.Disposable = _scheduler.SchedulePeriodic(state, period, state_ =>
-                {
-                    //
-                    // Cancellation may not be granted immediately; prevent from running user
-                    // code in that case. Periodic schedulers are assumed to introduce some
-                    // degree of concurrency, so we should return from the SchedulePeriodic
-                    // call eventually, allowing the d.Dispose() call in the catch block to
-                    // take effect.
-                    //
-                    if (failed)
-                        return default(TState);
-
-                    try
-                    {
-                        return action(state_);
-                    }
-                    catch (TException exception)
-                    {
-                        failed = true;
-
-                        if (!_handler(exception))
-                            throw;
-
-                        d.Dispose();
-                        return default(TState);
-                    }
-                });
-
-                return d;
+                return new PeriodicallyScheduledWorkItem<TState>(this, state, period, action);
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/ImmediateScheduler.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/ImmediateScheduler.cs
@@ -82,7 +82,7 @@ namespace System.Reactive.Concurrency
                     (@this: this, m, action, state),
                     tuple =>
                     {
-                        if (!m.IsDisposed)
+                        if (!tuple.m.IsDisposed)
                         {
                             tuple.m.Disposable = tuple.action(tuple.@this, tuple.state);
                         }

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/LocalScheduler.TimerQueue.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/LocalScheduler.TimerQueue.cs
@@ -195,7 +195,7 @@ namespace System.Reactive.Concurrency
                 // (though it should).
                 //
                 var dueTime = Scheduler.Normalize(item.DueTime - item.Scheduler.Now);
-                d.Disposable = item.Scheduler.Schedule(d, dueTime, ExecuteNextShortTermWorkItem);
+                d.Disposable = item.Scheduler.Schedule((@this: this, d), dueTime, (self, tuple) => tuple.@this.ExecuteNextShortTermWorkItem(self, tuple.d));
             }
         }
 
@@ -329,7 +329,7 @@ namespace System.Reactive.Concurrency
                 var dueCapped = TimeSpan.FromTicks(Math.Min(dueEarly.Ticks, MAXSUPPORTEDTIMER.Ticks));
 
                 s_nextLongTermWorkItem = next;
-                s_nextLongTermTimer.Disposable = ConcurrencyAbstractionLayer.Current.StartTimer(EvaluateLongTermQueue, null, dueCapped);
+                s_nextLongTermTimer.Disposable = ConcurrencyAbstractionLayer.Current.StartTimer(_ => EvaluateLongTermQueue(_), null, dueCapped);
             }
         }
 

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/Scheduler.Services.Emulation.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/Scheduler.Services.Emulation.cs
@@ -351,7 +351,7 @@ namespace System.Reactive.Concurrency
                 _nextDue = _period;
                 _runState = RUNNING;
 
-                Disposable.TrySetSingle(ref _task, _scheduler.Schedule(_nextDue, Tick));
+                Disposable.TrySetSingle(ref _task, _scheduler.Schedule(this, _nextDue, (@this, a) => @this.Tick(a)));
                 return this;
             }
 
@@ -361,7 +361,7 @@ namespace System.Reactive.Concurrency
                 Cancel();
             }
 
-            private void Tick(Action<TimeSpan> recurse)
+            private void Tick(Action<SchedulePeriodicStopwatch<TState>, TimeSpan> recurse)
             {
                 _nextDue += _period;
                 _state = _action(_state);
@@ -421,7 +421,7 @@ namespace System.Reactive.Concurrency
                     }
                 }
 
-                recurse(next);
+                recurse(this, next);
             }
 
             private void Cancel()

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/SchedulerOperation.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/SchedulerOperation.cs
@@ -68,7 +68,7 @@ namespace System.Reactive.Concurrency
 
             if (cancellationToken.CanBeCanceled)
             {
-                _ctr = _cancellationToken.Register(Cancel);
+                _ctr = _cancellationToken.Register(@this => ((SchedulerOperationAwaiter)@this).Cancel(), this);
             }
         }
 

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Delay.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Delay.cs
@@ -106,7 +106,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                     if (shouldRun)
                     {
-                        Disposable.TrySetSerial(ref _cancelable, _scheduler.Schedule(_delay, DrainQueue));
+                        Disposable.TrySetSerial(ref _cancelable, _scheduler.Schedule(this, _delay, (@this, a) => @this.DrainQueue(a)));
                     }
                 }
 
@@ -151,11 +151,11 @@ namespace System.Reactive.Linq.ObservableImpl
 
                     if (shouldRun)
                     {
-                        Disposable.TrySetSerial(ref _cancelable, _scheduler.Schedule(_delay, DrainQueue));
+                        Disposable.TrySetSerial(ref _cancelable, _scheduler.Schedule(this, _delay, (@this, a) => @this.DrainQueue(a)));
                     }
                 }
 
-                protected void DrainQueue(Action<TimeSpan> recurse)
+                protected void DrainQueue(Action<S, TimeSpan> recurse)
                 {
                     lock (_gate)
                     {
@@ -253,7 +253,7 @@ namespace System.Reactive.Linq.ObservableImpl
                             }
                             else if (shouldRecurse)
                             {
-                                recurse(recurseDueTime);
+                                recurse(this, recurseDueTime);
                             }
 
                             return;
@@ -524,7 +524,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                     if (shouldRun)
                     {
-                        Disposable.TrySetSerial(ref _cancelable, _scheduler.Schedule(next, DrainQueue));
+                        Disposable.TrySetSerial(ref _cancelable, _scheduler.Schedule((Base<Absolute>.S)this, next, (@this, a) => DrainQueue(a)));
                     }
                 }
             }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Generate.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Generate.cs
@@ -53,11 +53,11 @@ namespace System.Reactive.Linq.ObservableImpl
                     var longRunning = _parent._scheduler.AsLongRunning();
                     if (longRunning != null)
                     {
-                        SetUpstream(longRunning.ScheduleLongRunning(Loop));
+                        SetUpstream(longRunning.ScheduleLongRunning(this, (@this, c) => @this.Loop(c)));
                     }
                     else
                     {
-                        SetUpstream(_parent._scheduler.Schedule(LoopRec));
+                        SetUpstream(_parent._scheduler.Schedule(this, (@this, a) => @this.LoopRec(a)));
                     }
                 }
 
@@ -107,7 +107,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                 }
 
-                private void LoopRec(Action recurse)
+                private void LoopRec(Action<_> recurse)
                 {
                     var hasResult = false;
                     var result = default(TResult);
@@ -138,7 +138,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     if (hasResult)
                     {
                         ForwardOnNext(result);
-                        recurse();
+                        recurse(this);
                     }
                     else
                     {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Repeat.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Repeat.cs
@@ -39,18 +39,18 @@ namespace System.Reactive.Linq.ObservableImpl
                     var longRunning = parent._scheduler.AsLongRunning();
                     if (longRunning != null)
                     {
-                        SetUpstream(longRunning.ScheduleLongRunning(LoopInf));
+                        SetUpstream(longRunning.ScheduleLongRunning(this, (@this, c) => @this.LoopInf(c)));
                     }
                     else
                     {
-                        SetUpstream(parent._scheduler.Schedule(LoopRecInf));
+                        SetUpstream(parent._scheduler.Schedule(this, (@this, a) => @this.LoopRecInf(a)));
                     }
                 }
 
-                private void LoopRecInf(Action recurse)
+                private void LoopRecInf(Action<_> recurse)
                 {
                     ForwardOnNext(_value);
-                    recurse();
+                    recurse(this);
                 }
 
                 private void LoopInf(ICancelable cancel)

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/TakeLast.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/TakeLast.cs
@@ -72,17 +72,17 @@ namespace System.Reactive.Linq.ObservableImpl
 
                     var longRunning = _parent._loopScheduler.AsLongRunning();
                     if (longRunning != null)
-                        Disposable.SetSingle(ref _loopDisposable, longRunning.ScheduleLongRunning(Loop));
+                        Disposable.SetSingle(ref _loopDisposable, longRunning.ScheduleLongRunning(this, (@this, c) => @this.Loop(c)));
                     else
-                        Disposable.SetSingle(ref _loopDisposable, _parent._loopScheduler.Schedule(LoopRec));
+                        Disposable.SetSingle(ref _loopDisposable, _parent._loopScheduler.Schedule(this, (@this, a) => @this.LoopRec(a)));
                 }
 
-                private void LoopRec(Action recurse)
+                private void LoopRec(Action<_> recurse)
                 {
                     if (_queue.Count > 0)
                     {
                         ForwardOnNext(_queue.Dequeue());
-                        recurse();
+                        recurse(this);
                     }
                     else
                     {
@@ -180,17 +180,17 @@ namespace System.Reactive.Linq.ObservableImpl
 
                     var longRunning = _parent._loopScheduler.AsLongRunning();
                     if (longRunning != null)
-                        Disposable.SetSingle(ref _loopDisposable, longRunning.ScheduleLongRunning(Loop));
+                        Disposable.SetSingle(ref _loopDisposable, longRunning.ScheduleLongRunning(this, (@this, c) => @this.Loop(c)));
                     else
-                        Disposable.SetSingle(ref _loopDisposable, _parent._loopScheduler.Schedule(LoopRec));
+                        Disposable.SetSingle(ref _loopDisposable, _parent._loopScheduler.Schedule(this, (@this, a) => @this.LoopRec(a)));
                 }
 
-                private void LoopRec(Action recurse)
+                private void LoopRec(Action<_> recurse)
                 {
                     if (_queue.Count > 0)
                     {
                         ForwardOnNext(_queue.Dequeue().Value);
-                        recurse();
+                        recurse(this);
                     }
                     else
                     {


### PR DESCRIPTION
Mainly in the Concurrency-namespace and across usages of schedulers.