### PR TITLE
4.x: Window() don't init to default value

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Window.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Window.cs
@@ -50,8 +50,6 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public override void Run(IObservable<TSource> source)
                 {
-                    _n = 0;
-
                     var firstWindow = CreateWindow();
                     ForwardOnNext(firstWindow);
 
@@ -388,8 +386,6 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public override void Run(IObservable<TSource> source)
                 {
-                    _n = 0;
-
                     var groupDisposable = new CompositeDisposable(2) { _timerD };
                     _refCountDisposable = new RefCountDisposable(groupDisposable);
 


### PR DESCRIPTION
There is no reason to initialize `_n` to zero.