### PR TITLE
4.x: Improve the performance of ToObservable()

### DIFF
--- a/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/Program.cs
+++ b/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/Program.cs
@@ -15,7 +15,8 @@ namespace Benchmarks.System.Reactive
                 typeof(ZipBenchmark),
                 typeof(CombineLatestBenchmark),
                 typeof(SwitchBenchmark),
-                typeof(BufferCountBenchmark)
+                typeof(BufferCountBenchmark),
+                typeof(ToObservableBenchmark)
             });
 
             switcher.Run();

--- a/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/ToObservableBenchmark.cs
+++ b/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/ToObservableBenchmark.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading;
+using BenchmarkDotNet.Attributes;
+
+namespace Benchmarks.System.Reactive
+{
+    [MemoryDiagnoser]
+    public class ToObservableBenchmark
+    {
+        [Params(1, 10, 100, 1000, 10000, 100000, 1000000)]
+        public int N;
+
+        int _store;
+
+        [Benchmark]
+        public void Exact()
+        {
+            Enumerable.Range(1, N)
+                .ToObservable()
+                .Subscribe(v => Volatile.Write(ref _store, v));
+        }
+    }
+}

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/ToObservable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/ToObservable.cs
@@ -5,15 +5,16 @@
 using System.Collections.Generic;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
+using System.Threading;
 
 namespace System.Reactive.Linq.ObservableImpl
 {
-    internal sealed class ToObservable<TSource> : Producer<TSource, ToObservable<TSource>._>
+    internal sealed class ToObservableRecursive<TSource> : Producer<TSource, ToObservableRecursive<TSource>._>
     {
         private readonly IEnumerable<TSource> _source;
         private readonly IScheduler _scheduler;
 
-        public ToObservable(IEnumerable<TSource> source, IScheduler scheduler)
+        public ToObservableRecursive(IEnumerable<TSource> source, IScheduler scheduler)
         {
             _source = source;
             _scheduler = scheduler;
@@ -21,21 +22,24 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override _ CreateSink(IObserver<TSource> observer) => new _(observer);
 
-        protected override void Run(_ sink) => sink.Run(this);
+        protected override void Run(_ sink) => sink.Run(_source, _scheduler);
 
         internal sealed class _ : IdentitySink<TSource>
         {
+            IEnumerator<TSource> _enumerator;
+
+            volatile bool _disposed;
+
             public _(IObserver<TSource> observer)
                 : base(observer)
             {
             }
 
-            public void Run(ToObservable<TSource> parent)
+            public void Run(IEnumerable<TSource> source, IScheduler scheduler)
             {
-                var e = default(IEnumerator<TSource>);
                 try
                 {
-                    e = parent._source.GetEnumerator();
+                    _enumerator = source.GetEnumerator();
                 }
                 catch (Exception exception)
                 {
@@ -44,61 +48,44 @@ namespace System.Reactive.Linq.ObservableImpl
                     return;
                 }
 
-                var longRunning = parent._scheduler.AsLongRunning();
-                if (longRunning != null)
-                {
-                    //
-                    // Long-running schedulers have the contract they should *never* prevent
-                    // the work from starting, such that the scheduled work has the chance
-                    // to observe the cancellation and perform proper clean-up. In this case,
-                    // we're sure Loop will be entered, allowing us to dispose the enumerator.
-                    //
-                    SetUpstream(longRunning.ScheduleLongRunning((@this: this, e), (tuple, cancelable) => tuple.@this.Loop(tuple.e, cancelable)));
-                }
-                else
-                {
-                    //
-                    // We never allow the scheduled work to be cancelled. Instead, the flag
-                    // is used to have LoopRec bail out and perform proper clean-up of the
-                    // enumerator.
-                    //
-                    var flag = new BooleanDisposable();
-                    parent._scheduler.Schedule(new State(this, flag, e), (state, action) => state.sink.LoopRec(state, action));
-                    SetUpstream(flag);
-                }
+                //
+                // We never allow the scheduled work to be cancelled. Instead, the _disposed flag
+                // is used to have LoopRec bail out and perform proper clean-up of the
+                // enumerator.
+                //
+                scheduler.Schedule(this, (innerScheduler, @this) => @this.LoopRec(innerScheduler));
             }
 
-            private struct State
+            protected override void Dispose(bool disposing)
             {
-                public readonly _ sink;
-                public readonly ICancelable flag;
-                public readonly IEnumerator<TSource> enumerator;
-
-                public State(_ sink, ICancelable flag, IEnumerator<TSource> enumerator)
+                base.Dispose(disposing);
+                if (disposing)
                 {
-                    this.sink = sink;
-                    this.flag = flag;
-                    this.enumerator = enumerator;
+                    _disposed = true;
                 }
             }
 
-            private void LoopRec(State state, Action<State> recurse)
+            private IDisposable LoopRec(IScheduler scheduler)
             {
                 var hasNext = false;
                 var ex = default(Exception);
                 var current = default(TSource);
 
-                if (state.flag.IsDisposed)
+                var enumerator = _enumerator;
+
+                if (_disposed)
                 {
-                    state.enumerator.Dispose();
-                    return;
+                    _enumerator.Dispose();
+                    _enumerator = null;
+
+                    return Disposable.Empty;
                 }
 
                 try
                 {
-                    hasNext = state.enumerator.MoveNext();
+                    hasNext = enumerator.MoveNext();
                     if (hasNext)
-                        current = state.enumerator.Current;
+                        current = enumerator.Current;
                 }
                 catch (Exception exception)
                 {
@@ -107,22 +94,73 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 if (ex != null)
                 {
-                    state.enumerator.Dispose();
+                    enumerator.Dispose();
+                    _enumerator = null;
 
                     ForwardOnError(ex);
-                    return;
+                    return Disposable.Empty;
                 }
 
                 if (!hasNext)
                 {
-                    state.enumerator.Dispose();
+                    enumerator.Dispose();
+                    _enumerator = null;
 
                     ForwardOnCompleted();
-                    return;
+                    return Disposable.Empty;
                 }
 
                 ForwardOnNext(current);
-                recurse(state);
+
+                //
+                // We never allow the scheduled work to be cancelled. Instead, the _disposed flag
+                // is used to have LoopRec bail out and perform proper clean-up of the
+                // enumerator.
+                //
+                scheduler.Schedule(this, (innerScheduler, @this) => @this.LoopRec(innerScheduler));
+
+                return Disposable.Empty;
+            }
+        }
+    }
+
+    internal sealed class ToObservableLongRunning<TSource> : Producer<TSource, ToObservableLongRunning<TSource>._>
+    {
+        private readonly IEnumerable<TSource> _source;
+        private readonly ISchedulerLongRunning _scheduler;
+
+        public ToObservableLongRunning(IEnumerable<TSource> source, ISchedulerLongRunning scheduler)
+        {
+            _source = source;
+            _scheduler = scheduler;
+        }
+
+        protected override _ CreateSink(IObserver<TSource> observer) => new _(observer);
+
+        protected override void Run(_ sink) => sink.Run(_source, _scheduler);
+
+        internal sealed class _ : IdentitySink<TSource>
+        {
+            public _(IObserver<TSource> observer)
+                : base(observer)
+            {
+            }
+
+            public void Run(IEnumerable<TSource> source, ISchedulerLongRunning scheduler)
+            {
+                var e = default(IEnumerator<TSource>);
+                try
+                {
+                    e = source.GetEnumerator();
+                }
+                catch (Exception exception)
+                {
+                    ForwardOnError(exception);
+
+                    return;
+                }
+
+                SetUpstream(scheduler.ScheduleLongRunning((@this: this, e), (tuple, cancelable) => tuple.@this.Loop(tuple.e, cancelable)));
             }
 
             private void Loop(IEnumerator<TSource> enumerator, ICancelable cancel)

--- a/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Conversions.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Conversions.cs
@@ -26,10 +26,18 @@ namespace System.Reactive.Linq
 
         private static IDisposable Subscribe_<TSource>(IEnumerable<TSource> source, IObserver<TSource> observer, IScheduler scheduler)
         {
+            var longRunning = scheduler.AsLongRunning();
+            if (longRunning != null)
+            {
+                //
+                // [OK] Use of unsafe Subscribe: we're calling into a known producer implementation.
+                //
+                return new ToObservableLongRunning<TSource>(source, longRunning).Subscribe/*Unsafe*/(observer);
+            }
             //
             // [OK] Use of unsafe Subscribe: we're calling into a known producer implementation.
             //
-            return new ToObservable<TSource>(source, scheduler).Subscribe/*Unsafe*/(observer);
+            return new ToObservableRecursive<TSource>(source, scheduler).Subscribe/*Unsafe*/(observer);
         }
 
         #endregion
@@ -73,12 +81,28 @@ namespace System.Reactive.Linq
 
         public virtual IObservable<TSource> ToObservable<TSource>(IEnumerable<TSource> source)
         {
-            return new ToObservable<TSource>(source, SchedulerDefaults.Iteration);
+            return ToObservable_(source, SchedulerDefaults.Iteration);
         }
 
         public virtual IObservable<TSource> ToObservable<TSource>(IEnumerable<TSource> source, IScheduler scheduler)
         {
-            return new ToObservable<TSource>(source, scheduler);
+            return ToObservable_(source, scheduler);
+        }
+
+        private static IObservable<TSource> ToObservable_<TSource>(IEnumerable<TSource> source, IScheduler scheduler)
+        {
+            var longRunning = scheduler.AsLongRunning();
+            if (longRunning != null)
+            {
+                //
+                // [OK] Use of unsafe Subscribe: we're calling into a known producer implementation.
+                //
+                return new ToObservableLongRunning<TSource>(source, longRunning);
+            }
+            //
+            // [OK] Use of unsafe Subscribe: we're calling into a known producer implementation.
+            //
+            return new ToObservableRecursive<TSource>(source, scheduler);
         }
 
         #endregion


### PR DESCRIPTION
This PR improves the performance and allocation behavior of the `ToObservable(IEnumerable)` operator by inlining the recursive scheduling management and splits the operator into separate, dedicated long-running and recursive variants.

The recursive variant is still declared to not link up the disposable management so the `volatile bool _disposed` field is enough to signal cancellation. In addition, the previous `Action<Action<>>`-based recursive scheduling was mostly responsible for the overhead as it was still tracking each recursively scheduled task despite they would have never gotten disposed.

Comparison:
```
BenchmarkDotNet=v0.10.14, OS=Windows 10.0.17134
Intel Core i7-4790 CPU 3.60GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
Frequency=3513586 Hz, Resolution=284.6095 ns, Timer=TSC
  [Host]     : .NET Framework 4.6.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3110.0
  DefaultJob : .NET Framework 4.6.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3110.0

// ============================================
// Before

 Method |       N |           Mean |         Error |        StdDev |      Gen 0 |   Allocated |
------- |-------- |---------------:|--------------:|--------------:|-----------:|------------:|
  Exact |       1 |       1.136 us |     0.0122 us |     0.0108 us |     0.2346 |       992 B |
  Exact |      10 |       4.897 us |     0.0435 us |     0.0407 us |     0.5493 |      2312 B |
  Exact |     100 |      43.431 us |     0.5890 us |     0.5221 us |     3.6621 |     15552 B |
  Exact |    1000 |     432.782 us |     3.5242 us |     2.9429 us |    34.6680 |    146291 B |
  Exact |   10000 |   4,298.397 us |    72.5810 us |    67.8924 us |   343.7500 |   1450440 B |
  Exact |  100000 |  41,972.884 us |   240.8476 us |   225.2889 us |  3437.5000 |  14500174 B |
  Exact | 1000000 | 426,720.117 us | 7,334.0969 us | 6,860.3181 us | 34562.5000 | 144987362 B |

// ============================================
// After

 Method |       N |             Mean |          Error |         StdDev |      Gen 0 |  Allocated |
------- |-------- |-----------------:|---------------:|---------------:|-----------:|-----------:|
  Exact |       1 |         738.3 ns |       5.741 ns |       5.370 ns |     0.1497 |      632 B |
  Exact |      10 |       2,464.1 ns |      34.347 ns |      32.128 ns |     0.2861 |     1208 B |
  Exact |     100 |      26,969.5 ns |     167.985 ns |     157.133 ns |     1.6479 |     6968 B |
  Exact |    1000 |     189,754.5 ns |   2,804.522 ns |   2,486.136 ns |    15.3809 |    64569 B |
  Exact |   10000 |   1,882,753.7 ns |   6,135.018 ns |   5,738.699 ns |   152.3438 |   640589 B |
  Exact |  100000 |  26,518,449.9 ns | 180,846.221 ns | 169,163.651 ns |  1500.0000 |  6400644 B |
  Exact | 1000000 | 262,672,144.8 ns | 937,389.291 ns | 830,971.109 ns | 15250.0000 | 64001342 B |
```