### PR TITLE
4.x: Improve Buffer via dedicated exact/skip implementations

### DIFF
--- a/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/BufferCountBenchmark.cs
+++ b/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/BufferCountBenchmark.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Threading;
+using BenchmarkDotNet.Attributes;
+
+namespace Benchmarks.System.Reactive
+{
+    [MemoryDiagnoser]
+    public class BufferCountBenchmark
+    {
+        IList<int> _store;
+
+        [Benchmark]
+        public void Exact()
+        {
+            Observable.Range(1, 1000)
+                .Buffer(1)
+                .Subscribe(v => Volatile.Write(ref _store, v));
+        }
+
+        [Benchmark]
+        public void Skip()
+        {
+            Observable.Range(1, 1000)
+                .Buffer(1, 2)
+                .Subscribe(v => Volatile.Write(ref _store, v));
+        }
+
+        [Benchmark]
+        public void Overlap()
+        {
+            Observable.Range(1, 1000)
+                .Buffer(2, 1)
+                .Subscribe(v => Volatile.Write(ref _store, v));
+        }
+    }
+}

--- a/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/Program.cs
+++ b/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/Program.cs
@@ -14,7 +14,8 @@ namespace Benchmarks.System.Reactive
             var switcher = new BenchmarkSwitcher(new[] {
                 typeof(ZipBenchmark),
                 typeof(CombineLatestBenchmark),
-                typeof(SwitchBenchmark)
+                typeof(SwitchBenchmark),
+                typeof(BufferCountBenchmark)
             });
 
             switcher.Run();

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Buffer.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Buffer.cs
@@ -229,8 +229,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 public override void OnError(Exception error)
                 {
                     // just drop the ILists on the GC floor, no reason to clear them
-                    while (_queue.Count > 0)
-                        _queue.Dequeue();
+                    _queue.Clear();
 
                     ForwardOnError(error);
                 }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Buffer.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Buffer.cs
@@ -41,9 +41,8 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public override void OnNext(TSource value)
                 {
-                    var idx = _index;
                     var buffer = _buffer;
-                    if (idx == 0)
+                    if (buffer == null)
                     {
                         buffer = new List<TSource>();
                         _buffer = buffer;
@@ -51,11 +50,12 @@ namespace System.Reactive.Linq.ObservableImpl
 
                     buffer.Add(value);
 
-                    if (++idx == _count)
+                    var idx = _index + 1;
+                    if (idx == _count)
                     {
                         _buffer = null;
-                        ForwardOnNext(buffer);
                         _index = 0;
+                        ForwardOnNext(buffer);
                     }
                     else
                     {

--- a/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Single.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Single.cs
@@ -50,17 +50,21 @@ namespace System.Reactive.Linq
 
         public virtual IObservable<IList<TSource>> Buffer<TSource>(IObservable<TSource> source, int count)
         {
-            return Buffer_<TSource>(source, count, count);
+            return new Buffer<TSource>.CountExact(source, count);
         }
 
         public virtual IObservable<IList<TSource>> Buffer<TSource>(IObservable<TSource> source, int count, int skip)
         {
-            return Buffer_<TSource>(source, count, skip);
-        }
-
-        private static IObservable<IList<TSource>> Buffer_<TSource>(IObservable<TSource> source, int count, int skip)
-        {
-            return new Buffer<TSource>.Count(source, count, skip);
+            if (count > skip)
+            {
+                return new Buffer<TSource>.CountOverlap(source, count, skip);
+            }
+            else if (count < skip)
+            {
+                return new Buffer<TSource>.CountSkip(source, count, skip);
+            }
+            // count == skip
+            return new Buffer<TSource>.CountExact(source, count);
         }
 
         #endregion


### PR DESCRIPTION
This PR improves the counted `Buffer` operator by having dedicated exact (count == skip) and gapped (count < skip) implementations because these cases require only one buffer to be handled instead of the overhead of a queue holding at most one buffer.

The PR also adds a benchmark to verify the gains:
```
 // * Summary *

BenchmarkDotNet=v0.10.14, OS=Windows 7 SP1 (6.1.7601.0)
Intel Core i7-4770K CPU 3.50GHz (Haswell), 1 CPU, 8 logical and 4 physical cores

Frequency=3418007 Hz, Resolution=292.5682 ns, Timer=TSC
  [Host]     : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.255 8.0
  DefaultJob : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.255 8.0

// Before
  Method |     Mean |    Error |   StdDev |   Gen 0 | Allocated |
-------- |---------:|---------:|---------:|--------:|----------:|
   Exact | 451.4 us | 2.592 us | 2.425 us | 49.8047 | 205.57 KB |
    Skip | 426.2 us | 4.431 us | 4.145 us | 40.5273 | 166.51 KB |
 Overlap | 459.6 us | 3.067 us | 2.869 us | 49.8047 | 205.57 KB |


// After
  Method |     Mean |    Error |   StdDev |   Gen 0 | Allocated |
-------- |---------:|---------:|---------:|--------:|----------:|
   Exact | 410.2 us | 1.822 us | 1.615 us | 49.8047 | 205.43 KB |
    Skip | 400.0 us | 2.446 us | 2.168 us | 40.5273 | 166.37 KB |
 Overlap | 458.8 us | 2.248 us | 2.102 us | 49.8047 | 205.57 KB |
```

Improvement of **Exact**: 9.1%
Improvement of **Skip**: 6.1%

The **Overlap** (aka original algorithm) is practically the same within the noise range.

I've tried with a non-modulo algorithm for Overlap but it consistently produced 10 us slower results. I'm not sure why; I assume the special small numbers in the benchmark (1, 2) were JIT'd into binary-and and thus was much faster than an increment-test-store approach like the other two.