### PR TITLE
Improve path creation in license header test

### DIFF
--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/LicenseHeaderTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/LicenseHeaderTest.cs
@@ -35,7 +35,7 @@ namespace Tests.System.Reactive.Tests
 
             Assert.False(idx < 0, $"Could not locate sources directory: {dir}");
 
-            var newDir = dir.Substring(0, idx) + "Rx.NET/Source";
+            var newDir = Path.Combine(dir.Substring(0, idx), "Rx.NET", "Source");
 
             var error = new StringBuilder();
 


### PR DESCRIPTION
This makes the code look more portable. In reality it works on windows and since it use the unix path separator `/`, I think it already works on linux, even though I haven't test it on linux. (see #601)