### PR TITLE
4.x: indexed Select() don't init to default value

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Select.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Select.cs
@@ -73,7 +73,6 @@ namespace System.Reactive.Linq.ObservableImpl
                     : base(observer)
                 {
                     _selector = selector;
-                    _index = 0;
                 }
 
                 public override void OnNext(TSource value)


### PR DESCRIPTION
There is no need to initialize the index field to its default value.