### PR TITLE
4.x: Add ConcatEager & ConcatManyEager operators

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/IQueryLanguage.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/IQueryLanguage.cs
@@ -516,6 +516,8 @@ namespace System.Reactive.Linq
         IObservable<TSource> Concat<TSource>(params IObservable<TSource>[] sources);
         IObservable<TSource> Concat<TSource>(IEnumerable<IObservable<TSource>> sources);
         IObservable<TSource> Concat<TSource>(IObservable<IObservable<TSource>> sources);
+        IObservable<TSource> ConcatEager<TSource>(IObservable<IObservable<TSource>> sources, bool delayErrors, int maxConcurrency);
+        IObservable<TResult> ConcatManyEager<TSource, TResult>(IObservable<TSource> source, Func<TSource, IObservable<TResult>> mapper, bool delayErrors, int maxConcurrency);
         IObservable<TSource> Merge<TSource>(IObservable<IObservable<TSource>> sources);
         IObservable<TSource> Merge<TSource>(IObservable<IObservable<TSource>> sources, int maxConcurrent);
         IObservable<TSource> Merge<TSource>(IEnumerable<IObservable<TSource>> sources, int maxConcurrent);

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable.Multiple.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable.Multiple.cs
@@ -1115,7 +1115,7 @@ namespace System.Reactive.Linq
         /// Concatenates a sequence of observables eagerly by running some
         /// or all of them at once and emitting their items in order.
         /// </summary>
-        /// <typeparam name="T">The value type of the inner observables.</typeparam>
+        /// <typeparam name="TSource">The value type of the inner observables.</typeparam>
         /// <param name="sources">The sequence of observables to concatenate eagerly.</param>
         /// <param name="maxConcurrency">The maximum number of observables to run at a time.</param>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
@@ -1141,8 +1141,8 @@ namespace System.Reactive.Linq
         /// Maps the upstream items into observables, runs some or all of them at once, emits items from one
         /// of the observables until it completes, then switches to the next observable.
         /// </summary>
-        /// <typeparam name="T">The value type of the upstream.</typeparam>
-        /// <typeparam name="R">The output value type.</typeparam>
+        /// <typeparam name="TSource">The value type of the upstream.</typeparam>
+        /// <typeparam name="TResult">The output value type.</typeparam>
         /// <param name="source">The source observable to be mapper and concatenated eagerly.</param>
         /// <param name="mapper">The function that returns an observable for an upstream item.</param>
         /// <param name="maxConcurrency">The maximum number of observables to run at a time.</param>

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable.Multiple.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable.Multiple.cs
@@ -1118,7 +1118,8 @@ namespace System.Reactive.Linq
         /// <typeparam name="T">The value type of the inner observables.</typeparam>
         /// <param name="sources">The sequence of observables to concatenate eagerly.</param>
         /// <param name="maxConcurrency">The maximum number of observables to run at a time.</param>
-        /// <param name="capacityHint">The number of items expected from each observable.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxConcurrency"/> is non-positive.</exception>
         /// <returns>An observable sequence that eagerly runs some or all inner sources but relays
         /// their elements still in order.</returns>
         public static IObservable<TSource> ConcatEager<TSource>(this IObservable<IObservable<TSource>> sources, bool delayErrors = false, int maxConcurrency = int.MaxValue)

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable.Multiple.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable.Multiple.cs
@@ -1109,6 +1109,62 @@ namespace System.Reactive.Linq
 
         #endregion
 
+        #region + ConcatEager +
+
+        /// <summary>
+        /// Concatenates a sequence of observables eagerly by running some
+        /// or all of them at once and emitting their items in order.
+        /// </summary>
+        /// <typeparam name="T">The value type of the inner observables.</typeparam>
+        /// <param name="sources">The sequence of observables to concatenate eagerly.</param>
+        /// <param name="maxConcurrency">The maximum number of observables to run at a time.</param>
+        /// <param name="capacityHint">The number of items expected from each observable.</param>
+        /// <returns>An observable sequence that eagerly runs some or all inner sources but relays
+        /// their elements still in order.</returns>
+        public static IObservable<TSource> ConcatEager<TSource>(this IObservable<IObservable<TSource>> sources, bool delayErrors = false, int maxConcurrency = int.MaxValue)
+        {
+            if (sources == null)
+                throw new ArgumentNullException(nameof(sources));
+
+            if (maxConcurrency <= 0)
+                throw new ArgumentOutOfRangeException(nameof(maxConcurrency));
+
+            return s_impl.ConcatEager(sources, delayErrors, maxConcurrency);
+        }
+
+        #endregion
+
+        #region + ConcatManyEager +
+
+        /// <summary>
+        /// Maps the upstream items into observables, runs some or all of them at once, emits items from one
+        /// of the observables until it completes, then switches to the next observable.
+        /// </summary>
+        /// <typeparam name="T">The value type of the upstream.</typeparam>
+        /// <typeparam name="R">The output value type.</typeparam>
+        /// <param name="source">The source observable to be mapper and concatenated eagerly.</param>
+        /// <param name="mapper">The function that returns an observable for an upstream item.</param>
+        /// <param name="maxConcurrency">The maximum number of observables to run at a time.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="mapper"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxConcurrency"/> is non-positive.</exception>
+        /// <returns>An observable sequence that eagerly runs some or all mapped-in sources but relays
+        /// their elements still in order.</returns>
+        public static IObservable<TResult> ConcatManyEager<TSource, TResult>(this IObservable<TSource> source, Func<TSource, IObservable<TResult>> mapper, bool delayErrors = false, int maxConcurrency = int.MaxValue)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+
+            if (mapper == null)
+                throw new ArgumentNullException(nameof(mapper));
+
+            if (maxConcurrency <= 0)
+                throw new ArgumentOutOfRangeException(nameof(maxConcurrency));
+
+            return s_impl.ConcatManyEager(source, mapper, delayErrors, maxConcurrency);
+        }
+
+        #endregion
+
         #region + Merge +
 
         /// <summary>

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/ConcatManyEager.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/ConcatManyEager.cs
@@ -1,0 +1,623 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information. 
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+
+namespace System.Reactive.Linq.ObservableImpl
+{
+    /// <summary>
+    /// Maps the upstream items into observable sequences, 
+    /// runs some or all source observables at once but still concatenates them in order,
+    /// buffering later observable items until their turn.
+    /// </summary>
+    internal static class ConcatManyEager
+    {
+
+        /// <summary>
+        /// Run all sources at once.
+        /// </summary>
+        /// <typeparam name="TSource">The upstream element type.</typeparam>
+        /// <typeparam name="TResult">The result and inner sequence element type.</typeparam>
+        internal sealed class All<TSource, TResult> : Producer<TResult, All<TSource, TResult>.MainObserver>
+        {
+            readonly IObservable<TSource> _source;
+
+            readonly Func<TSource, IObservable<TResult>> _mapper;
+
+            readonly bool _delayErrors;
+
+            public All(IObservable<TSource> source, Func<TSource, IObservable<TResult>> mapper, bool delayErrors)
+            {
+                _source = source;
+                _mapper = mapper;
+                _delayErrors = delayErrors;
+            }
+
+            protected override MainObserver CreateSink(IObserver<TResult> observer) => new MainObserver(observer, _mapper, _delayErrors);
+
+            protected override void Run(MainObserver sink) => sink.Run(_source);
+
+            internal sealed class MainObserver : MainObserverBase<TSource, TResult>
+            {
+                internal MainObserver(IObserver<TResult> observer,
+                    Func<TSource, IObservable<TResult>> mapper, bool delayErrors) : base(observer, mapper, delayErrors)
+                {
+                }
+
+                public override void OnNext(TSource value)
+                {
+                    if (_done)
+                    {
+                        return;
+                    }
+
+                    var innerSource = default(IObservable<TResult>);
+
+                    try
+                    {
+                        innerSource = _mapper(value) ?? throw new NullReferenceException("The mapper returned a null IObservable");
+                    }
+                    catch (Exception ex)
+                    {
+                        DisposeUpstream();
+                        OnError(ex);
+                        return;
+                    }
+
+                    var innerObserver = new ConcatManyEagerInnerObserver<TResult>(this);
+                    _observers.Enqueue(innerObserver);
+
+                    innerObserver.SetResource(innerSource.SubscribeSafe(innerObserver));
+
+                    Drain();
+                }
+
+                protected override void DrainLoop()
+                {
+                    var missed = 1;
+
+                    for (; ; )
+                    {
+                        if (Volatile.Read(ref _disposed))
+                        {
+                            _current?.Dispose();
+                            _current = null;
+
+                            while (_observers.TryDequeue(out var inner))
+                            {
+                                inner.Dispose();
+                            }
+                        }
+                        else
+                        {
+                            var mainDone = Volatile.Read(ref _done);
+
+                            if (mainDone && !_delayErrors)
+                            {
+                                var ex = Volatile.Read(ref _errors);
+                                if (ex != null)
+                                {
+                                    ForwardOnError(ex);
+                                    continue;
+                                }
+                            }
+
+                            var current = _current;
+                            if (current == null)
+                            {
+                                if (_observers.TryDequeue(out current))
+                                {
+                                    _current = current;
+                                }
+                                else
+                                {
+                                    if (mainDone)
+                                    {
+                                        var ex = Volatile.Read(ref _errors);
+                                        if (ex != null)
+                                        {
+                                            ForwardOnError(ex);
+                                        }
+                                        else
+                                        {
+                                            ForwardOnCompleted();
+                                        }
+
+                                        continue;
+                                    }
+                                }
+                            }
+
+                            if (current != null)
+                            {
+                                var innerDone = current.IsDone();
+
+                                var innerQueue = current.GetQueue();
+
+                                var item = default(TResult);
+
+                                var success = innerQueue != null && innerQueue.TryDequeue(out item);
+
+                                if (innerDone && !success)
+                                {
+                                    _current = null;
+                                    continue;
+                                }
+
+                                if (success)
+                                {
+                                    ForwardOnNext(item);
+                                    continue;
+                                }
+                            }
+                        }
+
+                        missed = Interlocked.Add(ref _wip, -missed);
+                        if (missed == 0)
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Run some sources at once.
+        /// </summary>
+        /// <typeparam name="TSource">The upstream element type.</typeparam>
+        /// <typeparam name="TResult">The result and inner sequence element type.</typeparam>
+        internal sealed class Some<TSource, TResult> : Producer<TResult, Some<TSource, TResult>.MainObserver>
+        {
+            readonly IObservable<TSource> _source;
+
+            readonly Func<TSource, IObservable<TResult>> _mapper;
+
+            readonly bool _delayErrors;
+
+            readonly int _maxConcurrency;
+
+            public Some(IObservable<TSource> source, Func<TSource, IObservable<TResult>> mapper, bool delayErrors, int maxConcurrency)
+            {
+                _source = source;
+                _mapper = mapper;
+                _delayErrors = delayErrors;
+                _maxConcurrency = maxConcurrency;
+            }
+
+            protected override MainObserver CreateSink(IObserver<TResult> observer) => new MainObserver(observer, _mapper, _delayErrors, _maxConcurrency);
+
+            protected override void Run(MainObserver sink) => sink.Run(_source);
+
+            internal sealed class MainObserver : MainObserverBase<TSource, TResult>
+            {
+                /// <summary>
+                /// The maximum number of concurrent subscriptions to
+                /// inner sources.
+                /// </summary>
+                readonly int _maxConcurrency;
+
+                /// <summary>
+                /// Buffers the upstream items to be mapped into IObservables
+                /// as soon as there is a subscription "slot" available,
+                /// i.e., when _active &lt; _maxConcurrency
+                /// </summary>
+                readonly ConcurrentQueue<TSource> _sourceItems;
+
+                /// <summary>
+                /// Tracks how many inner observers have been created and
+                /// subscribed to an inner source.
+                /// </summary>
+                int _active;
+
+                /// <summary>
+                /// Indicates that no further upstream items should be mapped
+                /// to inner sources at all due to no more upstream items
+                /// or that the last mapping failed.
+                /// </summary>
+                bool _noMoreSources;
+
+                internal MainObserver(IObserver<TResult> observer,
+                    Func<TSource, IObservable<TResult>> mapper, bool delayErrors, int maxConcurrency) : base(observer, mapper, delayErrors)
+                {
+                    _maxConcurrency = maxConcurrency;
+                    _sourceItems = new ConcurrentQueue<TSource>();
+                }
+
+                public override void OnNext(TSource value)
+                {
+                    _sourceItems.Enqueue(value);
+                    Drain();
+                }
+
+                protected override void DrainLoop()
+                {
+                    var missed = 1;
+
+                    for (; ; )
+                    {
+                        if (Volatile.Read(ref _disposed))
+                        {
+                            _current?.Dispose();
+                            _current = null;
+
+                            while (_observers.TryDequeue(out var inner))
+                            {
+                                inner.Dispose();
+                            }
+
+                            while (_sourceItems.TryDequeue(out var _))
+                                ;
+                        }
+                        else
+                        {
+                            var mainDone = Volatile.Read(ref _done);
+
+                            if (mainDone && !_delayErrors)
+                            {
+                                var ex = Volatile.Read(ref _errors);
+                                if (ex != null)
+                                {
+                                    ForwardOnError(ex);
+                                    continue;
+                                }
+                            }
+
+                            if (!_noMoreSources && _active < _maxConcurrency)
+                            {
+                                if (_sourceItems.TryDequeue(out var item))
+                                {
+                                    var inner = default(IObservable<TResult>);
+                                    try
+                                    {
+                                        inner = _mapper(item) ?? throw new NullReferenceException("The mapper returned a null IObservable");
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        // If the mapping fails, we stop the upstream and
+                                        // pretend the upstream failed
+                                        // no further inner sources will be mapped or subscribed to
+                                        DisposeUpstream();
+                                        _noMoreSources = true;
+                                        if (_delayErrors)
+                                        {
+                                            ExceptionHelper.TryAddException(ref _errors, ex);
+                                        }
+                                        else
+                                        {
+                                            ExceptionHelper.TrySetException(ref _errors, ex);
+                                        }
+                                        Volatile.Write(ref _done, true);
+                                        continue;
+                                    }
+
+                                    _active++;
+                                    var innerObserver = new ConcatManyEagerInnerObserver<TResult>(this);
+                                    _observers.Enqueue(innerObserver);
+
+                                    innerObserver.SetResource(inner.SubscribeSafe(innerObserver));
+                                    continue;
+                                }
+                                else if (mainDone)
+                                {
+                                    _noMoreSources = true;
+                                }
+                            }
+
+                            var current = _current;
+                            if (current == null)
+                            {
+                                if (_observers.TryDequeue(out current))
+                                {
+                                    _current = current;
+                                }
+                                else
+                                {
+                                    if (mainDone)
+                                    {
+                                        var ex = Volatile.Read(ref _errors);
+                                        if (ex != null)
+                                        {
+                                            ForwardOnError(ex);
+                                        }
+                                        else
+                                        {
+                                            ForwardOnCompleted();
+                                        }
+
+                                        continue;
+                                    }
+                                }
+                            }
+
+                            if (current != null)
+                            {
+                                var innerDone = current.IsDone();
+
+                                var innerQueue = current.GetQueue();
+
+                                var item = default(TResult);
+
+                                var success = innerQueue != null && innerQueue.TryDequeue(out item);
+
+                                if (innerDone && !success)
+                                {
+                                    _current = null;
+                                    _active--;
+                                    continue;
+                                }
+
+                                if (success)
+                                {
+                                    ForwardOnNext(item);
+                                    continue;
+                                }
+                            }
+                        }
+
+                        missed = Interlocked.Add(ref _wip, -missed);
+                        if (missed == 0)
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Base observer for ConcatManyEager with common functionality to
+        /// both all and some concurrency modes.
+        /// </summary>
+        /// <typeparam name="TSource">The source element type.</typeparam>
+        /// <typeparam name="TResult">The result element type.</typeparam>
+        internal abstract class MainObserverBase<TSource, TResult> : Sink<TSource, TResult>, IConcatManyEagerSupport<TResult>
+        {
+            protected readonly Func<TSource, IObservable<TResult>> _mapper;
+
+            protected readonly bool _delayErrors;
+
+            /// <summary>
+            /// Holds the subscribed inner observers and gets dequeued when the current
+            /// one terminates.
+            /// </summary>
+            protected readonly ConcurrentQueue<ConcatManyEagerInnerObserver<TResult>> _observers;
+
+            /// <summary>
+            /// Holds the single or aggregate exception.
+            /// </summary>
+            protected Exception _errors;
+
+            /// <summary>
+            /// Indicates that the Drain() method should clean up the
+            /// queues and other references upon disposing the sequence.
+            /// </summary>
+            protected bool _disposed;
+
+            /// <summary>
+            /// Indicates the main source has finished signaling items.
+            /// </summary>
+            protected bool _done;
+
+            /// <summary>
+            /// Indicates the drain loop is active if non-zero.
+            /// </summary>
+            protected int _wip;
+
+            /// <summary>
+            /// The current inner observer whose elements are relayed to the downstream,
+            /// used for establishing a fast-path in InnerNext.
+            /// </summary>
+            protected ConcatManyEagerInnerObserver<TResult> _current;
+
+            internal MainObserverBase(IObserver<TResult> observer,
+                Func<TSource, IObservable<TResult>> mapper, bool delayErrors) : base(observer)
+            {
+                _mapper = mapper;
+                _delayErrors = delayErrors;
+                _observers = new ConcurrentQueue<ConcatManyEagerInnerObserver<TResult>>();
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                Volatile.Write(ref _disposed, true);
+
+                base.Dispose(disposing);
+
+                if (disposing)
+                {
+                    Drain();
+                }
+            }
+
+            public override void OnCompleted()
+            {
+                Volatile.Write(ref _done, true);
+                Drain();
+            }
+
+            public override void OnError(Exception error)
+            {
+                if (_delayErrors)
+                {
+                    ExceptionHelper.TryAddException(ref _errors, error);
+                }
+                else
+                {
+                    ExceptionHelper.TrySetException(ref _errors, error);
+                }
+                Volatile.Write(ref _done, true);
+                Drain();
+            }
+
+            public void InnerNext(ConcatManyEagerInnerObserver<TResult> sender, TResult item)
+            {
+                // fast path
+                if (Interlocked.CompareExchange(ref _wip, 1, 0) == 0)
+                {
+                    // the sender is the one allowed to emit
+                    if (_current == sender)
+                    {
+                        // if there is no items queued
+                        var q = sender.GetQueue();
+                        if (q == null || q.IsEmpty)
+                        {
+                            // emit directly
+                            ForwardOnNext(item);
+                        }
+                        else
+                        {
+                            // otherwise queue up
+                            q.Enqueue(item);
+                            // and drain all
+                            DrainLoop();
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        // the sender is not the active one
+                        // queue up items
+                        var q = sender.GetOrCreateQueue();
+                        q.Enqueue(item);
+                    }
+
+                    // quit if no further work has been signaled
+                    if (Interlocked.Decrement(ref _wip) == 0)
+                    {
+                        return;
+                    }
+                }
+                else
+                {
+                    // slow path, queue up items
+                    var q = sender.GetOrCreateQueue();
+                    q.Enqueue(item);
+
+                    // signal there is more work to be performed
+                    if (Interlocked.Increment(ref _wip) != 1)
+                    {
+                        return;
+                    }
+                }
+                // do the extra work
+                DrainLoop();
+            }
+
+            public void InnerError(ConcatManyEagerInnerObserver<TResult> sender, Exception error)
+            {
+                if (_delayErrors)
+                {
+                    ExceptionHelper.TryAddException(ref _errors, error);
+                }
+                else
+                {
+                    ExceptionHelper.TrySetException(ref _errors, error);
+                }
+                sender.SetDone();
+                Drain();
+            }
+
+            public void InnerCompleted(ConcatManyEagerInnerObserver<TResult> sender)
+            {
+                sender.SetDone();
+                Drain();
+            }
+
+            /// <summary>
+            /// Provides a serialized way for emitting items and handling
+            /// the operator's state, including termination and
+            /// possibly handling new subscriptions.
+            /// </summary>
+            protected void Drain()
+            {
+                if (Interlocked.Increment(ref _wip) == 1)
+                {
+                    DrainLoop();
+                }
+            }
+
+            protected abstract void DrainLoop();
+        }
+
+        /// <summary>
+        /// Callback support for the inner observers.
+        /// </summary>
+        /// <typeparam name="TResult">The output value type.</typeparam>
+        internal interface IConcatManyEagerSupport<TResult>
+        {
+            void InnerNext(ConcatManyEagerInnerObserver<TResult> sender, TResult item);
+
+            void InnerError(ConcatManyEagerInnerObserver<TResult> sender, Exception error);
+
+            void InnerCompleted(ConcatManyEagerInnerObserver<TResult> sender);
+        }
+
+        /// <summary>
+        /// Observer for the inner sources of the eager concatenation operator that
+        /// calls the main observer through the support interface.
+        /// </summary>
+        /// <typeparam name="TResult">The output value type.</typeparam>
+        internal sealed class ConcatManyEagerInnerObserver<TResult> : SafeObserver<TResult>
+        {
+            readonly IConcatManyEagerSupport<TResult> _parent;
+
+            bool _done;
+
+            ConcurrentQueue<TResult> _queue;
+
+            public ConcatManyEagerInnerObserver(IConcatManyEagerSupport<TResult> parent)
+            {
+                _parent = parent;
+            }
+
+            public override void OnCompleted()
+            {
+                _parent.InnerCompleted(this);
+                Dispose();
+            }
+
+            public override void OnError(Exception error)
+            {
+                _parent.InnerError(this, error);
+                Dispose();
+            }
+
+            public override void OnNext(TResult value)
+            {
+                _parent.InnerNext(this, value);
+            }
+
+            internal void SetDone()
+            {
+                Volatile.Write(ref _done, true);
+            }
+
+            internal bool IsDone()
+            {
+                return Volatile.Read(ref _done);
+            }
+
+            internal ConcurrentQueue<TResult> GetQueue()
+            {
+                return Volatile.Read(ref _queue);
+            }
+
+            internal ConcurrentQueue<TResult> GetOrCreateQueue()
+            {
+                var q = GetQueue();
+                if (q == null)
+                {
+                    q = new ConcurrentQueue<TResult>();
+                    Volatile.Write(ref _queue, q);
+                }
+                return q;
+            }
+        }
+    }
+}

--- a/Rx.NET/Source/src/System.Reactive/Linq/Qbservable.Generated.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Qbservable.Generated.cs
@@ -3089,7 +3089,8 @@ namespace System.Reactive.Linq
         /// <typeparam name="T">The value type of the inner observables.</typeparam>
         /// <param name="sources">The sequence of observables to concatenate eagerly.</param>
         /// <param name="maxConcurrency">The maximum number of observables to run at a time.</param>
-        /// <param name="capacityHint">The number of items expected from each observable.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxConcurrency"/> is non-positive.</exception>
         /// <returns>An observable sequence that eagerly runs some or all inner sources but relays
         /// their elements still in order.</returns>
         public static IQbservable<TSource> ConcatEager<TSource>(this IQbservable<IObservable<TSource>> sources, bool delayErrors = false, int maxConcurrency = int.MaxValue)

--- a/Rx.NET/Source/src/System.Reactive/Linq/Qbservable.Generated.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Qbservable.Generated.cs
@@ -3083,6 +3083,76 @@ namespace System.Reactive.Linq
         }
 
         /// <summary>
+        /// Concatenates a sequence of observables eagerly by running some
+        /// or all of them at once and emitting their items in order.
+        /// </summary>
+        /// <typeparam name="T">The value type of the inner observables.</typeparam>
+        /// <param name="sources">The sequence of observables to concatenate eagerly.</param>
+        /// <param name="maxConcurrency">The maximum number of observables to run at a time.</param>
+        /// <param name="capacityHint">The number of items expected from each observable.</param>
+        /// <returns>An observable sequence that eagerly runs some or all inner sources but relays
+        /// their elements still in order.</returns>
+        public static IQbservable<TSource> ConcatEager<TSource>(this IQbservable<IObservable<TSource>> sources, bool delayErrors = false, int maxConcurrency = int.MaxValue)
+        {
+            if (sources == null)
+                throw new ArgumentNullException(nameof(sources));
+
+            return sources.Provider.CreateQuery<TSource>(
+                Expression.Call(
+                    null,
+#if CRIPPLED_REFLECTION
+                    InfoOf(() => Qbservable.ConcatEager<TSource>(default(IQbservable<IObservable<TSource>>), default(bool), default(int))),
+#else
+                    ((MethodInfo)MethodInfo.GetCurrentMethod()).MakeGenericMethod(typeof(TSource)),
+#endif
+                    sources.Expression,
+                    Expression.Constant(delayErrors, typeof(bool)),
+                    Expression.Constant(maxConcurrency, typeof(int))
+                )
+            );
+        }
+
+        /// <summary>
+        /// Maps the upstream items into observables, runs some or all of them at once, emits items from one
+        /// of the observables until it completes, then switches to the next observable.
+        /// </summary>
+        /// <typeparam name="T">The value type of the upstream.</typeparam>
+        /// <typeparam name="R">The output value type.</typeparam>
+        /// <param name="source">The source observable to be mapper and concatenated eagerly.</param>
+        /// <param name="mapper">The function that returns an observable for an upstream item.</param>
+        /// <param name="maxConcurrency">The maximum number of observables to run at a time.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="mapper"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxConcurrency"/> is non-positive.</exception>
+        /// <returns>An observable sequence that eagerly runs some or all mapped-in sources but relays
+        /// their elements still in order.</returns>
+        public static IQbservable<TResult> ConcatManyEager<TSource, TResult>(this IQbservable<TSource> source, Expression<Func<TSource, IObservable<TResult>>> mapper, bool delayErrors = false, int maxConcurrency = int.MaxValue)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+
+            if (mapper == null)
+                throw new ArgumentNullException(nameof(mapper));
+
+            if (maxConcurrency <= 0)
+                throw new ArgumentOutOfRangeException(nameof(maxConcurrency));
+
+            return source.Provider.CreateQuery<TResult>(
+                Expression.Call(
+                    null,
+#if CRIPPLED_REFLECTION
+                    InfoOf(() => Qbservable.ConcatManyEager<TSource, TResult>(default(IQbservable<TSource>), default(Expression<Func<TSource, IObservable<TResult>>>), default(bool), default(int))),
+#else
+                    ((MethodInfo)MethodInfo.GetCurrentMethod()).MakeGenericMethod(typeof(TSource), typeof(TResult)),
+#endif
+                    source.Expression,
+                    mapper,
+                    Expression.Constant(delayErrors, typeof(bool)),
+                    Expression.Constant(maxConcurrency, typeof(int))
+                )
+            );
+        }
+
+        /// <summary>
         /// Determines whether an observable sequence contains a specified element by using the default equality comparer.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>

--- a/Rx.NET/Source/src/System.Reactive/Linq/Qbservable.Generated.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Qbservable.Generated.cs
@@ -3086,7 +3086,7 @@ namespace System.Reactive.Linq
         /// Concatenates a sequence of observables eagerly by running some
         /// or all of them at once and emitting their items in order.
         /// </summary>
-        /// <typeparam name="T">The value type of the inner observables.</typeparam>
+        /// <typeparam name="TSource">The value type of the inner observables.</typeparam>
         /// <param name="sources">The sequence of observables to concatenate eagerly.</param>
         /// <param name="maxConcurrency">The maximum number of observables to run at a time.</param>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
@@ -3117,8 +3117,8 @@ namespace System.Reactive.Linq
         /// Maps the upstream items into observables, runs some or all of them at once, emits items from one
         /// of the observables until it completes, then switches to the next observable.
         /// </summary>
-        /// <typeparam name="T">The value type of the upstream.</typeparam>
-        /// <typeparam name="R">The output value type.</typeparam>
+        /// <typeparam name="TSource">The value type of the upstream.</typeparam>
+        /// <typeparam name="TResult">The output value type.</typeparam>
         /// <param name="source">The source observable to be mapper and concatenated eagerly.</param>
         /// <param name="mapper">The function that returns an observable for an upstream item.</param>
         /// <param name="maxConcurrency">The maximum number of observables to run at a time.</param>

--- a/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Multiple.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Multiple.cs
@@ -225,6 +225,29 @@ namespace System.Reactive.Linq
 
         #endregion
 
+        #region + ConcatEager +
+
+        public IObservable<TSource> ConcatEager<TSource>(IObservable<IObservable<TSource>> sources, bool delayErrors, int maxConcurrency)
+        {
+            return ConcatManyEager(sources, v => v, delayErrors, maxConcurrency);
+        }
+
+        #endregion
+
+        #region + ConcatManyEager +
+
+        public IObservable<TResult> ConcatManyEager<TSource, TResult>(IObservable<TSource> source, Func<TSource, IObservable<TResult>> mapper, bool delayErrors, int maxConcurrency)
+        {
+            if (maxConcurrency == int.MaxValue)
+            {
+                return new ConcatManyEager.All<TSource, TResult>(source, mapper, delayErrors);
+            }
+
+            return new ConcatManyEager.Some<TSource, TResult>(source, mapper, delayErrors, maxConcurrency);
+        }
+
+        #endregion
+
         #region + Merge +
 
         public virtual IObservable<TSource> Merge<TSource>(IObservable<IObservable<TSource>> sources)

--- a/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Api/ApiApprovalTests.Core.approved.txt
+++ b/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Api/ApiApprovalTests.Core.approved.txt
@@ -947,6 +947,8 @@ namespace System.Reactive.Linq
         public static System.IObservable<TSource> Concat<TSource>(this System.Collections.Generic.IEnumerable<System.IObservable<TSource>> sources) { }
         public static System.IObservable<TSource> Concat<TSource>(this System.IObservable<System.IObservable<TSource>> sources) { }
         public static System.IObservable<TSource> Concat<TSource>(this System.IObservable<System.Threading.Tasks.Task<TSource>> sources) { }
+        public static System.IObservable<TSource> ConcatEager<TSource>(this System.IObservable<System.IObservable<TSource>> sources, bool delayErrors = False, int maxConcurrency = 2147483647) { }
+        public static System.IObservable<TResult> ConcatManyEager<TSource, TResult>(this System.IObservable<TSource> source, System.Func<TSource, System.IObservable<TResult>> mapper, bool delayErrors = False, int maxConcurrency = 2147483647) { }
         public static System.IObservable<bool> Contains<TSource>(this System.IObservable<TSource> source, TSource value) { }
         public static System.IObservable<bool> Contains<TSource>(this System.IObservable<TSource> source, TSource value, System.Collections.Generic.IEqualityComparer<TSource> comparer) { }
         public static System.IObservable<int> Count<TSource>(this System.IObservable<TSource> source) { }
@@ -1732,6 +1734,8 @@ namespace System.Reactive.Linq
         public static System.Reactive.Linq.IQbservable<TSource> Concat<TSource>(this System.Reactive.Linq.IQbservableProvider provider, System.Collections.Generic.IEnumerable<System.IObservable<TSource>> sources) { }
         public static System.Reactive.Linq.IQbservable<TSource> Concat<TSource>(this System.Reactive.Linq.IQbservable<System.IObservable<TSource>> sources) { }
         public static System.Reactive.Linq.IQbservable<TSource> Concat<TSource>(this System.Reactive.Linq.IQbservable<System.Threading.Tasks.Task<TSource>> sources) { }
+        public static System.Reactive.Linq.IQbservable<TSource> ConcatEager<TSource>(this System.Reactive.Linq.IQbservable<System.IObservable<TSource>> sources, bool delayErrors = False, int maxConcurrency = 2147483647) { }
+        public static System.Reactive.Linq.IQbservable<TResult> ConcatManyEager<TSource, TResult>(this System.Reactive.Linq.IQbservable<TSource> source, System.Linq.Expressions.Expression<System.Func<TSource, System.IObservable<TResult>>> mapper, bool delayErrors = False, int maxConcurrency = 2147483647) { }
         public static System.Reactive.Linq.IQbservable<bool> Contains<TSource>(this System.Reactive.Linq.IQbservable<TSource> source, TSource value) { }
         public static System.Reactive.Linq.IQbservable<bool> Contains<TSource>(this System.Reactive.Linq.IQbservable<TSource> source, TSource value, System.Collections.Generic.IEqualityComparer<TSource> comparer) { }
         public static System.Reactive.Linq.IQbservable<int> Count<TSource>(this System.Reactive.Linq.IQbservable<TSource> source) { }

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/ArgumentValidationTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/ArgumentValidationTest.cs
@@ -59,6 +59,7 @@ namespace ReactiveTests.Tests
             _defaultValues.Add("IObservable`1[][Int32]", new[] { Observable.Return(1) });
 
             _defaultValues.Add("IConnectableObservable`1[Int32]", Observable.Return(1).Publish());
+            _defaultValues.Add("Boolean", false);
             _defaultValues.Add("Int32", 1);
             _defaultValues.Add("Int64", 1L);
             _defaultValues.Add("IScheduler", Scheduler.Immediate);

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ConcatManyEagerTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ConcatManyEagerTest.cs
@@ -1,0 +1,1087 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Reactive.Testing;
+using Xunit;
+
+namespace ReactiveTests.Tests
+{
+    public class ConcatManyEagerTest : ReactiveTest
+    {
+        [Fact]
+        public void ConcatEager_ArgumentChecking()
+        {
+            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.ConcatEager(default(IObservable<IObservable<int>>)));
+            ReactiveAssert.Throws<ArgumentOutOfRangeException>(() => Observable.ConcatEager(Observable.Return(Observable.Return(1)), maxConcurrency: 0));
+            ReactiveAssert.Throws<ArgumentOutOfRangeException>(() => Observable.ConcatEager(Observable.Return(Observable.Return(1)), maxConcurrency: -1));
+        }
+
+        [Fact]
+        public void ConcatEager_All_Basic()
+        {
+            var scheduler = new TestScheduler();
+
+            var xs1 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 1),
+                OnNext(20, 2),
+                OnNext(30, 3),
+                OnCompleted<int>(40)
+            );
+
+            var xs2 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 4),
+                OnNext(20, 5),
+                OnCompleted<int>(30)
+            );
+
+            var xs3 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 6),
+                OnNext(20, 7),
+                OnNext(30, 8),
+                OnNext(40, 9),
+                OnCompleted<int>(50)
+            );
+
+            var res = scheduler.Start(() =>
+                Observable.ConcatEager(new[] { xs1, xs2, xs3 }.ToObservable())
+            );
+
+            res.Messages.AssertEqual(
+                OnNext(210, 1),
+                OnNext(220, 2),
+                OnNext(230, 3),
+                OnNext(240, 4),
+                OnNext(240, 5),
+                OnNext(240, 6),
+                OnNext(240, 7),
+                OnNext(240, 8),
+                OnNext(240, 9),
+                OnCompleted<int>(250)
+            );
+
+            xs1.Subscriptions.AssertEqual(
+                Subscribe(200, 240)
+            );
+
+            xs2.Subscriptions.AssertEqual(
+                Subscribe(200, 230)
+            );
+
+            xs3.Subscriptions.AssertEqual(
+                Subscribe(200, 250)
+            );
+        }
+
+        [Fact]
+        public void ConcatEager_All_Error()
+        {
+            var scheduler = new TestScheduler();
+
+            var xs1 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 1),
+                OnNext(20, 2),
+                OnNext(30, 3),
+                OnCompleted<int>(40)
+            );
+
+            var ex = new InvalidOperationException();
+
+            var xs2 = scheduler.CreateColdObservable<int>(
+                OnNext(5, 4),
+                OnError<int>(15, ex)
+            );
+
+            var res = scheduler.Start(() =>
+                Observable.ConcatEager(new[] { xs1, xs2 }.ToObservable())
+            );
+
+            res.Messages.AssertEqual(
+                OnNext(210, 1),
+                OnError<int>(215, ex)
+            );
+
+            xs1.Subscriptions.AssertEqual(
+                Subscribe(200, 215)
+            );
+
+            xs2.Subscriptions.AssertEqual(
+                Subscribe(200, 215)
+            );
+        }
+
+        [Fact]
+        public void ConcatEager_All_Delay_Error()
+        {
+            var scheduler = new TestScheduler();
+
+            var xs1 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 1),
+                OnNext(20, 2),
+                OnNext(30, 3),
+                OnCompleted<int>(40)
+            );
+
+            var ex = new InvalidOperationException();
+
+            var xs2 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 4),
+                OnError<int>(15, ex)
+            );
+
+            var res = scheduler.Start(() =>
+                Observable.ConcatEager(new[] { xs1, xs2 }.ToObservable(), delayErrors: true)
+            );
+
+            res.Messages.AssertEqual(
+                OnNext(210, 1),
+                OnNext(220, 2),
+                OnNext(230, 3),
+                OnNext(240, 4),
+                OnError<int>(240, ex)
+            );
+
+            xs1.Subscriptions.AssertEqual(
+                Subscribe(200, 240)
+            );
+
+            xs2.Subscriptions.AssertEqual(
+                Subscribe(200, 215)
+            );
+        }
+
+        [Fact]
+        public void ConcatEager_All_Delay_Error_First()
+        {
+            var scheduler = new TestScheduler();
+
+            var xs1 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 1),
+                OnNext(20, 2),
+                OnNext(30, 3),
+                OnCompleted<int>(40)
+            );
+
+            var ex = new InvalidOperationException();
+
+            var xs2 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 4),
+                OnError<int>(15, ex)
+            );
+
+            var res = scheduler.Start(() =>
+                Observable.ConcatEager(new[] { xs2, xs1 }.ToObservable(), delayErrors: true)
+            );
+
+            res.Messages.AssertEqual(
+                OnNext(210, 4),
+                OnNext(215, 1),
+                OnNext(220, 2),
+                OnNext(230, 3),
+                OnError<int>(240, ex)
+            );
+
+            xs1.Subscriptions.AssertEqual(
+                Subscribe(200, 240)
+            );
+
+            xs2.Subscriptions.AssertEqual(
+                Subscribe(200, 215)
+            );
+        }
+
+        [Fact]
+        public void ConcatEager_All_Empty()
+        {
+            var scheduler = new TestScheduler();
+
+            var xs1 = scheduler.CreateColdObservable<int>(
+                OnCompleted<int>(10)
+            );
+
+            var xs2 = scheduler.CreateColdObservable<int>(
+                OnCompleted<int>(10)
+            );
+
+            var res = scheduler.Start(() =>
+                Observable.ConcatEager(new[] { xs1, xs2 }.ToObservable())
+            );
+
+            res.Messages.AssertEqual(
+                OnCompleted<int>(210)
+            );
+
+            xs1.Subscriptions.AssertEqual(
+                Subscribe(200, 210)
+            );
+
+            xs2.Subscriptions.AssertEqual(
+                Subscribe(200, 210)
+            );
+        }
+
+        [Fact]
+        public void ConcatEager_All_Dispose()
+        {
+            var subj1 = new Subject<int>();
+            var subj2 = new Subject<int>();
+
+            using (new[] { subj1, subj2 }.ToObservable().ConcatEager().Subscribe())
+            {
+                Assert.True(subj1.HasObservers);
+                Assert.True(subj2.HasObservers);
+            }
+
+            Assert.False(subj1.HasObservers);
+            Assert.False(subj2.HasObservers);
+        }
+
+        [Fact]
+        public void ConcatEager_Some_Basic_1()
+        {
+            var scheduler = new TestScheduler();
+
+            var xs1 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 1),
+                OnNext(20, 2),
+                OnNext(30, 3),
+                OnCompleted<int>(40)
+            );
+
+            var xs2 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 4),
+                OnNext(20, 5),
+                OnCompleted<int>(30)
+            );
+
+            var xs3 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 6),
+                OnNext(20, 7),
+                OnNext(30, 8),
+                OnNext(40, 9),
+                OnCompleted<int>(50)
+            );
+
+            var res = scheduler.Start(() =>
+                Observable.ConcatEager(new[] { xs1, xs2, xs3 }.ToObservable(), maxConcurrency: 1)
+            );
+
+            res.Messages.AssertEqual(
+                OnNext(210, 1),
+                OnNext(220, 2),
+                OnNext(230, 3),
+                OnNext(250, 4),
+                OnNext(260, 5),
+                OnNext(280, 6),
+                OnNext(290, 7),
+                OnNext(300, 8),
+                OnNext(310, 9),
+                OnCompleted<int>(320)
+            );
+
+            xs1.Subscriptions.AssertEqual(
+                Subscribe(200, 240)
+            );
+
+            xs2.Subscriptions.AssertEqual(
+                Subscribe(240, 270)
+            );
+
+            xs3.Subscriptions.AssertEqual(
+                Subscribe(270, 320)
+            );
+        }
+
+        [Fact]
+        public void ConcatEager_Some_Basic_3()
+        {
+            var scheduler = new TestScheduler();
+
+            var xs1 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 1),
+                OnNext(20, 2),
+                OnNext(30, 3),
+                OnCompleted<int>(40)
+            );
+
+            var xs2 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 4),
+                OnNext(20, 5),
+                OnCompleted<int>(30)
+            );
+
+            var xs3 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 6),
+                OnNext(20, 7),
+                OnNext(30, 8),
+                OnNext(40, 9),
+                OnCompleted<int>(50)
+            );
+
+            var res = scheduler.Start(() =>
+                Observable.ConcatEager(new[] { xs1, xs2, xs3 }.ToObservable(), maxConcurrency: 3)
+            );
+
+            res.Messages.AssertEqual(
+                OnNext(210, 1),
+                OnNext(220, 2),
+                OnNext(230, 3),
+                OnNext(240, 4),
+                OnNext(240, 5),
+                OnNext(240, 6),
+                OnNext(240, 7),
+                OnNext(240, 8),
+                OnNext(240, 9),
+                OnCompleted<int>(250)
+            );
+
+            xs1.Subscriptions.AssertEqual(
+                Subscribe(200, 240)
+            );
+
+            xs2.Subscriptions.AssertEqual(
+                Subscribe(200, 230)
+            );
+
+            xs3.Subscriptions.AssertEqual(
+                Subscribe(200, 250)
+            );
+        }
+
+        [Fact]
+        public void ConcatEager_Some_Error_1()
+        {
+            var scheduler = new TestScheduler();
+
+            var xs1 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 1),
+                OnNext(20, 2),
+                OnNext(30, 3),
+                OnCompleted<int>(40)
+            );
+
+            var ex = new InvalidOperationException();
+
+            var xs2 = scheduler.CreateColdObservable<int>(
+                OnNext(5, 4),
+                OnError<int>(15, ex)
+            );
+
+            var res = scheduler.Start(() =>
+                Observable.ConcatEager(new[] { xs1, xs2 }.ToObservable(), maxConcurrency: 1)
+            );
+
+            res.Messages.AssertEqual(
+                OnNext(210, 1),
+                OnNext(220, 2),
+                OnNext(230, 3),
+                OnNext(245, 4),
+                OnError<int>(255, ex)
+            );
+
+            xs1.Subscriptions.AssertEqual(
+                Subscribe(200, 240)
+            );
+
+            xs2.Subscriptions.AssertEqual(
+                Subscribe(240, 255)
+            );
+        }
+
+        [Fact]
+        public void ConcatEager_Some_Error_2()
+        {
+            var scheduler = new TestScheduler();
+
+            var xs1 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 1),
+                OnNext(20, 2),
+                OnNext(30, 3),
+                OnCompleted<int>(40)
+            );
+
+            var ex = new InvalidOperationException();
+
+            var xs2 = scheduler.CreateColdObservable<int>(
+                OnNext(5, 4),
+                OnError<int>(15, ex)
+            );
+
+            var res = scheduler.Start(() =>
+                Observable.ConcatEager(new[] { xs1, xs2 }.ToObservable(), maxConcurrency: 2)
+            );
+
+            res.Messages.AssertEqual(
+                OnNext(210, 1),
+                OnError<int>(215, ex)
+            );
+
+            xs1.Subscriptions.AssertEqual(
+                Subscribe(200, 215)
+            );
+
+            xs2.Subscriptions.AssertEqual(
+                Subscribe(200, 215)
+            );
+        }
+
+        [Fact]
+        public void ConcatEager_Some_Delay_Error()
+        {
+            var scheduler = new TestScheduler();
+
+            var xs1 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 1),
+                OnNext(20, 2),
+                OnNext(30, 3),
+                OnCompleted<int>(40)
+            );
+
+            var ex = new InvalidOperationException();
+
+            var xs2 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 4),
+                OnError<int>(15, ex)
+            );
+
+            var res = scheduler.Start(() =>
+                Observable.ConcatEager(new[] { xs1, xs2 }.ToObservable(), delayErrors: true, maxConcurrency: 2)
+            );
+
+            res.Messages.AssertEqual(
+                OnNext(210, 1),
+                OnNext(220, 2),
+                OnNext(230, 3),
+                OnNext(240, 4),
+                OnError<int>(240, ex)
+            );
+
+            xs1.Subscriptions.AssertEqual(
+                Subscribe(200, 240)
+            );
+
+            xs2.Subscriptions.AssertEqual(
+                Subscribe(200, 215)
+            );
+        }
+
+        [Fact]
+        public void ConcatEager_Some_Delay_Error_First()
+        {
+            var scheduler = new TestScheduler();
+
+            var xs1 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 1),
+                OnNext(20, 2),
+                OnNext(30, 3),
+                OnCompleted<int>(40)
+            );
+
+            var ex = new InvalidOperationException();
+
+            var xs2 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 4),
+                OnError<int>(15, ex)
+            );
+
+            var res = scheduler.Start(() =>
+                Observable.ConcatEager(new[] { xs2, xs1 }.ToObservable(), delayErrors: true, maxConcurrency: 2)
+            );
+
+            res.Messages.AssertEqual(
+                OnNext(210, 4),
+                OnNext(215, 1),
+                OnNext(220, 2),
+                OnNext(230, 3),
+                OnError<int>(240, ex)
+            );
+
+            xs1.Subscriptions.AssertEqual(
+                Subscribe(200, 240)
+            );
+
+            xs2.Subscriptions.AssertEqual(
+                Subscribe(200, 215)
+            );
+        }
+
+        [Fact]
+        public void ConcatEager_Some_Empty_1()
+        {
+            var scheduler = new TestScheduler();
+
+            var xs1 = scheduler.CreateColdObservable<int>(
+                OnCompleted<int>(10)
+            );
+
+            var xs2 = scheduler.CreateColdObservable<int>(
+                OnCompleted<int>(10)
+            );
+
+            var res = scheduler.Start(() =>
+                Observable.ConcatEager(new[] { xs1, xs2 }.ToObservable(), maxConcurrency: 1)
+            );
+
+            res.Messages.AssertEqual(
+                OnCompleted<int>(220)
+            );
+
+            xs1.Subscriptions.AssertEqual(
+                Subscribe(200, 210)
+            );
+
+            xs2.Subscriptions.AssertEqual(
+                Subscribe(210, 220)
+            );
+        }
+
+        [Fact]
+        public void ConcatEager_Some_Empty_2()
+        {
+            var scheduler = new TestScheduler();
+
+            var xs1 = scheduler.CreateColdObservable<int>(
+                OnCompleted<int>(10)
+            );
+
+            var xs2 = scheduler.CreateColdObservable<int>(
+                OnCompleted<int>(10)
+            );
+
+            var res = scheduler.Start(() =>
+                Observable.ConcatEager(new[] { xs1, xs2 }.ToObservable(), maxConcurrency: 2)
+            );
+
+            res.Messages.AssertEqual(
+                OnCompleted<int>(210)
+            );
+
+            xs1.Subscriptions.AssertEqual(
+                Subscribe(200, 210)
+            );
+
+            xs2.Subscriptions.AssertEqual(
+                Subscribe(200, 210)
+            );
+        }
+
+        [Fact]
+        public void ConcatEager_Some_Dispose_1()
+        {
+            var subj1 = new Subject<int>();
+            var subj2 = new Subject<int>();
+
+            using (new[] { subj1, subj2 }.ToObservable().ConcatEager(maxConcurrency: 1).Subscribe())
+            {
+                Assert.True(subj1.HasObservers);
+                Assert.False(subj2.HasObservers);
+            }
+
+            Assert.False(subj1.HasObservers);
+            Assert.False(subj2.HasObservers);
+        }
+
+        [Fact]
+        public void ConcatEager_Some_Dispose_2()
+        {
+            var subj1 = new Subject<int>();
+            var subj2 = new Subject<int>();
+
+            using (new[] { subj1, subj2 }.ToObservable().ConcatEager(maxConcurrency: 2).Subscribe())
+            {
+                Assert.True(subj1.HasObservers);
+                Assert.True(subj2.HasObservers);
+            }
+
+            Assert.False(subj1.HasObservers);
+            Assert.False(subj2.HasObservers);
+        }
+
+        [Fact]
+        public void ConcatEager_Some_Switch_Over_1()
+        {
+            var subj1 = new Subject<int>();
+            var subj2 = new Subject<int>();
+
+            using (new[] { subj1, subj2 }.ToObservable().ConcatEager(maxConcurrency: 1).Subscribe())
+            {
+                Assert.True(subj1.HasObservers);
+                Assert.False(subj2.HasObservers);
+
+                subj1.OnCompleted();
+
+                Assert.True(subj2.HasObservers);
+            }
+
+            Assert.False(subj1.HasObservers);
+            Assert.False(subj2.HasObservers);
+        }
+
+        [Fact]
+        public void ConcatManyEager_ArgumentChecking()
+        {
+            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.ConcatManyEager(default(IObservable<IObservable<int>>), v => v));
+            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.ConcatManyEager<int, int>(Observable.Return(1), null));
+            ReactiveAssert.Throws<ArgumentOutOfRangeException>(() => Observable.ConcatManyEager(Observable.Return(Observable.Return(1)), v => v, maxConcurrency: 0));
+            ReactiveAssert.Throws<ArgumentOutOfRangeException>(() => Observable.ConcatManyEager(Observable.Return(Observable.Return(1)), v => v, maxConcurrency: -1));
+        }
+
+        [Fact]
+        public void ConcatManyEager_All_Basic()
+        {
+            var scheduler = new TestScheduler();
+
+            var xs1 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 1),
+                OnNext(20, 2),
+                OnNext(30, 3),
+                OnCompleted<int>(40)
+            );
+
+            var xs2 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 4),
+                OnNext(20, 5),
+                OnCompleted<int>(30)
+            );
+
+            var xs3 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 6),
+                OnNext(20, 7),
+                OnNext(30, 8),
+                OnNext(40, 9),
+                OnCompleted<int>(50)
+            );
+
+            var sources = new[] { xs1, xs2, xs3 };
+
+            var res = scheduler.Start(() =>
+                Observable.Range(0, 3).ConcatManyEager(v => sources[v])
+            );
+
+            res.Messages.AssertEqual(
+                OnNext(210, 1),
+                OnNext(220, 2),
+                OnNext(230, 3),
+                OnNext(240, 4),
+                OnNext(240, 5),
+                OnNext(240, 6),
+                OnNext(240, 7),
+                OnNext(240, 8),
+                OnNext(240, 9),
+                OnCompleted<int>(250)
+            );
+
+            xs1.Subscriptions.AssertEqual(
+                Subscribe(200, 240)
+            );
+
+            xs2.Subscriptions.AssertEqual(
+                Subscribe(200, 230)
+            );
+
+            xs3.Subscriptions.AssertEqual(
+                Subscribe(200, 250)
+            );
+        }
+
+        [Fact]
+        public void ConcatManyEager_All_Mapper_Crash()
+        {
+            var scheduler = new TestScheduler();
+
+            var xs1 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 1),
+                OnNext(20, 2),
+                OnNext(30, 3),
+                OnCompleted<int>(40)
+            );
+
+            var ex = new InvalidOperationException();
+
+            var res = scheduler.Start(() =>
+                Observable.Range(0, 3).ConcatManyEager(v => 
+                {
+                    if (v == 1)
+                    {
+                        throw ex;
+                    }
+                    return xs1;
+                })
+            );
+
+            res.Messages.AssertEqual(
+                OnError<int>(200, ex)
+            );
+
+            xs1.Subscriptions.AssertEqual(
+                Subscribe(200, 200)
+            );
+
+        }
+
+        [Fact]
+        public void ConcatManyEager_All_Mapper_Crash_DelayError()
+        {
+            var scheduler = new TestScheduler();
+
+            var xs1 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 1),
+                OnNext(20, 2),
+                OnNext(30, 3),
+                OnCompleted<int>(40)
+            );
+
+            var ex = new InvalidOperationException();
+
+            var res = scheduler.Start(() =>
+                Observable.Range(0, 3).ConcatManyEager(v => 
+                {
+                    if (v == 1)
+                    {
+                        throw ex;
+                    }
+                    return xs1;
+                }, delayErrors: true)
+            );
+
+            res.Messages.AssertEqual(
+                OnNext(210, 1),
+                OnNext(220, 2),
+                OnNext(230, 3),
+                OnError<int>(240, ex)
+            );
+
+            xs1.Subscriptions.AssertEqual(
+                Subscribe(200, 240)
+            );
+        }
+
+        [Fact]
+        public void ConcatManyEager_All_Async()
+        {
+            var list = new List<int>(20000);
+            var error = default(Exception);
+            var mre = new CountdownEvent(1);
+
+            Observable.Range(1, 100)
+                .ConcatManyEager(v => Observable.Range(1, 200).SubscribeOn(TaskPoolScheduler.Default))
+                .Subscribe(v => list.Add(v), e =>
+                {
+                    error = e;
+                    mre.Signal();
+                }, () => mre.Signal());
+
+            Assert.True(mre.Wait(5000), "Timeout!");
+
+            Assert.Equal(20000, list.Count);
+            Assert.Null(error);
+
+            var idx = 0;
+            for (var j = 1; j <= 100; j++)
+            {
+                for (var k = 1; k <= 200; k++)
+                {
+                    Assert.Equal(k, list[idx++]);
+                }
+            }
+        }
+
+        [Fact]
+        public void ConcatManyEager_Some_Basic_1()
+        {
+            var scheduler = new TestScheduler();
+
+            var xs1 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 1),
+                OnNext(20, 2),
+                OnNext(30, 3),
+                OnCompleted<int>(40)
+            );
+
+            var xs2 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 4),
+                OnNext(20, 5),
+                OnCompleted<int>(30)
+            );
+
+            var xs3 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 6),
+                OnNext(20, 7),
+                OnNext(30, 8),
+                OnNext(40, 9),
+                OnCompleted<int>(50)
+            );
+
+            var sources = new[] { xs1, xs2, xs3 };
+
+            var res = scheduler.Start(() =>
+                Observable.Range(0, 3).ConcatManyEager(v => sources[v], maxConcurrency: 1)
+            );
+
+            res.Messages.AssertEqual(
+                OnNext(210, 1),
+                OnNext(220, 2),
+                OnNext(230, 3),
+                OnNext(250, 4),
+                OnNext(260, 5),
+                OnNext(280, 6),
+                OnNext(290, 7),
+                OnNext(300, 8),
+                OnNext(310, 9),
+                OnCompleted<int>(320)
+            );
+
+            xs1.Subscriptions.AssertEqual(
+                Subscribe(200, 240)
+            );
+
+            xs2.Subscriptions.AssertEqual(
+                Subscribe(240, 270)
+            );
+
+            xs3.Subscriptions.AssertEqual(
+                Subscribe(270, 320)
+            );
+        }
+
+        [Fact]
+        public void ConcatManyEager_Some_Basic_3()
+        {
+            var scheduler = new TestScheduler();
+
+            var xs1 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 1),
+                OnNext(20, 2),
+                OnNext(30, 3),
+                OnCompleted<int>(40)
+            );
+
+            var xs2 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 4),
+                OnNext(20, 5),
+                OnCompleted<int>(30)
+            );
+
+            var xs3 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 6),
+                OnNext(20, 7),
+                OnNext(30, 8),
+                OnNext(40, 9),
+                OnCompleted<int>(50)
+            );
+
+            var sources = new[] { xs1, xs2, xs3 };
+
+            var res = scheduler.Start(() =>
+                Observable.Range(0, 3).ConcatManyEager(v => sources[v], maxConcurrency: 3)
+            );
+
+            res.Messages.AssertEqual(
+                OnNext(210, 1),
+                OnNext(220, 2),
+                OnNext(230, 3),
+                OnNext(240, 4),
+                OnNext(240, 5),
+                OnNext(240, 6),
+                OnNext(240, 7),
+                OnNext(240, 8),
+                OnNext(240, 9),
+                OnCompleted<int>(250)
+            );
+
+            xs1.Subscriptions.AssertEqual(
+                Subscribe(200, 240)
+            );
+
+            xs2.Subscriptions.AssertEqual(
+                Subscribe(200, 230)
+            );
+
+            xs3.Subscriptions.AssertEqual(
+                Subscribe(200, 250)
+            );
+        }
+
+        [Fact]
+        public void ConcatManyEager_Some_Mapper_Crash_1()
+        {
+            var scheduler = new TestScheduler();
+
+            var xs1 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 1),
+                OnNext(20, 2),
+                OnNext(30, 3),
+                OnCompleted<int>(40)
+            );
+
+            var ex = new InvalidOperationException();
+
+            var res = scheduler.Start(() =>
+                Observable.Range(0, 3).ConcatManyEager(v =>
+                {
+                    if (v == 1)
+                    {
+                        throw ex;
+                    }
+                    return xs1;
+                }, maxConcurrency: 1)
+            );
+
+            res.Messages.AssertEqual(
+                OnNext(210, 1),
+                OnNext(220, 2),
+                OnNext(230, 3),
+                OnError<int>(240, ex)
+            );
+
+            xs1.Subscriptions.AssertEqual(
+                Subscribe(200, 240)
+            );
+
+        }
+
+        [Fact]
+        public void ConcatManyEager_Some_Mapper_Crash_2()
+        {
+            var scheduler = new TestScheduler();
+
+            var xs1 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 1),
+                OnNext(20, 2),
+                OnNext(30, 3),
+                OnCompleted<int>(40)
+            );
+
+            var ex = new InvalidOperationException();
+
+            var res = scheduler.Start(() =>
+                Observable.Range(0, 3).ConcatManyEager(v =>
+                {
+                    if (v == 1)
+                    {
+                        throw ex;
+                    }
+                    return xs1;
+                }, maxConcurrency: 2)
+            );
+
+            res.Messages.AssertEqual(
+                OnError<int>(200, ex)
+            );
+
+            xs1.Subscriptions.AssertEqual(
+                Subscribe(200, 200)
+            );
+
+        }
+
+        [Fact]
+        public void ConcatManyEager_Some_Mapper_Crash_2_DelayError()
+        {
+            var scheduler = new TestScheduler();
+
+            var xs1 = scheduler.CreateColdObservable<int>(
+                OnNext(10, 1),
+                OnNext(20, 2),
+                OnNext(30, 3),
+                OnCompleted<int>(40)
+            );
+
+            var ex = new InvalidOperationException();
+
+            var res = scheduler.Start(() =>
+                Observable.Range(0, 3).ConcatManyEager(v =>
+                {
+                    if (v == 1)
+                    {
+                        throw ex;
+                    }
+                    return xs1;
+                }, delayErrors: true, maxConcurrency: 2)
+            );
+
+            res.Messages.AssertEqual(
+                OnNext(210, 1),
+                OnNext(220, 2),
+                OnNext(230, 3),
+                OnError<int>(240, ex)
+            );
+
+            xs1.Subscriptions.AssertEqual(
+                Subscribe(200, 240)
+            );
+        }
+
+        [Fact]
+        public void ConcatManyEager_All_Crash_Disposes_Main()
+        {
+            var subj1 = new Subject<int>();
+
+            subj1.ConcatManyEager<int, int>(v => throw new InvalidOperationException())
+                .Subscribe(v => { }, e => { });
+
+            Assert.True(subj1.HasObservers);
+
+            subj1.OnNext(1);
+
+            Assert.False(subj1.HasObservers);
+        }
+
+        [Fact]
+        public void ConcatManyEager_Some_Crash_Disposes_Main()
+        {
+            var subj1 = new Subject<int>();
+
+            subj1.ConcatManyEager<int, int>(v => throw new InvalidOperationException(), maxConcurrency: 1)
+                .Subscribe(v => { }, e => { });
+
+            Assert.True(subj1.HasObservers);
+
+            subj1.OnNext(1);
+
+            Assert.False(subj1.HasObservers);
+        }
+
+        [Fact]
+        public void ConcatManyEager_Some_Async()
+        {
+            for (var i = 1; i < 17; i++)
+            {
+                var list = new List<int>(20000);
+                var error = default(Exception);
+                var mre = new CountdownEvent(1);
+
+                Observable.Range(1, 100)
+                    .ConcatManyEager(v => Observable.Range(1, 200).SubscribeOn(TaskPoolScheduler.Default), maxConcurrency: i)
+                    .Subscribe(v => list.Add(v), e =>
+                    {
+                        error = e;
+                        mre.Signal();
+                    }, () => mre.Signal());
+
+                Assert.True(mre.Wait(5000), "Timeout!");
+
+                Assert.Equal(20000, list.Count);
+                Assert.Null(error);
+
+                var idx = 0;
+                for (var j = 1; j <= 100; j++)
+                {
+                    for (var k = 1; k <= 200; k++)
+                    {
+                        Assert.Equal(k, list[idx++]);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the `ConcatEager` and `ConcatManyEager` operators that allow running multiple sources concurrently but still emit items in an ordered fashion like `Concat`. It means that items from the non-active sources are buffered until their turn.

`ConcatEager` is implemented as `ConcatManyEager(sources, v => v)`.

The operator supports delaying all errors until all sources terminate and allows specifying the maximum number of inner sources to run at once. When one terminates and also has been fully consumed, the a new source will be started.

Proposed in #489.