### PR TITLE
4.x: TakeWhile() don't init to default value

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/TakeWhile.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/TakeWhile.cs
@@ -86,7 +86,6 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     _predicate = predicate;
                     _running = true;
-                    _index = 0;
                 }
 
                 public override void OnNext(TSource value)


### PR DESCRIPTION
There is no reason to initialize the field to the default value.