### PR TITLE
4.x: Sum() don't init to default values

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Sum.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Sum.cs
@@ -24,7 +24,6 @@ namespace System.Reactive.Linq.ObservableImpl
             public _(IObserver<double> observer)
                 : base(observer)
             {
-                _sum = 0.0;
             }
 
             public override void OnNext(double value)
@@ -55,12 +54,11 @@ namespace System.Reactive.Linq.ObservableImpl
 
         internal sealed class _ : IdentitySink<float>
         {
-            private double _sum; // This is what LINQ to Objects does!
+            private double _sum; // This is what LINQ to Objects does (accumulates into double that is)!
 
             public _(IObserver<float> observer)
                 : base(observer)
             {
-                _sum = 0.0; // This is what LINQ to Objects does!
             }
 
             public override void OnNext(float value)
@@ -96,7 +94,6 @@ namespace System.Reactive.Linq.ObservableImpl
             public _(IObserver<decimal> observer)
                 : base(observer)
             {
-                _sum = 0M;
             }
 
             public override void OnNext(decimal value)
@@ -132,7 +129,6 @@ namespace System.Reactive.Linq.ObservableImpl
             public _(IObserver<int> observer)
                 : base(observer)
             {
-                _sum = 0;
             }
 
             public override void OnNext(int value)
@@ -178,7 +174,6 @@ namespace System.Reactive.Linq.ObservableImpl
             public _(IObserver<long> observer)
                 : base(observer)
             {
-                _sum = 0L;
             }
 
             public override void OnNext(long value)
@@ -224,7 +219,6 @@ namespace System.Reactive.Linq.ObservableImpl
             public _(IObserver<double?> observer)
                 : base(observer)
             {
-                _sum = 0.0;
             }
 
             public override void OnNext(double? value)
@@ -256,12 +250,11 @@ namespace System.Reactive.Linq.ObservableImpl
 
         internal sealed class _ : IdentitySink<float?>
         {
-            private double _sum; // This is what LINQ to Objects does!
+            private double _sum; // This is what LINQ to Objects does (accumulates into double that is)!
 
             public _(IObserver<float?> observer)
                 : base(observer)
             {
-                _sum = 0.0; // This is what LINQ to Objects does!
             }
 
             public override void OnNext(float? value)
@@ -298,7 +291,6 @@ namespace System.Reactive.Linq.ObservableImpl
             public _(IObserver<decimal?> observer)
                 : base(observer)
             {
-                _sum = 0M;
             }
 
             public override void OnNext(decimal? value)
@@ -335,7 +327,6 @@ namespace System.Reactive.Linq.ObservableImpl
             public _(IObserver<int?> observer)
                 : base(observer)
             {
-                _sum = 0;
             }
 
             public override void OnNext(int? value)
@@ -382,7 +373,6 @@ namespace System.Reactive.Linq.ObservableImpl
             public _(IObserver<long?> observer)
                 : base(observer)
             {
-                _sum = 0L;
             }
 
             public override void OnNext(long? value)


### PR DESCRIPTION
There is no reason to initialize the fields to their default values.