### PR TITLE
4.x: SingleOrDefaultAsync() don't init to default

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/SingleOrDefaultAsync.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/SingleOrDefaultAsync.cs
@@ -27,8 +27,6 @@ namespace System.Reactive.Linq.ObservableImpl
                 public _(IObserver<TSource> observer)
                     : base(observer)
                 {
-                    _value = default(TSource);
-                    _seenValue = false;
                 }
 
                 public override void OnNext(TSource value)
@@ -76,9 +74,6 @@ namespace System.Reactive.Linq.ObservableImpl
                     : base(observer)
                 {
                     _predicate = predicate;
-
-                    _value = default(TSource);
-                    _seenValue = false;
                 }
 
                 public override void OnNext(TSource value)


### PR DESCRIPTION
There is no reason to initialize the fields to their default values.