### PR TITLE
4.x: SkipUntil() remove unused helper class

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/SkipUntil.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/SkipUntil.cs
@@ -114,11 +114,6 @@ namespace System.Reactive.Linq.ObservableImpl
         }
     }
 
-    internal static class SkipUntilTerminalException
-    {
-        internal static readonly Exception Instance = new Exception("No further exceptions");
-    }
-
     internal sealed class SkipUntil<TSource> : Producer<TSource, SkipUntil<TSource>._>
     {
         private readonly IObservable<TSource> _source;


### PR DESCRIPTION
The `SkipUntilTerminalException` class was a remnant before the `ExceptionHelper` was introduced for the same and common functionality.