### PR TITLE
4.x: SingleAsync() don't init to default values

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/SingleAsync.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/SingleAsync.cs
@@ -27,8 +27,6 @@ namespace System.Reactive.Linq.ObservableImpl
                 public _(IObserver<TSource> observer)
                     : base(observer)
                 {
-                    _value = default(TSource);
-                    _seenValue = false;
                 }
 
                 public override void OnNext(TSource value)
@@ -83,9 +81,6 @@ namespace System.Reactive.Linq.ObservableImpl
                     : base(observer)
                 {
                     _predicate = predicate;
-
-                    _value = default(TSource);
-                    _seenValue = false;
                 }
 
                 public override void OnNext(TSource value)


### PR DESCRIPTION
There is no reason to initialize the fields to their default values.