### PR TITLE
4.x: Check for license header and add them

### DIFF
--- a/Rx.NET/Source/facades/GlobalAssemblyVersion.cs
+++ b/Rx.NET/Source/facades/GlobalAssemblyVersion.cs
@@ -1,4 +1,8 @@
-﻿
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+
 using System.Reflection;
 
 

--- a/Rx.NET/Source/facades/System.Reactive.Core/TypeForwarders.Core.cs
+++ b/Rx.NET/Source/facades/System.Reactive.Core/TypeForwarders.Core.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.ObservableExtensions))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Reactive.AnonymousObservable<>))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Reactive.AnonymousObserver<>))]

--- a/Rx.NET/Source/facades/System.Reactive.Experimental/TypeForwarders.Experimental.cs
+++ b/Rx.NET/Source/facades/System.Reactive.Experimental/TypeForwarders.Experimental.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Reactive.ExperimentalAttribute))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Reactive.ListObservable<>))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Reactive.Linq.ObservableEx))]

--- a/Rx.NET/Source/facades/System.Reactive.Interfaces/TypeForwarders.Interfaces.cs
+++ b/Rx.NET/Source/facades/System.Reactive.Interfaces/TypeForwarders.Interfaces.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Reactive.IEventPatternSource<>))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Reactive.IEventPattern<,>))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Reactive.IEventSource<>))]

--- a/Rx.NET/Source/facades/System.Reactive.Linq/TypeForwarders.Linq.cs
+++ b/Rx.NET/Source/facades/System.Reactive.Linq/TypeForwarders.Linq.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Reactive.EventPatternSourceBase<,>))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Reactive.EventPattern<>))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Reactive.EventPattern<,>))]

--- a/Rx.NET/Source/facades/System.Reactive.PlatformServices/TypeForwarders.PlatformServices.cs
+++ b/Rx.NET/Source/facades/System.Reactive.PlatformServices/TypeForwarders.PlatformServices.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Reactive.Concurrency.EventLoopScheduler))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Reactive.Concurrency.NewThreadScheduler))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Reactive.Concurrency.TaskPoolScheduler))]

--- a/Rx.NET/Source/facades/System.Reactive.Providers/TypeForwarders.Providers.cs
+++ b/Rx.NET/Source/facades/System.Reactive.Providers/TypeForwarders.Providers.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Reactive.Joins.QueryablePattern))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Reactive.Joins.QueryablePattern<,,,,,,,,,>))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Reactive.Joins.QueryablePattern<,,,,,,,,,,>))]

--- a/Rx.NET/Source/facades/System.Reactive.Runtime.Remoting/TypeForwarders.Remoting.cs
+++ b/Rx.NET/Source/facades/System.Reactive.Runtime.Remoting/TypeForwarders.Remoting.cs
@@ -1,1 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Reactive.Linq.RemotingObservable))]

--- a/Rx.NET/Source/facades/System.Reactive.Windows.Forms/TypeForwarders.Forms.cs
+++ b/Rx.NET/Source/facades/System.Reactive.Windows.Forms/TypeForwarders.Forms.cs
@@ -1,2 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Reactive.Concurrency.ControlScheduler))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Reactive.Linq.ControlObservable))]

--- a/Rx.NET/Source/facades/System.Reactive.Windows.Threading/TypeForwarders.Threading.cs
+++ b/Rx.NET/Source/facades/System.Reactive.Windows.Threading/TypeForwarders.Threading.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
 #if WINDOWS
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Reactive.Concurrency.CoreDispatcherScheduler))]
 #else

--- a/Rx.NET/Source/facades/System.Reactive.WindowsRuntime/TypeForwarders.WindowsRuntime.cs
+++ b/Rx.NET/Source/facades/System.Reactive.WindowsRuntime/TypeForwarders.WindowsRuntime.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Reactive.IEventPatternSource<,>))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Reactive.Linq.AsyncInfoObservable))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Reactive.Linq.WindowsObservable))]

--- a/Rx.NET/Source/src/System.Reactive/Linq/QueryDebugger.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/QueryDebugger.cs
@@ -1,4 +1,8 @@
-﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
 //
 // This file acts as a placeholder for future extension with a debugger service

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/ImmutableListTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/ImmutableListTest.cs
@@ -1,4 +1,8 @@
-﻿using Xunit;
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
 using System.Linq;
 using System.Reactive;
 

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Internal/PriorityQueueTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Internal/PriorityQueueTest.cs
@@ -1,4 +1,8 @@
-﻿using System.Reactive;
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System.Reactive;
 using Xunit;
 
 namespace ReactiveTests.Tests

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/LicenseHeaderTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/LicenseHeaderTest.cs
@@ -1,0 +1,98 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Tests.System.Reactive.Tests
+{
+    /// <summary>
+    /// Verify that main classes and unit tests have a license header
+    /// in the source files.
+    /// </summary>
+    public class LicenseHeaderTest
+    {
+        static readonly bool fixHeaders = true;
+
+        static readonly string[] lines = {
+            "// Licensed to the .NET Foundation under one or more agreements.",
+            "// The .NET Foundation licenses this file to you under the Apache 2.0 License.",
+            "// See the LICENSE file in the project root for more information.",
+            ""
+        };
+
+        [Fact]
+        public void ScanFiles()
+        {
+            var dir = Directory.GetCurrentDirectory();
+            var idx = dir.IndexOf("Rx.NET");
+            if (idx < 0)
+            {
+                Console.WriteLine($"Could not locate sources directory: {dir}");
+            }
+            else
+            {
+                var newDir = dir.Substring(0, idx) + "Rx.NET/Source";
+
+                var error = new StringBuilder();
+
+                var count = ScanPath(newDir, error);
+
+                if (error.Length != 0)
+                {
+
+                    Assert.False(true, $"Files with no license header: {count}\r\n{error.ToString()}");
+                }
+            }
+        }
+
+        int ScanPath(string path, StringBuilder error)
+        {
+            var count = 0;
+            foreach (var file in Directory.EnumerateFiles(path, "*.cs", SearchOption.AllDirectories))
+            {
+                // exclusions
+                if (file.Contains("obj/Debug") 
+                    || file.Contains(@"obj\Debug")
+                    || file.Contains("AssemblyInfo.cs")
+                    || file.Contains(".Designer.cs")
+                    || file.Contains(".Generated.cs")
+                    || file.Contains("Uwp.DeviceRunner")
+                )
+                {
+                    continue;
+                }
+
+                // analysis
+                string content = File.ReadAllText(file);
+
+                if (!content.StartsWith(lines[0]))
+                {
+                    count++;
+                    error.Append(file).Append("\r\n");
+
+                    if (fixHeaders)
+                    {
+                        StringBuilder newContent = new StringBuilder();
+                        string separator = content.Contains("\r\n") ? "\r\n" : "\n";
+
+                        foreach (var s in lines)
+                        {
+                            newContent.Append(s).Append(separator);
+                        }
+                        newContent.Append(content);
+
+                        File.WriteAllText(file, newContent.ToString());
+                     }
+                }
+            }
+            return count;
+        }
+    }
+}

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/LicenseHeaderTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/LicenseHeaderTest.cs
@@ -64,6 +64,8 @@ namespace Tests.System.Reactive.Tests
                     || file.Contains(".Designer.cs")
                     || file.Contains(".Generated.cs")
                     || file.Contains("Uwp.DeviceRunner")
+                    || file.Contains(@"obj\Release")
+                    || file.Contains("obj/Release")
                 )
                 {
                     continue;


### PR DESCRIPTION
This PR adds an unit test that scans most `*.cs` files in the `Rx.NET` project for the existence of a license header:

```cs
// Licensed to the .NET Foundation under one or more agreements.
// The .NET Foundation licenses this file to you under the Apache 2.0 License.
// See the LICENSE file in the project root for more information.

```

It creates a list of such files and by default, the header is added to those files. The logic excludes certain type of `cs` files such as generated ones and designer ones.

I'm not 100% certain for the file path detection part. Works for me locally, which assumes the work directory will be somewhere below `Rx.NET`.