### PR TITLE
4.x: ComparisonBenchmarks solution

### DIFF
--- a/Rx.NET/ComparisonBenchmarks/ComparisonBenchmarks.sln
+++ b/Rx.NET/ComparisonBenchmarks/ComparisonBenchmarks.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27703.2035
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ComparisonBenchmarks", "ComparisonBenchmarks\ComparisonBenchmarks.csproj", "{50DDB92A-793F-43DF-A84E-1759A235A15D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{50DDB92A-793F-43DF-A84E-1759A235A15D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{50DDB92A-793F-43DF-A84E-1759A235A15D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{50DDB92A-793F-43DF-A84E-1759A235A15D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{50DDB92A-793F-43DF-A84E-1759A235A15D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {643F4DF5-5DD7-4AFB-A95E-29414DDA9379}
+	EndGlobalSection
+EndGlobal

--- a/Rx.NET/ComparisonBenchmarks/ComparisonBenchmarks/ComparisonBenchmarks.csproj
+++ b/Rx.NET/ComparisonBenchmarks/ComparisonBenchmarks/ComparisonBenchmarks.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
+    <PackageReference Include="System.Reactive" Version="4.1.0-preview.215" />
+  </ItemGroup>
+
+</Project>

--- a/Rx.NET/ComparisonBenchmarks/ComparisonBenchmarks/Program.cs
+++ b/Rx.NET/ComparisonBenchmarks/ComparisonBenchmarks/Program.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using BenchmarkDotNet.Running;
+
+namespace ComparisonBenchmarks
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            var switcher = new BenchmarkSwitcher(new[] {
+                typeof(RangeBenchmark)
+            });
+
+            switcher.Run();
+            Console.ReadLine();
+        }
+    }
+}

--- a/Rx.NET/ComparisonBenchmarks/ComparisonBenchmarks/RangeBenchmark.cs
+++ b/Rx.NET/ComparisonBenchmarks/ComparisonBenchmarks/RangeBenchmark.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reactive.Linq;
+using System.Threading;
+using BenchmarkDotNet.Attributes;
+
+namespace ComparisonBenchmarks
+{
+    [MemoryDiagnoser]
+    public class RangeBenchmark
+    {
+        [Params(1, 10, 100, 1000, 10000, 100000, 1000000)]
+        public int N;
+        private int _store;
+
+        [Benchmark]
+        public void Range()
+        {
+            Observable.Range(1, N).Subscribe(v => Volatile.Write(ref _store, v));
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a standalone netcoreapp2.1 solution with BenchmarkDotnet and Rx.NET as a NuGet dependency and should enable comparative benchmark runs via changing the dependency on the actual Rx.NET version.

Example comparative benchmark for `Range`:

```
BenchmarkDotNet=v0.10.14, OS=Windows 10.0.17134
Intel Core i7-4790 CPU 3.60GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
Frequency=3513588 Hz, Resolution=284.6094 ns, Timer=TSC
.NET Core SDK=2.1.300
  [Host]     : .NET Core 2.1.0 (CoreCLR 4.6.26515.07, CoreFX 4.6.26515.06), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.0 (CoreCLR 4.6.26515.07, CoreFX 4.6.26515.06), 64bit RyuJIT
```

#### Rx.NET 3.1.1

 Method |       N |           Mean |       Error |      StdDev |      Gen 0 |    Allocated |
------- |--------:|---------------:|------------:|------------:|-----------:|-------------:|
  Range |       1 |       1.391 us |   0.0059 us |   0.0052 us |     0.4406 |      1.81 KB |
  Range |      10 |       4.460 us |   0.0136 us |   0.0127 us |     1.1368 |      4.67 KB |
  Range |     100 |      34.751 us |   0.1546 us |   0.1446 us |     7.7515 |     31.86 KB |
  Range |    1000 |     336.790 us |   1.0798 us |   1.0100 us |    73.2422 |    300.08 KB |
  Range |   10000 |   3,470.563 us |   8.8414 us |   8.2702 us |   726.5625 |   2980.11 KB |
  Range |  100000 |  34,452.518 us | 169.7244 us | 150.4562 us |  7250.0000 |  29785.81 KB |
  Range | 1000000 | 341,178.302 us | 563.2819 us | 439.7734 us | 72687.5000 | 297838.53 KB |

#### Rx.NET 4.0.0

 Method |       N |           Mean |       Error |      StdDev |      Gen 0 |   Allocated |
------- |--------:|---------------:|------------:|------------:|-----------:|------------:|
  Range |       1 |       1.115 us |   0.0073 us |   0.0068 us |     0.4082 |     1.68 KB |
  Range |      10 |       4.127 us |   0.0172 us |   0.0152 us |     1.1063 |     4.54 KB |
  Range |     100 |      34.334 us |   0.1415 us |   0.1324 us |     7.6904 |    31.73 KB |
  Range |    1000 |     342.211 us |   0.5639 us |   0.4998 us |    72.7539 |   299.95 KB |
  Range |   10000 |   3,411.588 us |  10.3184 us |   9.6518 us |   726.5625 |  2979.98 KB |
  Range |  100000 |  33,460.104 us | 203.2846 us | 190.1526 us |  7250.0000 | 29785.68 KB |
  Range | 1000000 | 336,870.757 us | 772.5311 us | 722.6260 us | 72687.5000 | 297838.4 KB |

#### Rx.NET 4.1.0-preview.215

 Method |       N |             Mean |          Error |         StdDev |      Gen 0 |  Allocated |
------- |--------:|-----------------:|---------------:|---------------:|-----------:|-----------:|
  Range |       1 |         648.9 ns |       3.667 ns |       3.251 ns |     0.1392 |      584 B |
  Range |      10 |       2,209.8 ns |       7.703 ns |       6.828 ns |     0.2747 |     1160 B |
  Range |     100 |      18,301.3 ns |      96.817 ns |      90.563 ns |     1.6479 |     6920 B |
  Range |    1000 |     176,247.7 ns |     499.962 ns |     467.664 ns |    15.3809 |    64520 B |
  Range |   10000 |   1,794,827.6 ns |   7,230.111 ns |   6,763.050 ns |   152.3438 |   640520 B |
  Range |  100000 |  17,042,315.4 ns |  96,952.856 ns |  90,689.753 ns |  1500.0000 |  6400520 B |
  Range | 1000000 | 174,388,878.4 ns | 548,979.219 ns | 486,655.731 ns | 15250.0000 | 64000520 B |
