### PR TITLE
4.x: Improve the performance of Range()

### DIFF
--- a/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/Program.cs
+++ b/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/Program.cs
@@ -14,7 +14,8 @@ namespace Benchmarks.System.Reactive
             var switcher = new BenchmarkSwitcher(new[] {
                 typeof(ZipBenchmark),
                 typeof(CombineLatestBenchmark),
-                typeof(SwitchBenchmark)
+                typeof(SwitchBenchmark),
+                typeof(RangeBenchmark)
             });
 
             switcher.Run();

--- a/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/RangeBenchmark.cs
+++ b/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/RangeBenchmark.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reactive.Linq;
+using System.Threading;
+using BenchmarkDotNet.Attributes;
+
+namespace Benchmarks.System.Reactive
+{
+    [MemoryDiagnoser]
+    public class RangeBenchmark
+    {
+        [Params(1, 10, 100, 1000, 10000, 100000, 1000000)]
+        public int N;
+
+        int _store;
+
+        [Benchmark]
+        public void Range()
+        {
+            Observable.Range(1, N).Subscribe(v => Volatile.Write(ref _store, v));
+        }
+    }
+}

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Range.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Range.cs
@@ -45,6 +45,15 @@ namespace System.Reactive.Linq.ObservableImpl
                 Disposable.TrySetSingle(ref _task, first);
             }
 
+            protected override void Dispose(bool disposing)
+            {
+                base.Dispose(disposing);
+                if (disposing)
+                {
+                    Disposable.TryDispose(ref _task);
+                }
+            }   
+
             private IDisposable LoopRec(IScheduler scheduler)
             {
                 var idx = _index;

--- a/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Creation.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Creation.cs
@@ -338,7 +338,12 @@ namespace System.Reactive.Linq
 
         private static IObservable<int> Range_(int start, int count, IScheduler scheduler)
         {
-            return new Range(start, count, scheduler);
+            var longRunning = scheduler.AsLongRunning();
+            if (longRunning != null)
+            {
+                return new RangeLongRunning(start, count, longRunning);
+            }
+            return new RangeRecursive(start, count, scheduler);
         }
 
         #endregion


### PR DESCRIPTION
This PR improves the performance and reduces allocations in `Range()` as well as splits the operator to recursive and non-recursive variants due to a workaround required in the recursive version. See further explanations in the diff.

The PR also adds a benchmark for verifying the gains:

```
BenchmarkDotNet=v0.10.14, OS=Windows 10.0.17134
Intel Core i7-4790 CPU 3.60GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
Frequency=3513586 Hz, Resolution=284.6095 ns, Timer=TSC
  [Host]     : .NET Framework 4.6.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3110.0
  DefaultJob : .NET Framework 4.6.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3110.0

// =============================
// Before

 Method |       N |           Mean |         Error |        StdDev |      Gen 0 |   Allocated |
------- |-------- |---------------:|--------------:|--------------:|-----------:|------------:|
  Range |       1 |       1.097 us |     0.0212 us |     0.0218 us |     0.2270 |       960 B |
  Range |      10 |       4.377 us |     0.0854 us |     0.0757 us |     0.5035 |      2136 B |
  Range |     100 |      37.894 us |     0.1508 us |     0.1411 us |     3.2959 |     13936 B |
  Range |    1000 |     385.828 us |     2.6659 us |     2.4937 us |    30.7617 |    130277 B |
  Range |   10000 |   3,779.018 us |    13.7689 us |    10.7498 us |   304.6875 |   1290436 B |
  Range |  100000 |  37,165.724 us |   167.5172 us |   148.4996 us |  3062.5000 |  12899950 B |
  Range | 1000000 | 372,437.302 us | 3,172.0311 us | 2,811.9227 us | 30750.0000 | 128990179 B |

// =============================
// After

 Method |       N |             Mean |           Error |          StdDev |      Gen 0 |  Allocated |
------- |-------- |-----------------:|----------------:|----------------:|-----------:|-----------:|
  Range |       1 |         774.0 ns |        10.81 ns |        10.11 ns |     0.1392 |      584 B |
  Range |      10 |       2,648.0 ns |        50.40 ns |        47.15 ns |     0.2747 |     1160 B |
  Range |     100 |      19,796.7 ns |       203.15 ns |       190.03 ns |     1.6479 |     6920 B |
  Range |    1000 |     191,159.1 ns |       657.33 ns |       614.86 ns |    15.3809 |    64521 B |
  Range |   10000 |   1,903,824.9 ns |    12,620.89 ns |    11,805.59 ns |   152.3438 |   640541 B |
  Range |  100000 |  19,427,114.8 ns |    90,760.45 ns |    75,789.08 ns |  1500.0000 |  6400644 B |
  Range | 1000000 | 233,398,566.0 ns | 1,215,269.71 ns | 1,014,805.15 ns | 15250.0000 | 64001854 B |
```