### PR TITLE
4.x: SkipWhile() don't init to default value

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/SkipWhile.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/SkipWhile.cs
@@ -85,7 +85,6 @@ namespace System.Reactive.Linq.ObservableImpl
                     : base(observer)
                 {
                     _predicate = predicate;
-                    _index = 0;
                 }
 
                 public override void OnNext(TSource value)


### PR DESCRIPTION
There is no reason to initialize the field to its default value.