### PR TITLE
4.x: OfType() use pattern variable instead of double cast

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/OfType.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/OfType.cs
@@ -26,9 +26,9 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public override void OnNext(TSource value)
             {
-                if (value is TResult)
+                if (value is TResult v)
                 {
-                    ForwardOnNext((TResult)(object)value);
+                    ForwardOnNext(v);
                 }
             }
         }


### PR DESCRIPTION
Use a more recent C# language feature.