### PR TITLE
4.x: FirstAsync don't create exception after finding the item

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/FirstAsync.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/FirstAsync.cs
@@ -21,6 +21,8 @@ namespace System.Reactive.Linq.ObservableImpl
 
             internal sealed class _ : IdentitySink<TSource>
             {
+                bool _found;
+
                 public _(IObserver<TSource> observer)
                     : base(observer)
                 {
@@ -28,13 +30,15 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public override void OnNext(TSource value)
                 {
+                    _found = true;
                     ForwardOnNext(value);
                     ForwardOnCompleted();
                 }
 
                 public override void OnCompleted()
                 {
-                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    if (!_found)
+                        ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
                 }
             }
         }
@@ -58,6 +62,8 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 private readonly Func<TSource, bool> _predicate;
 
+                bool _found;
+
                 public _(Func<TSource, bool> predicate, IObserver<TSource> observer)
                     : base(observer)
                 {
@@ -80,6 +86,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                     if (b)
                     {
+                        _found = true;
                         ForwardOnNext(value);
                         ForwardOnCompleted();
                     }
@@ -87,7 +94,8 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public override void OnCompleted()
                 {
-                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_MATCHING_ELEMENTS));
+                    if (!_found)
+                        ForwardOnError(new InvalidOperationException(Strings_Linq.NO_MATCHING_ELEMENTS));
                 }
             }
         }


### PR DESCRIPTION
When `FirstAsync` finds an item, it disposes the upstream, however, the upstream may still emit an `OnCompleted` if it is unable to detect this dispose call (or ignores it). In this case, the `FirstAsync`'s `OnCompleted` gets invoked which creates an exception that gets thrown away as the base observer is already the no-op observer, wasting resources creating the stacktrace in the process. Both plain and predicated versions are affected.

I don't know how to verify this via unit test, but this extra call can be seen when placing a breakpoint in `FirstAsync`'s `OnCompleted` method and running this flow:

```cs
Observable.Return(1).FirstAsync().Subscribe();
```