### PR TITLE
4.x: Scan() don't init to default values

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Scan.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Scan.cs
@@ -75,8 +75,6 @@ namespace System.Reactive.Linq.ObservableImpl
                 : base(observer)
             {
                 _accumulator = accumulator;
-                _accumulation = default(TSource);
-                _hasAccumulation = false;
             }
 
             public override void OnNext(TSource value)


### PR DESCRIPTION
There is no need to initialize these fields to their default.