### PR TITLE
Adding ns2.0 and netcoreapp2.0 targets to Ix.NET

### DIFF
--- a/Ix.NET/Source/Directory.build.targets
+++ b/Ix.NET/Source/Directory.build.targets
@@ -11,6 +11,12 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <DefineConstants>$(DefineConstants);NO_CODE_COVERAGE_ATTRIBUTE;CRIPPLED_REFLECTION;PLIB;SIGNED</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <DefineConstants>$(DefineConstants);NO_CODE_COVERAGE_ATTRIBUTE;PLIB;SIGNED</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <DefineConstants>$(DefineConstants);BUILT_IN_QUERYABLE_METHODS;NO_CODE_COVERAGE_ATTRIBUTE;PLIB;SIGNED</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net45'">
     <DefineConstants>$(DefineConstants);HAS_APTCA;NO_ARRAY_EMPTY;DESKTOPCLR;DESKTOPCLR45;SIGNED</DefineConstants>
   </PropertyGroup>

--- a/Ix.NET/Source/System.Interactive.Async.Providers/System.Interactive.Async.Providers.csproj
+++ b/Ix.NET/Source/System.Interactive.Async.Providers/System.Interactive.Async.Providers.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Interactive Extensions Async Providers Library used to build query providers and express queries over async enumerable sequences.</Description>
     <AssemblyTitle>Interactive Extensions - Async Providers Library</AssemblyTitle>
-    <TargetFrameworks>net45;netstandard1.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.0;netstandard2.0</TargetFrameworks>
     <PackageTags>Ix;Interactive;Extensions;Enumerable;Asynchronous</PackageTags>
   </PropertyGroup>
 

--- a/Ix.NET/Source/System.Interactive.Async.Tests/System.Interactive.Async.Tests.csproj
+++ b/Ix.NET/Source/System.Interactive.Async.Tests/System.Interactive.Async.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;netcoreapp2.0;net461</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
 

--- a/Ix.NET/Source/System.Interactive.Async/System.Interactive.Async.csproj
+++ b/Ix.NET/Source/System.Interactive.Async/System.Interactive.Async.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Interactive Extensions Async Library used to express queries over asynchronous enumerable sequences.</Description>
     <AssemblyTitle>Interactive Extensions - Async Library</AssemblyTitle>
-    <TargetFrameworks>net45;net46;netstandard1.0;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net45;net46;netstandard1.0;netstandard1.3;netstandard2.0</TargetFrameworks>
     <PackageTags>Ix;Interactive;Extensions;Enumerable;Asynchronous</PackageTags>
   </PropertyGroup>
 

--- a/Ix.NET/Source/System.Interactive.Providers/QueryableEx.cs
+++ b/Ix.NET/Source/System.Interactive.Providers/QueryableEx.cs
@@ -2125,6 +2125,7 @@ namespace System.Linq
         }
 #pragma warning restore 1591
 
+#if !BUILT_IN_QUERYABLE_METHODS
         /// <summary>
         /// Returns a specified number of contiguous elements from the end of the sequence.
         /// </summary>
@@ -2193,6 +2194,7 @@ namespace System.Linq
         }
 #pragma warning restore 1591
 
+#endif
         /// <summary>
         /// Repeats and concatenates the source sequence infinitely.
         /// </summary>

--- a/Ix.NET/Source/System.Interactive.Providers/System.Interactive.Providers.csproj
+++ b/Ix.NET/Source/System.Interactive.Providers/System.Interactive.Providers.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Interactive Extensions Providers Library used to build query providers and express queries over enumerable sequences.</Description>
     <AssemblyTitle>Interactive Extensions - Providers Library</AssemblyTitle>
-    <TargetFrameworks>net45;netstandard1.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.0;netstandard2.0;netcoreapp2.0</TargetFrameworks>
     <PackageTags>Ix;Interactive;Extensions;Enumerable</PackageTags>
   </PropertyGroup>
 

--- a/Ix.NET/Source/System.Interactive.Tests/System.Interactive.Tests.csproj
+++ b/Ix.NET/Source/System.Interactive.Tests/System.Interactive.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;netcoreapp2.0;net461</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
 

--- a/Ix.NET/Source/System.Interactive.Tests/Tests.Single.cs
+++ b/Ix.NET/Source/System.Interactive.Tests/Tests.Single.cs
@@ -341,6 +341,7 @@ namespace Tests
             Assert.Equal(10, n);
         }
 
+#if !BUILT_IN_QUERYABLE_METHODS
         [Fact]
         public void TakeLast_Arguments()
         {
@@ -410,7 +411,7 @@ namespace Tests
             var r = e.SkipLast(3).ToList();
             Assert.True(Enumerable.SequenceEqual(r, e.Take(2)));
         }
-
+#endif
         [Fact]
         public void Scan_Arguments()
         {

--- a/Ix.NET/Source/System.Interactive/System.Interactive.csproj
+++ b/Ix.NET/Source/System.Interactive/System.Interactive.csproj
@@ -4,7 +4,7 @@
     <Description>Interactive Extensions Main Library used to express queries over enumerable sequences.</Description>
     <AssemblyTitle>Interactive Extensions - Main Library</AssemblyTitle>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>net45;netstandard1.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.0;netstandard2.0;netcoreapp2.0</TargetFrameworks>
     <PackageTags>Ix;Interactive;Extensions;Enumerable</PackageTags>
   </PropertyGroup>
 

--- a/Ix.NET/Source/System.Interactive/Take.cs
+++ b/Ix.NET/Source/System.Interactive/Take.cs
@@ -11,6 +11,7 @@ namespace System.Linq
 {
     public static partial class EnumerableEx
     {
+#if !BUILT_IN_QUERYABLE_METHODS
         /// <summary>
         ///     Returns a specified number of contiguous elements from the end of the sequence.
         /// </summary>
@@ -47,5 +48,6 @@ namespace System.Linq
             while (q.Count > 0)
                 yield return q.Dequeue();
         }
+#endif
     }
 }


### PR DESCRIPTION
Adding `netstandard2.0` and `netcoreapp2.0` targets to Ix.NET.

.NET Core 2.0 added [TakeLast](https://docs.microsoft.com/en-us/dotnet/api/system.linq.queryable.takelast?view=netcore-2.1) and [SkipLast](https://docs.microsoft.com/en-us/dotnet/api/system.linq.queryable.skiplast?view=netcore-2.1) methods so you need to exclude those methods against that target.