### PR TITLE
Use LastIndexOf instead of IndexOf in LicenseHeaderTest

### DIFF
--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/LicenseHeaderTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/LicenseHeaderTest.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
@@ -31,24 +31,19 @@ namespace Tests.System.Reactive.Tests
         public void ScanFiles()
         {
             var dir = Directory.GetCurrentDirectory();
-            var idx = dir.IndexOf("Rx.NET");
-            if (idx < 0)
+            var idx = dir.LastIndexOf("Rx.NET");
+
+            Assert.False(idx < 0, $"Could not locate sources directory: {dir}");
+
+            var newDir = dir.Substring(0, idx) + "Rx.NET/Source";
+
+            var error = new StringBuilder();
+
+            var count = ScanPath(newDir, error);
+
+            if (error.Length != 0)
             {
-                Console.WriteLine($"Could not locate sources directory: {dir}");
-            }
-            else
-            {
-                var newDir = dir.Substring(0, idx) + "Rx.NET/Source";
-
-                var error = new StringBuilder();
-
-                var count = ScanPath(newDir, error);
-
-                if (error.Length != 0)
-                {
-
-                    Assert.False(true, $"Files with no license header: {count}\r\n{error.ToString()}");
-                }
+                Assert.False(true, $"Files with no license header: {count}\r\n{error.ToString()}");
             }
         }
 


### PR DESCRIPTION
My Rx git repository happens to be in the directory `Rx.NET`. So the resulting global source path is:

`C:\Users\peter\Documents\src\Rx.NET\Rx.NET\Source`.

Unfortunately, that makes the license header test fail, because in the test, the second occurance of `Rx.NET` is searched for but the first one is found.

The PR fix this by using `LastIndexOf`, addditionally the test will now fail, if there is no occurance at all instead of silently passing.