### PR TITLE
4.x: LongCount() don't init to default zero

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/LongCount.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/LongCount.cs
@@ -26,7 +26,6 @@ namespace System.Reactive.Linq.ObservableImpl
                 public _(IObserver<long> observer)
                     : base(observer)
                 {
-                    _count = 0L;
                 }
 
                 public override void OnNext(TSource value)
@@ -76,7 +75,6 @@ namespace System.Reactive.Linq.ObservableImpl
                     : base(observer)
                 {
                     _predicate = predicate;
-                    _count = 0L;
                 }
 
                 public override void OnNext(TSource value)


### PR DESCRIPTION
There is no reason to initialize the `_count` to its default zero value.