### PR TITLE
4x: ForEach() don't init to default values

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/ForEach.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/ForEach.cs
@@ -20,8 +20,6 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 _onNext = onNext;
                 _done = done;
-
-                _stopped = 0;
             }
 
             public Exception Error => _exception;
@@ -72,9 +70,6 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 _onNext = onNext;
                 _done = done;
-
-                _index = 0;
-                _stopped = 0;
             }
 
             public Exception Error => _exception;


### PR DESCRIPTION
There is no need to initialize fields to their default values.