### PR TITLE
4.x: ToArray() avoid retention of the list beyond the conversion

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/ToArray.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/ToArray.cs
@@ -21,7 +21,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         internal sealed class _ : Sink<TSource, TSource[]> 
         {
-            private readonly List<TSource> _list;
+            private List<TSource> _list;
 
             public _(IObserver<TSource[]> observer)
                 : base(observer)
@@ -34,9 +34,17 @@ namespace System.Reactive.Linq.ObservableImpl
                 _list.Add(value);
             }
 
+            public override void OnError(Exception error)
+            {
+                _list = null;
+                base.OnError(error);
+            }
+
             public override void OnCompleted()
             {
-                ForwardOnNext(_list.ToArray());
+                var list = _list;
+                _list = null;
+                ForwardOnNext(list.ToArray());
                 ForwardOnCompleted();
             }
         }


### PR DESCRIPTION
Once converted to an array, the list used for accumulating the items can be freed by GC. In addition, a failure should also free the list.