### PR TITLE
4.x: Where() don't init to default value

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Where.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Where.cs
@@ -38,7 +38,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public override void OnNext(TSource value)
                 {
-                    var shouldRun = default(bool);
+                    var shouldRun = false;
                     try
                     {
                         shouldRun = _predicate(value);
@@ -81,12 +81,11 @@ namespace System.Reactive.Linq.ObservableImpl
                     : base(observer)
                 {
                     _predicate = predicate;
-                    _index = 0;
                 }
 
                 public override void OnNext(TSource value)
                 {
-                    var shouldRun = default(bool);
+                    var shouldRun = false;
                     try
                     {
                         shouldRun = _predicate(value, checked(_index++));


### PR DESCRIPTION
There is no reason to initialize the index to its default value. Also `default(bool)` was too elegant for me and I simply replaced them with `var shouldRun = false`.