### PR TITLE
4.x: Improve the performance of Repeat()

### DIFF
--- a/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/Program.cs
+++ b/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/Program.cs
@@ -14,7 +14,8 @@ namespace Benchmarks.System.Reactive
             var switcher = new BenchmarkSwitcher(new[] {
                 typeof(ZipBenchmark),
                 typeof(CombineLatestBenchmark),
-                typeof(SwitchBenchmark)
+                typeof(SwitchBenchmark),
+                typeof(RepeatBenchmark)
             });
 
             switcher.Run();

--- a/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/RepeatBenchmark.cs
+++ b/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/RepeatBenchmark.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reactive.Linq;
+using System.Threading;
+using BenchmarkDotNet.Attributes;
+
+namespace Benchmarks.System.Reactive
+{
+    [MemoryDiagnoser]
+    public class RepeatBenchmark
+    {
+        [Params(1, 10, 100, 1000, 10000, 100000, 1000000)]
+        public int N;
+
+        public int _store;
+
+        [Benchmark]
+        public void Repeat_Infinite()
+        {
+            Observable.Repeat(1).Take(N).Subscribe(v => Volatile.Write(ref _store, v));
+        }
+
+        [Benchmark]
+        public void Repeat_Finite()
+        {
+            Observable.Repeat(1, N).Subscribe(v => Volatile.Write(ref _store, v));
+        }
+    }
+}

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Repeat.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Repeat.cs
@@ -9,12 +9,12 @@ namespace System.Reactive.Linq.ObservableImpl
 {
     internal static class Repeat<TResult>
     {
-        internal sealed class Forever : Producer<TResult, Forever._>
+        internal sealed class ForeverRecursive : Producer<TResult, ForeverRecursive._>
         {
             private readonly TResult _value;
             private readonly IScheduler _scheduler;
 
-            public Forever(TResult value, IScheduler scheduler)
+            public ForeverRecursive(TResult value, IScheduler scheduler)
             {
                 _value = value;
                 _scheduler = scheduler;
@@ -22,7 +22,61 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override _ CreateSink(IObserver<TResult> observer) => new _(_value, observer);
 
-            protected override void Run(_ sink) => sink.Run(this);
+            protected override void Run(_ sink) => sink.Run(_scheduler);
+
+            internal sealed class _ : IdentitySink<TResult>
+            {
+                private readonly TResult _value;
+
+                IDisposable _task;
+
+                public _(TResult value, IObserver<TResult> observer)
+                    : base(observer)
+                {
+                    _value = value;
+                }
+
+                public void Run(IScheduler scheduler)
+                {
+                    var first = scheduler.Schedule(this, (innerScheduler, @this) => @this.LoopRecInf(innerScheduler));
+                    Disposable.TrySetSingle(ref _task, first);
+                }
+
+                protected override void Dispose(bool disposing)
+                {
+                    base.Dispose(disposing);
+                    if (disposing)
+                    {
+                        Disposable.TryDispose(ref _task);
+                    }
+                }
+
+                private IDisposable LoopRecInf(IScheduler scheduler)
+                {
+                    ForwardOnNext(_value);
+
+                    var next = scheduler.Schedule(this, (innerScheduler, @this) => @this.LoopRecInf(innerScheduler));
+                    Disposable.TrySetMultiple(ref _task, next);
+
+                    return Disposable.Empty;
+                }
+            }
+        }
+
+        internal sealed class ForeverLongRunning : Producer<TResult, ForeverLongRunning._>
+        {
+            private readonly TResult _value;
+            private readonly ISchedulerLongRunning _scheduler;
+
+            public ForeverLongRunning(TResult value, ISchedulerLongRunning scheduler)
+            {
+                _value = value;
+                _scheduler = scheduler;
+            }
+
+            protected override _ CreateSink(IObserver<TResult> observer) => new _(_value, observer);
+
+            protected override void Run(_ sink) => sink.Run(_scheduler);
 
             internal sealed class _ : IdentitySink<TResult>
             {
@@ -34,23 +88,9 @@ namespace System.Reactive.Linq.ObservableImpl
                     _value = value;
                 }
 
-                public void Run(Forever parent)
+                public void Run(ISchedulerLongRunning longRunning)
                 {
-                    var longRunning = parent._scheduler.AsLongRunning();
-                    if (longRunning != null)
-                    {
-                        SetUpstream(longRunning.ScheduleLongRunning(this, (@this, c) => @this.LoopInf(c)));
-                    }
-                    else
-                    {
-                        SetUpstream(parent._scheduler.Schedule(this, (@this, a) => @this.LoopRecInf(a)));
-                    }
-                }
-
-                private void LoopRecInf(Action<_> recurse)
-                {
-                    ForwardOnNext(_value);
-                    recurse(this);
+                    SetUpstream(longRunning.ScheduleLongRunning(this, (@this, c) => @this.LoopInf(c)));
                 }
 
                 private void LoopInf(ICancelable cancel)
@@ -64,66 +104,115 @@ namespace System.Reactive.Linq.ObservableImpl
             }
         }
 
-        internal sealed class Count : Producer<TResult, Count._>
+        internal sealed class CountRecursive : Producer<TResult, CountRecursive._>
         {
             private readonly TResult _value;
             private readonly IScheduler _scheduler;
             private readonly int _repeatCount;
 
-            public Count(TResult value, int repeatCount, IScheduler scheduler)
+            public CountRecursive(TResult value, int repeatCount, IScheduler scheduler)
             {
                 _value = value;
                 _scheduler = scheduler;
                 _repeatCount = repeatCount;
             }
 
-            protected override _ CreateSink(IObserver<TResult> observer) => new _(_value, observer);
+            protected override _ CreateSink(IObserver<TResult> observer) => new _(_value, _repeatCount, observer);
 
-            protected override void Run(_ sink) => sink.Run(this);
+            protected override void Run(_ sink) => sink.Run(_scheduler);
 
             internal sealed class _ : IdentitySink<TResult>
             {
                 private readonly TResult _value;
 
-                public _(TResult value, IObserver<TResult> observer)
+                int _remaining;
+
+                IDisposable _task;
+
+                public _(TResult value, int repeatCount, IObserver<TResult> observer)
                     : base(observer)
                 {
                     _value = value;
+                    _remaining = repeatCount;
                 }
 
-                public void Run(Count parent)
+                public void Run(IScheduler scheduler)
                 {
-                    var longRunning = parent._scheduler.AsLongRunning();
-                    if (longRunning != null)
+                    var first = scheduler.Schedule(this, (innerScheduler, @this) => @this.LoopRec(innerScheduler));
+                    Disposable.TrySetSingle(ref _task, first);
+                }
+
+                protected override void Dispose(bool disposing)
+                {
+                    base.Dispose(disposing);
+                    if (disposing)
                     {
-                        SetUpstream(longRunning.ScheduleLongRunning(parent._repeatCount, Loop));
+                        Disposable.TryDispose(ref _task);
+                    }
+                }
+
+                private IDisposable LoopRec(IScheduler scheduler)
+                {
+                    var remaining = _remaining;
+                    if (remaining > 0)
+                    {
+                        ForwardOnNext(_value);
+                        _remaining = --remaining;
+                    }
+
+                    if (remaining == 0)
+                    {
+                        ForwardOnCompleted();
                     }
                     else
                     {
-                        SetUpstream(parent._scheduler.Schedule(parent._repeatCount, LoopRec));
+                        var next = scheduler.Schedule(this, (innerScheduler, @this) => @this.LoopRec(innerScheduler));
+                        Disposable.TrySetMultiple(ref _task, next);
                     }
+                    return Disposable.Empty;
                 }
+            }
+        }
 
-                private void LoopRec(int n, Action<int> recurse)
+        internal sealed class CountLongRunning : Producer<TResult, CountLongRunning._>
+        {
+            private readonly TResult _value;
+            private readonly ISchedulerLongRunning _scheduler;
+            private readonly int _repeatCount;
+
+            public CountLongRunning(TResult value, int repeatCount, ISchedulerLongRunning scheduler)
+            {
+                _value = value;
+                _scheduler = scheduler;
+                _repeatCount = repeatCount;
+            }
+
+            protected override _ CreateSink(IObserver<TResult> observer) => new _(_value, _repeatCount, observer);
+
+            protected override void Run(_ sink) => sink.Run(_scheduler);
+
+            internal sealed class _ : IdentitySink<TResult>
+            {
+                private readonly TResult _value;
+
+                int _remaining;
+
+                public _(TResult value, int remaining, IObserver<TResult> observer)
+                    : base(observer)
                 {
-                    if (n > 0)
-                    {
-                        ForwardOnNext(_value);
-                        n--;
-                    }
-
-                    if (n == 0)
-                    {
-                        ForwardOnCompleted();
-                        return;
-                    }
-
-                    recurse(n);
+                    _value = value;
+                    _remaining = remaining;
                 }
 
-                private void Loop(int n, ICancelable cancel)
+                public void Run(ISchedulerLongRunning longRunning)
+                {
+                    SetUpstream(longRunning.ScheduleLongRunning(this, (@this, cancel) => @this.Loop(cancel)));
+                }
+
+                private void Loop(ICancelable cancel)
                 {
                     var value = _value;
+                    var n = _remaining;
                     while (n > 0 && !cancel.IsDisposed)
                     {
                         ForwardOnNext(value);

--- a/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Creation.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Creation.cs
@@ -347,22 +347,42 @@ namespace System.Reactive.Linq
 
         public virtual IObservable<TResult> Repeat<TResult>(TResult value)
         {
-            return new Repeat<TResult>.Forever(value, SchedulerDefaults.Iteration);
+            return Repeat_(value, SchedulerDefaults.Iteration);
         }
 
         public virtual IObservable<TResult> Repeat<TResult>(TResult value, IScheduler scheduler)
         {
-            return new Repeat<TResult>.Forever(value, scheduler);
+            return Repeat_(value, scheduler);
+        }
+
+        private IObservable<TResult> Repeat_<TResult>(TResult value, IScheduler scheduler)
+        {
+            var longRunning = scheduler.AsLongRunning();
+            if (longRunning != null)
+            {
+                return new Repeat<TResult>.ForeverLongRunning(value, longRunning);
+            }
+            return new Repeat<TResult>.ForeverRecursive(value, scheduler);
         }
 
         public virtual IObservable<TResult> Repeat<TResult>(TResult value, int repeatCount)
         {
-            return new Repeat<TResult>.Count(value, repeatCount, SchedulerDefaults.Iteration);
+            return Repeat_(value, repeatCount, SchedulerDefaults.Iteration);
         }
 
         public virtual IObservable<TResult> Repeat<TResult>(TResult value, int repeatCount, IScheduler scheduler)
         {
-            return new Repeat<TResult>.Count(value, repeatCount, scheduler);
+            return Repeat_(value, repeatCount, scheduler);
+        }
+
+        private IObservable<TResult> Repeat_<TResult>(TResult value, int repeatCount, IScheduler scheduler)
+        {
+            var longRunning = scheduler.AsLongRunning();
+            if (longRunning != null)
+            {
+                return new Repeat<TResult>.CountLongRunning(value, repeatCount, longRunning);
+            }
+            return new Repeat<TResult>.CountRecursive(value, repeatCount, scheduler);
         }
 
         #endregion


### PR DESCRIPTION
This PR improves the performance of `Repeat()` as well as reduces the allocations in it.

The changes are similar to #684:

- Split the implementation into recursive and long-running variants
- Use the sink fields to keep track of numbers
- Use direct task management for the recursive scheduling parts

Benchmark comparison:

```
BenchmarkDotNet=v0.10.14, OS=Windows 10.0.17134
Intel Core i7-4790 CPU 3.60GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
Frequency=3513586 Hz, Resolution=284.6095 ns, Timer=TSC
  [Host]     : .NET Framework 4.6.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3110.0
  DefaultJob : .NET Framework 4.6.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3110.0

// =============================
// Before

          Method |       N |             Mean |           Error |           StdDev |      Gen 0 |   Allocated |
---------------- |-------- |-----------------:|----------------:|-----------------:|-----------:|------------:|
 Repeat_Infinite |       1 |       1,124.2 ns |        14.62 ns |        13.676 ns |     0.2289 |       968 B |
   Repeat_Finite |       1 |         658.9 ns |        10.03 ns |         8.888 ns |     0.1898 |       800 B |
 Repeat_Infinite |      10 |       4,746.5 ns |        44.52 ns |        41.648 ns |     0.5035 |      2144 B |
   Repeat_Finite |      10 |       4,015.5 ns |        19.13 ns |        15.978 ns |     0.4807 |      2032 B |
 Repeat_Infinite |     100 |      40,143.7 ns |       265.54 ns |       248.388 ns |     3.2959 |     13944 B |
   Repeat_Finite |     100 |      37,831.2 ns |       148.16 ns |       138.590 ns |     3.2959 |     13833 B |
 Repeat_Infinite |    1000 |     395,852.8 ns |     2,473.30 ns |     2,313.527 ns |    30.7617 |    130286 B |
   Repeat_Finite |    1000 |     374,635.1 ns |     3,186.28 ns |     2,980.447 ns |    30.7617 |    130174 B |
 Repeat_Infinite |   10000 |   3,958,720.3 ns |     9,353.88 ns |     7,302.893 ns |   304.6875 |   1290444 B |
   Repeat_Finite |   10000 |   3,791,888.7 ns |    13,149.28 ns |    10,980.241 ns |   304.6875 |   1290312 B |
 Repeat_Infinite |  100000 |  40,644,575.8 ns |   655,346.49 ns |   613,011.451 ns |  3062.5000 |  12899958 B |
   Repeat_Finite |  100000 |  37,461,446.1 ns |   172,926.03 ns |   161,755.103 ns |  3062.5000 |  12899840 B |
 Repeat_Infinite | 1000000 | 393,461,337.2 ns | 1,903,940.74 ns | 1,780,947.174 ns | 30750.0000 | 128990086 B |
   Repeat_Finite | 1000000 | 377,989,073.5 ns | 6,045,007.96 ns | 5,654,503.648 ns | 30750.0000 | 128989308 B |

// =============================
// After

          Method |       N |             Mean |            Error |           StdDev |      Gen 0 |  Allocated |
---------------- |-------- |-----------------:|-----------------:|-----------------:|-----------:|-----------:|
 Repeat_Infinite |       1 |         929.7 ns |        10.904 ns |         9.666 ns |     0.1554 |      656 B |
   Repeat_Finite |       1 |         575.5 ns |        10.578 ns |         9.895 ns |     0.1230 |      520 B |
 Repeat_Infinite |      10 |       2,959.2 ns |        12.433 ns |        11.629 ns |     0.2899 |     1232 B |
   Repeat_Finite |      10 |       2,266.2 ns |         6.947 ns |         6.498 ns |     0.2594 |     1096 B |
 Repeat_Infinite |     100 |      19,660.3 ns |        52.412 ns |        49.027 ns |     1.6479 |     6992 B |
   Repeat_Finite |     100 |      21,740.8 ns |       153.386 ns |       143.478 ns |     1.6174 |     6856 B |
 Repeat_Infinite |    1000 |     223,735.8 ns |       841.558 ns |       787.194 ns |    15.3809 |    64593 B |
   Repeat_Finite |    1000 |     187,399.5 ns |     1,283.175 ns |     1,200.282 ns |    15.1367 |    64457 B |
 Repeat_Infinite |   10000 |   1,885,503.8 ns |     6,665.867 ns |     6,235.255 ns |   152.3438 |   640605 B |
   Repeat_Finite |   10000 |   1,883,624.3 ns |     6,752.810 ns |     6,316.582 ns |   152.3438 |   640477 B |
 Repeat_Infinite |  100000 |  18,769,865.2 ns |    65,556.399 ns |    61,321.490 ns |  1500.0000 |  6400900 B |
   Repeat_Finite |  100000 |  18,871,466.9 ns |    99,828.389 ns |    93,379.528 ns |  1500.0000 |  6400644 B |
 Repeat_Infinite | 1000000 | 188,786,400.6 ns |   679,486.687 ns |   635,592.207 ns | 15250.0000 | 64001342 B |
   Repeat_Finite | 1000000 | 188,306,308.8 ns | 1,101,114.930 ns | 1,029,983.488 ns | 15250.0000 | 64001340 B |
```