### PR TITLE
4.x: Remove an indirection observer from If()

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/If.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/If.cs
@@ -36,7 +36,6 @@ namespace System.Reactive.Linq.ObservableImpl
             }
 
             return result.SubscribeSafe(observer);
-
         }
     }
 }


### PR DESCRIPTION
This PR changes `If` so that it directly uses the downstream's `IObserver` without wrapping it into a layer of `IdentitySink`. I think this avoids an allocation if I understood the recent internal changes to sinks and producers.
