### PR TITLE
[WIP] Increment the used C# language version to 7.3.

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/GroupBy.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/GroupBy.cs
@@ -25,7 +25,7 @@ namespace System.Reactive.Linq.ObservableImpl
             _comparer = comparer;
         }
 
-        protected override _ CreateSink(IObserver<IGroupedObservable<TKey, TElement>> observer) => new _(this, observer);
+        protected override _ CreateSink(IObserver<IGroupedObservable<TKey, TElement>> observer) => new _(_keySelector, _elementSelector, _capacity, _comparer, observer);
 
         protected override void Run(_ sink) => sink.Run(_source);
 
@@ -38,19 +38,19 @@ namespace System.Reactive.Linq.ObservableImpl
             private RefCountDisposable _refCountDisposable;
             private Subject<TElement> _null;
 
-            public _(GroupBy<TSource, TKey, TElement> parent, IObserver<IGroupedObservable<TKey, TElement>> observer)
+            public _(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, int? capacity, IEqualityComparer<TKey> comparer, IObserver<IGroupedObservable<TKey, TElement>> observer)
                 : base(observer)
             {
-                _keySelector = parent._keySelector;
-                _elementSelector = parent._elementSelector;
+                _keySelector = keySelector;
+                _elementSelector = elementSelector;
 
-                if (parent._capacity.HasValue)
+                if (capacity.HasValue)
                 {
-                    _map = new Dictionary<TKey, Subject<TElement>>(parent._capacity.Value, parent._comparer);
+                    _map = new Dictionary<TKey, Subject<TElement>>(capacity.Value, comparer);
                 }
                 else
                 {
-                    _map = new Dictionary<TKey, Subject<TElement>>(parent._comparer);
+                    _map = new Dictionary<TKey, Subject<TElement>>(comparer);
                 }
             }
 

--- a/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
+++ b/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
@@ -4,7 +4,7 @@
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>       
     <PackageTags>Rx;Reactive;Extensions;Observable;LINQ;Events</PackageTags>
     <Description>Reactive Extensions (Rx) for .NET</Description>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
 


### PR DESCRIPTION
 Probably due to the new features (readonly-structs etc.) some tests related to GroupBy will now fail. The error has been described [here](https://github.com/dotnet/roslyn/issues/27382). It's directly related to [this readonly struct field](https://github.com/dotnet/reactive/blob/master/Rx.NET/Source/src/System.Reactive/Linq/Observable/GroupBy.cs#L16), removing the readonl modifier solves the issue. What exact message the error is trying to get across is still unclear, the workaround presented in this commit however fixes it.