### PR TITLE
Benchmark test for Append and Prepend

### DIFF
--- a/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/AppendPrependBenchmark.cs
+++ b/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/AppendPrependBenchmark.cs
@@ -1,0 +1,88 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading;
+using BenchmarkDotNet.Attributes;
+
+namespace Benchmarks.System.Reactive
+{
+    [MemoryDiagnoser]
+    public class AppendPrependBenchmark
+    {
+        [Params(1, 10, 100, 1000, 10000)]
+        public int N;
+
+        int _store;
+
+        [Benchmark(Baseline = true)]
+        public void StartWithArray()
+        {
+            var array = new int[2 * N];
+            var max = 2 * N - 1;
+
+            for (var i = 0; i < N; i++)
+            {
+                array[i] = i;
+                array[max - i] = i;
+            }
+
+            Observable
+                .Empty<int>()
+                .StartWith(array)
+                .Subscribe(v => Volatile.Write(ref _store, v));
+        }
+
+        [Benchmark]
+        public void StartWithList()
+        {
+            var list = new List<int>();
+
+            for (var i = 0; i < N; i++)
+            {
+                list.Insert(i, 0);
+                list.Add(i);
+            }
+
+            Observable
+                .Empty<int>()
+                .StartWith(list)
+                .Subscribe(v => Volatile.Write(ref _store, v));
+        }
+
+        [Benchmark]
+        public void StartWithLinkedList()
+        {
+            var list = new LinkedList<int>();
+
+            for (var i = 0; i < N; i++)
+            {
+                list.AddFirst(i);
+                list.AddLast(i);
+            }
+
+            Observable
+                .Empty<int>()
+                .StartWith(list)
+                .Subscribe(v => Volatile.Write(ref _store, v));
+        }
+
+        [Benchmark]
+        public void AppendPrepend()
+        {
+            var obs = Observable.Empty<int>();
+
+            for (var i = 0; i < N; i++)
+            {
+                obs = obs.Prepend(0);
+                obs = obs.Append(0);
+            }
+
+            obs.Subscribe(v => Volatile.Write(ref _store, v));
+        }
+    }
+}

--- a/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/AppendPrependBenchmark.cs
+++ b/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/AppendPrependBenchmark.cs
@@ -78,8 +78,8 @@ namespace Benchmarks.System.Reactive
 
             for (var i = 0; i < N; i++)
             {
-                obs = obs.Prepend(0);
-                obs = obs.Append(0);
+                obs = obs.Prepend(i);
+                obs = obs.Append(i);
             }
 
             obs.Subscribe(v => Volatile.Write(ref _store, v));

--- a/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/Program.cs
+++ b/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/Program.cs
@@ -16,7 +16,8 @@ namespace Benchmarks.System.Reactive
                 typeof(CombineLatestBenchmark),
                 typeof(SwitchBenchmark),
                 typeof(BufferCountBenchmark),
-                typeof(RangeBenchmark)
+                typeof(RangeBenchmark),
+                typeof(AppendPrependBenchmark)
             });
 
             switcher.Run();


### PR DESCRIPTION
Here is a benchmark for the append and prepend operators. The results on my slow machine:

``` ini

BenchmarkDotNet=v0.10.14, OS=Windows 10.0.17134
Intel Core i5-5200U CPU 2.20GHz (Broadwell), 1 CPU, 4 logical and 2 physical cores
Frequency=2143476 Hz, Resolution=466.5319 ns, Timer=TSC
  [Host]     : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3110.0
  DefaultJob : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3110.0


```
|              Method |     N |          Mean |       Error |      StdDev |        Median | Scaled | ScaledSD |     Gen 0 |    Gen 1 |   Gen 2 |  Allocated |
|-------------------- |------ |--------------:|------------:|------------:|--------------:|-------:|---------:|----------:|---------:|--------:|-----------:|
|      **StartWithArray** |     **1** |      **4.157 us** |   **0.0440 us** |   **0.0412 us** |      **4.143 us** |   **1.00** |     **0.00** |    **1.1520** |        **-** |       **-** |    **1.77 KB** |
|       StartWithList |     1 |      4.386 us |   0.0325 us |   0.0304 us |      4.384 us |   1.06 |     0.01 |    1.2512 |        - |       - |    1.92 KB |
| StartWithLinkedList |     1 |      4.465 us |   0.0369 us |   0.0345 us |      4.456 us |   1.07 |     0.01 |    1.2894 |        - |       - |    1.99 KB |
|       AppendPrepend |     1 |      3.094 us |   0.0393 us |   0.0328 us |      3.088 us |   0.74 |     0.01 |    1.3046 |        - |       - |    2.01 KB |
|                     |       |               |             |             |               |        |          |           |          |         |            |
|      **StartWithArray** |    **10** |     **14.520 us** |   **0.1870 us** |   **0.1749 us** |     **14.497 us** |   **1.00** |     **0.00** |    **2.9907** |        **-** |       **-** |    **4.61 KB** |
|       StartWithList |    10 |     15.032 us |   0.0622 us |   0.0582 us |     15.034 us |   1.04 |     0.01 |    3.3264 |        - |       - |    5.12 KB |
| StartWithLinkedList |    10 |     15.148 us |   0.1282 us |   0.1199 us |     15.135 us |   1.04 |     0.01 |    3.7231 |        - |       - |    5.75 KB |
|       AppendPrepend |    10 |     15.397 us |   0.3420 us |   0.3359 us |     15.261 us |   1.06 |     0.03 |    4.6082 |        - |       - |     7.1 KB |
|                     |       |               |             |             |               |        |          |           |          |         |            |
|      **StartWithArray** |   **100** |    **121.692 us** |   **2.1790 us** |   **1.9317 us** |    **121.235 us** |   **1.00** |     **0.00** |   **21.4844** |        **-** |       **-** |   **33.13 KB** |
|       StartWithList |   100 |    132.711 us |   2.7900 us |   6.3541 us |    130.194 us |   1.09 |     0.05 |   23.4375 |        - |       - |   36.15 KB |
| StartWithLinkedList |   100 |    124.043 us |   1.0964 us |   1.0256 us |    123.699 us |   1.02 |     0.02 |   28.0762 |        - |       - |   43.36 KB |
|       AppendPrepend |   100 |    136.074 us |   1.4399 us |   1.3469 us |    135.607 us |   1.12 |     0.02 |   33.6914 |        - |       - |   51.91 KB |
|                     |       |               |             |             |               |        |          |           |          |         |            |
|      **StartWithArray** |  **1000** |  **1,160.993 us** |   **9.5362 us** |   **8.9202 us** |  **1,160.188 us** |   **1.00** |     **0.00** |  **199.2188** |        **-** |       **-** |  **307.99 KB** |
|       StartWithList |  1000 |  1,340.885 us |  13.3405 us |  12.4787 us |  1,337.502 us |   1.16 |     0.01 |  214.8438 |        - |       - |  332.15 KB |
| StartWithLinkedList |  1000 |  1,252.666 us |  26.5136 us |  30.5331 us |  1,245.025 us |   1.08 |     0.03 |  265.6250 |   1.9531 |       - |  409.66 KB |
|       AppendPrepend |  1000 |  1,431.723 us |   7.4256 us |   6.2007 us |  1,432.273 us |   1.23 |     0.01 |  322.2656 |        - |       - |  497.14 KB |
|                     |       |               |             |             |               |        |          |           |          |         |            |
|      **StartWithArray** | **10000** | **11,558.631 us** | **102.2574 us** |  **95.6516 us** | **11,566.695 us** |   **1.00** |     **0.00** | **1984.3750** |        **-** |       **-** | **3067.82 KB** |
|       StartWithList | 10000 | 23,047.888 us | 211.2504 us | 197.6038 us | 22,985.356 us |   1.99 |     0.02 | 2062.5000 |  31.2500 | 31.2500 | 3403.14 KB |
| StartWithLinkedList | 10000 | 13,543.742 us | 141.5279 us | 132.3853 us | 13,574.052 us |   1.17 |     0.01 | 1328.1250 | 343.7500 |       - | 4083.39 KB |
|       AppendPrepend | 10000 | 16,860.421 us | 333.0837 us | 518.5712 us | 16,816.951 us |   1.46 |     0.05 |  906.2500 | 437.5000 |       - |  4942.9 KB |


I guess without the lastest improvements for `ToObservable` the `AppendPrepend` test would score even better. 😏