### PR TITLE
4.x: Buffer(count, skip) remove unused _index field

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Buffer.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Buffer.cs
@@ -190,7 +190,6 @@ namespace System.Reactive.Linq.ObservableImpl
                 private readonly int _count;
                 private readonly int _skip;
 
-                int _index;
                 int _n;
 
                 public OverlapSink(IObserver<IList<TSource>> observer, int count, int skip)


### PR DESCRIPTION
Remove the `_index` field from the overlap-variant (accidentally left behind by some algorithm experimentation).