### PR TITLE
Enable switching Rx versions for benchmarks.

### DIFF
--- a/Rx.NET/Source/System.Reactive.sln
+++ b/Rx.NET/Source/System.Reactive.sln
@@ -56,7 +56,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Reactive.Interfaces"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tests.System.Reactive.ApiApprovals", "tests\Tests.System.Reactive.ApiApprovals\Tests.System.Reactive.ApiApprovals.csproj", "{01CCDA6D-4D00-4DF2-82B0-359FD5E0CDC6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Benchmarks.System.Reactive", "benchmarks\Benchmarks.System.Reactive\Benchmarks.System.Reactive.csproj", "{5C7906F6-232E-455C-9269-68EF84F393C9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Benchmarks.System.Reactive", "benchmarks\Benchmarks.System.Reactive\Benchmarks.System.Reactive.csproj", "{5C7906F6-232E-455C-9269-68EF84F393C9}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Benchmarks", "Benchmarks", "{C8E480ED-B592-4341-A0C9-183E822EB6B9}"
 EndProject
@@ -334,22 +334,22 @@ Global
 		{01CCDA6D-4D00-4DF2-82B0-359FD5E0CDC6}.Release|x64.Build.0 = Release|Any CPU
 		{01CCDA6D-4D00-4DF2-82B0-359FD5E0CDC6}.Release|x86.ActiveCfg = Release|Any CPU
 		{01CCDA6D-4D00-4DF2-82B0-359FD5E0CDC6}.Release|x86.Build.0 = Release|Any CPU
-		{5C7906F6-232E-455C-9269-68EF84F393C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5C7906F6-232E-455C-9269-68EF84F393C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5C7906F6-232E-455C-9269-68EF84F393C9}.Debug|ARM.ActiveCfg = Debug|Any CPU
-		{5C7906F6-232E-455C-9269-68EF84F393C9}.Debug|ARM.Build.0 = Debug|Any CPU
-		{5C7906F6-232E-455C-9269-68EF84F393C9}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{5C7906F6-232E-455C-9269-68EF84F393C9}.Debug|x64.Build.0 = Debug|Any CPU
-		{5C7906F6-232E-455C-9269-68EF84F393C9}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{5C7906F6-232E-455C-9269-68EF84F393C9}.Debug|x86.Build.0 = Debug|Any CPU
-		{5C7906F6-232E-455C-9269-68EF84F393C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5C7906F6-232E-455C-9269-68EF84F393C9}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5C7906F6-232E-455C-9269-68EF84F393C9}.Release|ARM.ActiveCfg = Release|Any CPU
-		{5C7906F6-232E-455C-9269-68EF84F393C9}.Release|ARM.Build.0 = Release|Any CPU
-		{5C7906F6-232E-455C-9269-68EF84F393C9}.Release|x64.ActiveCfg = Release|Any CPU
-		{5C7906F6-232E-455C-9269-68EF84F393C9}.Release|x64.Build.0 = Release|Any CPU
-		{5C7906F6-232E-455C-9269-68EF84F393C9}.Release|x86.ActiveCfg = Release|Any CPU
-		{5C7906F6-232E-455C-9269-68EF84F393C9}.Release|x86.Build.0 = Release|Any CPU
+		{5C7906F6-232E-455C-9269-68EF84F393C9}.Debug|Any CPU.ActiveCfg = Current Sources|Any CPU
+		{5C7906F6-232E-455C-9269-68EF84F393C9}.Debug|Any CPU.Build.0 = Current Sources|Any CPU
+		{5C7906F6-232E-455C-9269-68EF84F393C9}.Debug|ARM.ActiveCfg = Rx.net 4.0|Any CPU
+		{5C7906F6-232E-455C-9269-68EF84F393C9}.Debug|ARM.Build.0 = Rx.net 4.0|Any CPU
+		{5C7906F6-232E-455C-9269-68EF84F393C9}.Debug|x64.ActiveCfg = Rx.net 4.0|Any CPU
+		{5C7906F6-232E-455C-9269-68EF84F393C9}.Debug|x64.Build.0 = Rx.net 4.0|Any CPU
+		{5C7906F6-232E-455C-9269-68EF84F393C9}.Debug|x86.ActiveCfg = Rx.net 4.0|Any CPU
+		{5C7906F6-232E-455C-9269-68EF84F393C9}.Debug|x86.Build.0 = Rx.net 4.0|Any CPU
+		{5C7906F6-232E-455C-9269-68EF84F393C9}.Release|Any CPU.ActiveCfg = Rx.net 4.0|Any CPU
+		{5C7906F6-232E-455C-9269-68EF84F393C9}.Release|Any CPU.Build.0 = Rx.net 4.0|Any CPU
+		{5C7906F6-232E-455C-9269-68EF84F393C9}.Release|ARM.ActiveCfg = Rx.net 4.0|Any CPU
+		{5C7906F6-232E-455C-9269-68EF84F393C9}.Release|ARM.Build.0 = Rx.net 4.0|Any CPU
+		{5C7906F6-232E-455C-9269-68EF84F393C9}.Release|x64.ActiveCfg = Rx.net 4.0|Any CPU
+		{5C7906F6-232E-455C-9269-68EF84F393C9}.Release|x64.Build.0 = Rx.net 4.0|Any CPU
+		{5C7906F6-232E-455C-9269-68EF84F393C9}.Release|x86.ActiveCfg = Rx.net 4.0|Any CPU
+		{5C7906F6-232E-455C-9269-68EF84F393C9}.Release|x86.Build.0 = Rx.net 4.0|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/AppendPrependBenchmark.cs
+++ b/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/AppendPrependBenchmark.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#if (CURRENT)
 using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
@@ -85,3 +86,4 @@ namespace Benchmarks.System.Reactive
         }
     }
 }
+#endif

--- a/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/Benchmarks.System.Reactive.csproj
+++ b/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/Benchmarks.System.Reactive.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net46</TargetFramework>
+    <Optimize>true</Optimize>
     <Configurations>Current Sources;Rx.net 3.1.1;Rx.net 4.0</Configurations>
   </PropertyGroup>
 

--- a/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/Benchmarks.System.Reactive.csproj
+++ b/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/Benchmarks.System.Reactive.csproj
@@ -3,10 +3,31 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net46</TargetFramework>
+    <Configurations>Current Sources;Rx.net 3.1.1;Rx.net 4.0</Configurations>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Rx.net 3.1.1|AnyCPU'">
+    <DefineConstants>$(DefineConstants);RX3_1_1</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Rx.net 4.0|AnyCPU'">
+    <DefineConstants>$(DefineConstants);RX4_0</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Current Sources|AnyCPU'">
+    <DefineConstants>$(DefineConstants);CURRENT</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(Configuration)|$(Platform)'=='Rx.net 3.1.1|AnyCPU'">
+    <PackageReference Include="System.Reactive" Version="3.1.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(Configuration)|$(Platform)'=='Rx.net 4.0|AnyCPU'">
+    <PackageReference Include="System.Reactive" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/Program.cs
+++ b/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/Program.cs
@@ -1,8 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Reactive.Linq;
 using BenchmarkDotNet.Running;
 
 namespace Benchmarks.System.Reactive
@@ -11,6 +12,8 @@ namespace Benchmarks.System.Reactive
     {
         private static void Main()
         {
+            Console.WriteLine("Effective Rx-version: " + typeof(Observable).Assembly.GetName().Version);
+
             var switcher = new BenchmarkSwitcher(new[] {
                 typeof(ZipBenchmark),
                 typeof(CombineLatestBenchmark),
@@ -18,8 +21,11 @@ namespace Benchmarks.System.Reactive
                 typeof(BufferCountBenchmark),
                 typeof(RangeBenchmark),
                 typeof(ToObservableBenchmark),
-                typeof(RepeatBenchmark),
-                typeof(AppendPrependBenchmark)
+                typeof(RepeatBenchmark)
+
+#if (CURRENT)
+                ,typeof(AppendPrependBenchmark)
+#endif
             });
 
             switcher.Run();


### PR DESCRIPTION
 This PR makes the referenced Rx-version switchable. It works by force-overriding the used Rx-version (if taken from nuget). It can be combined with the standalone solution from https://github.com/dotnet/reactive/pull/730, the solution should then have configurations that match the project configurations (current, Rx3.1.1, etc), so the config can easily be switched in the VS dropdown.