### PR TITLE
Use Instance as the name for UWP to match public netstandard surface area

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Concurrency/NewThreadScheduler.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/NewThreadScheduler.cs
@@ -12,7 +12,7 @@ namespace System.Reactive.Concurrency
     /// </summary>
     public sealed class NewThreadScheduler : LocalScheduler, ISchedulerLongRunning, ISchedulerPeriodic
     {
-        internal static readonly Lazy<NewThreadScheduler> Instance = new Lazy<NewThreadScheduler>(() => new NewThreadScheduler());
+        private static readonly Lazy<NewThreadScheduler> Instance = new Lazy<NewThreadScheduler>(() => new NewThreadScheduler());
 
         private readonly Func<ThreadStart, Thread> _threadFactory;
 

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/TaskPoolScheduler.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/TaskPoolScheduler.cs
@@ -32,7 +32,7 @@ namespace System.Reactive.Concurrency
 
                 Disposable.SetSingle(ref _cancel, cancelable);
 
-                scheduler.taskFactory.StartNew(
+                scheduler._taskFactory.StartNew(
                     @thisObject =>
                     {
                         var @this = (ScheduledWorkItem<TState>)@thisObject;
@@ -102,7 +102,7 @@ namespace System.Reactive.Concurrency
                     this,
                     CancellationToken.None,
                     TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnRanToCompletion,
-                    scheduler.taskFactory.Scheduler);
+                    scheduler._taskFactory.Scheduler);
             }
 
             public void Dispose()
@@ -123,7 +123,7 @@ namespace System.Reactive.Concurrency
                 _state = state;
                 _action = action;
 
-                scheduler.taskFactory.StartNew(
+                scheduler._taskFactory.StartNew(
                     @thisObject =>
                     {
                         var @this = (LongScheduledWorkItem<TState>)thisObject;
@@ -147,8 +147,8 @@ namespace System.Reactive.Concurrency
             public bool IsDisposed => Disposable.GetIsDisposed(ref _cancel);
         }
 
-        private static readonly Lazy<TaskPoolScheduler> s_instance = new Lazy<TaskPoolScheduler>(() => new TaskPoolScheduler(new TaskFactory(TaskScheduler.Default)));
-        private readonly TaskFactory taskFactory;
+        private static readonly Lazy<TaskPoolScheduler> LazyInstance = new Lazy<TaskPoolScheduler>(() => new TaskPoolScheduler(new TaskFactory(TaskScheduler.Default)));
+        private readonly TaskFactory _taskFactory;
 
         /// <summary>
         /// Creates an object that schedules units of work using the provided <see cref="TaskFactory"/>.
@@ -157,13 +157,13 @@ namespace System.Reactive.Concurrency
         /// <exception cref="ArgumentNullException"><paramref name="taskFactory"/> is <c>null</c>.</exception>
         public TaskPoolScheduler(TaskFactory taskFactory)
         {
-            this.taskFactory = taskFactory ?? throw new ArgumentNullException(nameof(taskFactory));
+            _taskFactory = taskFactory ?? throw new ArgumentNullException(nameof(taskFactory));
         }
 
         /// <summary>
         /// Gets an instance of this scheduler that uses the default <see cref="TaskScheduler"/>.
         /// </summary>
-        public static TaskPoolScheduler Default => s_instance.Value;
+        public static TaskPoolScheduler Default => LazyInstance.Value;
 
         /// <summary>
         /// Schedules an action to be executed.
@@ -262,7 +262,7 @@ namespace System.Reactive.Concurrency
                 throw new ArgumentNullException(nameof(action));
             }
 
-            return new PeriodicallyScheduledWorkItem<TState>(state, period, action, taskFactory);
+            return new PeriodicallyScheduledWorkItem<TState>(state, period, action, _taskFactory);
         }
 
         private sealed class PeriodicallyScheduledWorkItem<TState> : IDisposable

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/ThreadPoolScheduler.Windows.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/ThreadPoolScheduler.Windows.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information. 
 
 #if WINDOWS
+using System.ComponentModel;
 using Windows.System.Threading;
 
 namespace System.Reactive.Concurrency
@@ -14,7 +15,7 @@ namespace System.Reactive.Concurrency
     [CLSCompliant(false)]
     public sealed class ThreadPoolScheduler : LocalScheduler, ISchedulerPeriodic
     {
-        private static Lazy<ThreadPoolScheduler> s_default = new Lazy<ThreadPoolScheduler>(() => new ThreadPoolScheduler());
+        private static readonly Lazy<ThreadPoolScheduler> LazyDefault = new Lazy<ThreadPoolScheduler>(() => new ThreadPoolScheduler());
 
         /// <summary>
         /// Constructs a ThreadPoolScheduler that schedules units of work on the Windows ThreadPool.
@@ -47,7 +48,14 @@ namespace System.Reactive.Concurrency
         /// <summary>
         /// Gets the singleton instance of the Windows Runtime thread pool scheduler.
         /// </summary>
-        public static ThreadPoolScheduler Default => s_default.Value;
+        [Obsolete("Use the Instance property", false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static ThreadPoolScheduler Default => LazyDefault.Value;
+
+        /// <summary>
+        /// Gets the singleton instance of the Windows Runtime thread pool scheduler.
+        /// </summary>
+        public static ThreadPoolScheduler Instance => LazyDefault.Value;
 
         /// <summary>
         /// Gets the priority at which work is scheduled.

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/ThreadPoolScheduler.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/ThreadPoolScheduler.cs
@@ -15,13 +15,13 @@ namespace System.Reactive.Concurrency
     /// <seealso cref="ThreadPoolScheduler.Instance">Singleton instance of this type exposed through this static property.</seealso>
     public sealed class ThreadPoolScheduler : LocalScheduler, ISchedulerLongRunning, ISchedulerPeriodic
     {
-        private static readonly Lazy<ThreadPoolScheduler> s_instance = new Lazy<ThreadPoolScheduler>(() => new ThreadPoolScheduler());
-        private static readonly Lazy<NewThreadScheduler> s_newBackgroundThread = new Lazy<NewThreadScheduler>(() => new NewThreadScheduler(action => new Thread(action) { IsBackground = true }));
+        private static readonly Lazy<ThreadPoolScheduler> LazyInstance = new Lazy<ThreadPoolScheduler>(() => new ThreadPoolScheduler());
+        private static readonly Lazy<NewThreadScheduler> LazyNewBackgroundThread = new Lazy<NewThreadScheduler>(() => new NewThreadScheduler(action => new Thread(action) { IsBackground = true }));
 
         /// <summary>
         /// Gets the singleton instance of the CLR thread pool scheduler.
         /// </summary>
-        public static ThreadPoolScheduler Instance => s_instance.Value;
+        public static ThreadPoolScheduler Instance => LazyInstance.Value;
 
         private ThreadPoolScheduler()
         {
@@ -99,7 +99,7 @@ namespace System.Reactive.Concurrency
                 throw new ArgumentNullException(nameof(action));
             }
 
-            return s_newBackgroundThread.Value.ScheduleLongRunning(state, action);
+            return LazyNewBackgroundThread.Value.ScheduleLongRunning(state, action);
         }
 
         /// <summary>

--- a/Rx.NET/Source/src/System.Reactive/Internal/CurrentPlatformEnlightenmentProvider.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/CurrentPlatformEnlightenmentProvider.cs
@@ -45,13 +45,8 @@ namespace System.Reactive.PlatformServices
             {
                 switch ((string)args[0])
                 {
-#if !WINDOWS && !NO_THREAD
                     case "ThreadPool":
                         return (T)(object)ThreadPoolScheduler.Instance;
-#elif WINDOWS
-                    case "ThreadPool":
-                        return (T)(object)ThreadPoolScheduler.Default;
-#endif
                     case "TaskPool":
                         return (T)(object)TaskPoolScheduler.Default;
                     case "NewThread":


### PR DESCRIPTION
Currently the `ThreadPoolScheduler` uses `Instance` on `netstandard` and `Default` on UWP. This will lead to missing member exceptions if someone uses it from netstandard but runs on UWP since it won't be there.

This PR adds Instance to UWP and deprecates Default on UWP.