### PR TITLE
4.x: DistinctUntilChanged() don't init to default values

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/DistinctUntilChanged.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/DistinctUntilChanged.cs
@@ -36,9 +36,6 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 _keySelector = parent._keySelector;
                 _comparer = parent._comparer;
-
-                _currentKey = default(TKey);
-                _hasCurrentKey = false;
             }
 
             public override void OnNext(TSource value)


### PR DESCRIPTION
There is no need to initialize fields to their default values.