### PR TITLE
4.x: Remove unused field in InvokeRecBaseState

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Concurrency/Scheduler.Recursive.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/Scheduler.Recursive.cs
@@ -148,8 +148,6 @@ namespace System.Reactive.Concurrency
 
             protected readonly CompositeDisposable group;
 
-            protected long index;
-
             public InvokeRecBaseState(IScheduler scheduler)
             {
                 this.scheduler = scheduler;


### PR DESCRIPTION
Remove the `index` field from the `InvokeRecBaseState` class as it is not needed and is a remnant from an earlier algorithm from #617.