### PR TITLE
4.x: Count() don't init to default zero

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Count.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Count.cs
@@ -26,7 +26,6 @@ namespace System.Reactive.Linq.ObservableImpl
                 public _(IObserver<int> observer)
                     : base(observer)
                 {
-                    _count = 0;
                 }
 
                 public override void OnNext(TSource value)
@@ -76,7 +75,6 @@ namespace System.Reactive.Linq.ObservableImpl
                     : base(observer)
                 {
                     _predicate = predicate;
-                    _count = 0;
                 }
 
                 public override void OnNext(TSource value)


### PR DESCRIPTION
No need to initialize the `_count` field to its default value.