### PR TITLE
4.x: ElementAt don't create exception after finding the item

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/ElementAt.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/ElementAt.cs
@@ -42,7 +42,10 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public override void OnCompleted()
             {
-                ForwardOnError(new ArgumentOutOfRangeException("index"));
+                if (_i >= 0)
+                {
+                    ForwardOnError(new ArgumentOutOfRangeException("index"));
+                }
             }
         }
     }


### PR DESCRIPTION
When `ElementAt` finds an item, it disposes the upstream, however, the upstream may still emit an `OnCompleted` if it is unable to detect this dispose call (or ignores it). In this case, the `ElementAt`'s `OnCompleted` gets invoked which creates an exception that gets thrown away as the base observer is already the no-op observer, wasting resources creating the stacktrace in the process.

I don't know how to verify this via unit test, but this extra call can be seen when placing a breakpoint in `ElementAt`'s `OnCompleted` method and running this flow:

```cs
Observable.Return(1).ElementAt(0).Subscribe();
```