### PR TITLE
4.x: Improve PushPullAdapter+Sink dispose management

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Collect.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Collect.cs
@@ -84,6 +84,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     if (error != null)
                     {
                         current = default;
+                        _collector = default;
                         error.Throw();
                     }
                     else
@@ -93,6 +94,7 @@ namespace System.Reactive.Linq.ObservableImpl
                             if (_done)
                             {
                                 current = default;
+                                _collector = default;
                                 return false;
                             }
 

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Collect.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Collect.cs
@@ -18,37 +18,26 @@ namespace System.Reactive.Linq.ObservableImpl
             _getNewCollector = getNewCollector;
         }
 
-        protected override PushToPullSink<TSource, TResult> Run(IDisposable subscription)
-        {
-            var sink = new _(this, subscription);
-            sink.Initialize();
-            return sink;
-        }
+        protected override PushToPullSink<TSource, TResult> Run() => new _(_merge, _getNewCollector, _getInitialCollector());
 
         private sealed class _ : PushToPullSink<TSource, TResult>
         {
-            // CONSIDER: This sink has a parent reference that can be considered for removal.
+            readonly object _gate;
+            readonly Func<TResult, TSource, TResult> _merge;
+            readonly Func<TResult, TResult> _getNewCollector;
 
-            private readonly Collect<TSource, TResult> _parent;
-
-            public _(Collect<TSource, TResult> parent, IDisposable subscription)
-                : base(subscription)
+            public _(Func<TResult, TSource, TResult> merge, Func<TResult, TResult> getNewCollector, TResult collector)
             {
-                _parent = parent;
+                _gate = new object();
+                _merge = merge;
+                _getNewCollector = getNewCollector;
+                _collector = collector;
             }
 
-            private object _gate;
             private TResult _collector;
-            private bool _hasFailed;
             private Exception _error;
             private bool _hasCompleted;
             private bool _done;
-
-            public void Initialize()
-            {
-                _gate = new object();
-                _collector = _parent._getInitialCollector();
-            }
 
             public override void OnNext(TSource value)
             {
@@ -56,12 +45,11 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     try
                     {
-                        _collector = _parent._merge(_collector, value);
+                        _collector = _merge(_collector, value);
                     }
                     catch (Exception ex)
                     {
                         _error = ex;
-                        _hasFailed = true;
 
                         Dispose();
                     }
@@ -75,7 +63,6 @@ namespace System.Reactive.Linq.ObservableImpl
                 lock (_gate)
                 {
                     _error = error;
-                    _hasFailed = true;
                 }
             }
 
@@ -93,10 +80,11 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 lock (_gate)
                 {
-                    if (_hasFailed)
+                    var error = _error;
+                    if (error != null)
                     {
-                        current = default(TResult);
-                        _error.Throw();
+                        current = default;
+                        error.Throw();
                     }
                     else
                     {
@@ -104,7 +92,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         {
                             if (_done)
                             {
-                                current = default(TResult);
+                                current = default;
                                 return false;
                             }
 
@@ -117,7 +105,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                             try
                             {
-                                _collector = _parent._getNewCollector(current);
+                                _collector = _getNewCollector(current);
                             }
                             catch
                             {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Latest.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Latest.cs
@@ -13,9 +13,9 @@ namespace System.Reactive.Linq.ObservableImpl
         {
         }
 
-        protected override PushToPullSink<TSource, TSource> Run(IDisposable subscription)
+        protected override PushToPullSink<TSource, TSource> Run()
         {
-            return new _(subscription);
+            return new _();
         }
 
         private sealed class _ : PushToPullSink<TSource, TSource>
@@ -23,8 +23,7 @@ namespace System.Reactive.Linq.ObservableImpl
             private readonly object _gate;
             private readonly SemaphoreSlim _semaphore;
 
-            public _(IDisposable subscription)
-                : base(subscription)
+            public _()
             {
                 _gate = new object();
                 _semaphore = new SemaphoreSlim(0, 1);

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/MostRecent.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/MostRecent.cs
@@ -14,15 +14,14 @@ namespace System.Reactive.Linq.ObservableImpl
             _initialValue = initialValue;
         }
 
-        protected override PushToPullSink<TSource, TSource> Run(IDisposable subscription)
+        protected override PushToPullSink<TSource, TSource> Run()
         {
-            return new _(_initialValue, subscription);
+            return new _(_initialValue);
         }
 
         private sealed class _ : PushToPullSink<TSource, TSource>
         {
-            public _(TSource initialValue, IDisposable subscription)
-                : base(subscription)
+            public _(TSource initialValue)
             {
                 _kind = NotificationKind.OnNext;
                 _value = initialValue;

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Next.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Next.cs
@@ -13,9 +13,9 @@ namespace System.Reactive.Linq.ObservableImpl
         {
         }
 
-        protected override PushToPullSink<TSource, TSource> Run(IDisposable subscription)
+        protected override PushToPullSink<TSource, TSource> Run()
         {
-            return new _(subscription);
+            return new _();
         }
 
         private sealed class _ : PushToPullSink<TSource, TSource>
@@ -23,8 +23,7 @@ namespace System.Reactive.Linq.ObservableImpl
             private readonly object _gate;
             private readonly SemaphoreSlim _semaphore;
 
-            public _(IDisposable subscription)
-                : base(subscription)
+            public _()
             {
                 _gate = new object();
                 _semaphore = new SemaphoreSlim(0, 1);


### PR DESCRIPTION
Inline the `SingleAssignmentDisposable` into the `PushPullSink` (similar to how `Sink`s were inlined).

This PR also includes the logic changes from #667 as the `Collect()` operator also uses the push-pull adapter.