### PR TITLE
Add new lines and space-indentation only to *.cs files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,19 +3,14 @@
 # top-most EditorConfig file
 root = true
 
-# Default settings:
-# A newline ending every file
-# Use 4 spaces as indentation
-[*]
-insert_final_newline = true
-indent_style = space
-indent_size = 4
-
 [project.json]
 indent_size = 2
 
 # C# files
 [*.cs]
+insert_final_newline = true
+indent_style = space
+indent_size = 4
 # New line preferences
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true


### PR DESCRIPTION
The previous settings forced **all** files edited by Visual Studio to receive a newline at the end, including the approval text files. This had the side effect that accessing the `approved.txt` files would add a newline to the end which then would show up as an error when the approval tests run; the generated test file has no trailing newline and it seems it can't be added without from our side.

This PR limits this feature only to `*.cs` files so accessing other files won't mess them up.