### PR TITLE
4.x: Improve MaxBy cleanup/initialization

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/MaxBy.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/MaxBy.cs
@@ -25,7 +25,8 @@ namespace System.Reactive.Linq.ObservableImpl
 
         internal sealed class _ : Sink<TSource, IList<TSource>> 
         {
-            private readonly MaxBy<TSource, TKey> _parent;
+            readonly Func<TSource, TKey> _keySelector;
+            readonly IComparer<TKey> _comparer;
             private bool _hasValue;
             private TKey _lastKey;
             private List<TSource> _list;
@@ -33,10 +34,9 @@ namespace System.Reactive.Linq.ObservableImpl
             public _(MaxBy<TSource, TKey> parent, IObserver<IList<TSource>> observer)
                 : base(observer)
             {
-                _parent = parent;
+                _keySelector = parent._keySelector;
+                _comparer = parent._comparer;
 
-                _hasValue = false;
-                _lastKey = default(TKey);
                 _list = new List<TSource>();
             }
 
@@ -45,7 +45,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 var key = default(TKey);
                 try
                 {
-                    key = _parent._keySelector(value);
+                    key = _keySelector(value);
                 }
                 catch (Exception ex)
                 {
@@ -64,7 +64,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     try
                     {
-                        comparison = _parent._comparer.Compare(key, _lastKey);
+                        comparison = _comparer.Compare(key, _lastKey);
                     }
                     catch (Exception ex)
                     {
@@ -85,9 +85,17 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
 
+            public override void OnError(Exception error)
+            {
+                _list = null;
+                base.OnError(error);
+            }
+
             public override void OnCompleted()
             {
-                ForwardOnNext(_list);
+                var list = _list;
+                _list = null;
+                ForwardOnNext(list);
                 ForwardOnCompleted();
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/MaxBy.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/MaxBy.cs
@@ -68,6 +68,8 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception ex)
                     {
+                        _lastKey = default;
+                        _list = null;
                         ForwardOnError(ex);
                         return;
                     }
@@ -87,6 +89,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public override void OnError(Exception error)
             {
+                _lastKey = default;
                 _list = null;
                 base.OnError(error);
             }
@@ -95,6 +98,7 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 var list = _list;
                 _list = null;
+                _lastKey = default;
                 ForwardOnNext(list);
                 ForwardOnCompleted();
             }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/MaxBy.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/MaxBy.cs
@@ -49,6 +49,8 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 catch (Exception ex)
                 {
+                    _list = null;
+                    _lastKey = default;
                     ForwardOnError(ex);
                     return;
                 }
@@ -68,8 +70,8 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     catch (Exception ex)
                     {
-                        _lastKey = default;
                         _list = null;
+                        _lastKey = default;
                         ForwardOnError(ex);
                         return;
                     }


### PR DESCRIPTION
- Inline the selector and comparer callback fields into the sink.
- Don't initialize fields to their defaults.
- Clear the `_list` and `_lastKey` field on failure and completion.