### PR TITLE
4.x: Inline AnonymousObserver use at places

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Internal/ObserverWithToken.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/ObserverWithToken.cs
@@ -1,0 +1,63 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information. 
+
+using System;
+using System.Collections.Generic;
+using System.Reactive.Disposables;
+using System.Text;
+
+namespace System.Reactive
+{
+    /// <summary>
+    /// Wraps another IObserver, relays signals to it
+    /// and hosts an external IDisposable
+    /// to be disposed upon termination.
+    /// </summary>
+    /// <typeparam name="T">The element type of the sequence.</typeparam>
+    internal sealed class ObserverWithToken<T> : IObserver<T>
+    {
+        readonly IObserver<T> _downstream;
+
+        IDisposable _tokenDisposable;
+
+        public ObserverWithToken(IObserver<T> downstream)
+        {
+            this._downstream = downstream;
+        }
+
+        internal void SetTokenDisposable(IDisposable d)
+        {
+            Disposable.SetSingle(ref _tokenDisposable, d);
+        }
+
+        public void OnCompleted()
+        {
+            try
+            {
+                _downstream.OnCompleted();
+            }
+            finally
+            {
+                Disposable.TryDispose(ref _tokenDisposable);    
+            }
+        }
+
+        public void OnError(Exception error)
+        {
+            try
+            {
+                _downstream.OnError(error);
+            }
+            finally
+            {
+                Disposable.TryDispose(ref _tokenDisposable);
+            }
+        }
+
+        public void OnNext(T value)
+        {
+            _downstream.OnNext(value);
+        }
+    }
+}

--- a/Rx.NET/Source/src/System.Reactive/Notification.cs
+++ b/Rx.NET/Source/src/System.Reactive/Notification.cs
@@ -337,9 +337,15 @@ namespace System.Reactive
         internal sealed class OnCompletedNotification : Notification<T>
         {
             /// <summary>
+            /// Complete notifications are stateless thus only one instance
+            /// can ever exist per type <see cref="T"/>.
+            /// </summary>
+            internal static readonly Notification<T> Instance = new OnCompletedNotification();
+
+            /// <summary>
             /// Constructs a notification of the end of a sequence.
             /// </summary>
-            public OnCompletedNotification()
+            private OnCompletedNotification()
             {
             }
 
@@ -628,7 +634,7 @@ namespace System.Reactive
         /// <returns>The OnCompleted notification.</returns>
         public static Notification<T> CreateOnCompleted<T>()
         {
-            return new Notification<T>.OnCompletedNotification();
+            return Notification<T>.OnCompletedNotification.Instance;
         }
     }
 }


### PR DESCRIPTION
Inline the use of `AnonymousObserver` at various locations:

- `Subscribe` with `CancellationTokenSource`
- Remoting `Subscribe`.


Also make `Notification.OnCompletedNotification` static singleton; it is stateless so there is no reason to create an instance of it all the time.

