### PR TITLE
Ix: Allow Share to be disposed, Make Finally react to token cancellation

### DIFF
--- a/Ix.NET/Source/System.Interactive.Async.Tests/AsyncTests.Exceptions.cs
+++ b/Ix.NET/Source/System.Interactive.Async.Tests/AsyncTests.Exceptions.cs
@@ -393,12 +393,12 @@ namespace Tests
             Assert.True(b);
         }
 
-        //[Fact]
+        [Fact]
         public void Finally6()
         {
             var b = false;
 
-            var xs = new[] { 1, 2 }.ToAsyncEnumerable().Finally(() => { b = true; });
+            var xs = new[] { 1, 2 }.ToAsyncEnumerable().Finally(() => { Volatile.Write(ref b, true); });
 
             var e = xs.GetEnumerator();
 
@@ -408,7 +408,16 @@ namespace Tests
             cts.Cancel();
             t.Wait(WaitTimeoutMs);
 
-            Assert.True(b);
+            for (int i = 0; i < WaitTimeoutMs / 100; i++)
+            {
+                if (Volatile.Read(ref b))
+                {
+                    return;
+                }
+                Thread.Sleep(100);
+            }
+
+            Assert.True(true, "Timeout while waiting for b to become true.");
         }
 
         [Fact]

--- a/Ix.NET/Source/System.Interactive.Tests/Tests.Buffering.cs
+++ b/Ix.NET/Source/System.Interactive.Tests/Tests.Buffering.cs
@@ -65,7 +65,7 @@ namespace Tests
             NoNext(e1);
         }
 
-        //[Fact]
+        [Fact]
         public void Share4()
         {
             var rng = Enumerable.Range(0, 5).Share();


### PR DESCRIPTION
The `Share4` was disabled because disposing a yield return-based IEnumerator has no effect. The code has been turned into a manual implementation.

The `Finally6` was disabled likely because the cancellation token could not trigger the finally action in time or due to a missing token registration. The code has been extended to react to the token as well as making sure the operator remains safe with now a possible concurrent `MoveNextCore` and `Dispose`.

Fixes: #625