### PR TITLE
4.x: Fix AppendPrepend disposing the main source on ILongRunningSchedulers

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/AppendPrepend.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/AppendPrepend.cs
@@ -308,8 +308,6 @@ namespace System.Reactive.Linq.ObservableImpl
                             break;
                         }
                     }
-
-                    base.Dispose();
                 }
             }
         }


### PR DESCRIPTION
In the original code, calling `base.Dispose` disposed the `_upstream` as well so when the `_source` is subscribed to, it is immediately disposed and may never run or items may never appear downstream due to a detached observer. 

The PR removes this call and is safe because:
- if `_continue` is a `ForwardOnCompleted`, that calls `base.Dispose()` anyway
- if `_continue` is a `SubscribeSafe`, that is okay as `_scheduledDisposable` is just a `BooleanDisposable` and no other resources have to be disposed.

The `AppendPrepend_SchedulerLongRunning` verifies this scenario.