### PR TITLE
Ix Reference Assemblies

### DIFF
--- a/.vsts.ix-shared.yml
+++ b/.vsts.ix-shared.yml
@@ -16,6 +16,13 @@ steps:
 
 - task: DotNetCoreCLI@2
   inputs:
+    command: build
+    projects: Ix.NET/Source/refs/**/System.Interactive*.csproj
+    arguments: -c $(BuildConfiguration)   
+  displayName: Build reference assemblies
+
+- task: DotNetCoreCLI@2
+  inputs:
     command: pack
     packagesToPack: Ix.NET/Source/**/System.Interactive*.csproj;!Ix.NET/Source/**/*.Tests*.csproj
     configuration: $(BuildConfiguration)

--- a/Ix.NET/Source/Directory.build.props
+++ b/Ix.NET/Source/Directory.build.props
@@ -12,7 +12,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>    
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)ReactiveX.snk</AssemblyOriginatorKeyFile>
-    <NoWarn>$(NoWarn);1701;1702;CS1591</NoWarn>
+    <NoWarn>$(NoWarn);1701;1702;CS1591;NU5105</NoWarn>
     <DefaultLanguage>en-US</DefaultLanguage>
     <IsTestProject>$(MSBuildProjectName.Contains('Test'))</IsTestProject>
     <DebugType>embedded</DebugType>

--- a/Ix.NET/Source/Ix.NET.sln
+++ b/Ix.NET/Source/Ix.NET.sln
@@ -25,6 +25,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Interactive.Tests", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Interactive.Async.Tests", "System.Interactive.Async.Tests\System.Interactive.Async.Tests.csproj", "{172BD8C4-5C3E-4928-9D3F-746CF336FFEC}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Refs", "Refs", "{A3D72E6E-4ADA-42E0-8B2A-055B1F244281}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Interactive", "refs\System.Interactive\System.Interactive.csproj", "{2EC0C302-B029-4DDB-AC91-000BF11006AD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,6 +59,10 @@ Global
 		{172BD8C4-5C3E-4928-9D3F-746CF336FFEC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{172BD8C4-5C3E-4928-9D3F-746CF336FFEC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{172BD8C4-5C3E-4928-9D3F-746CF336FFEC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2EC0C302-B029-4DDB-AC91-000BF11006AD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2EC0C302-B029-4DDB-AC91-000BF11006AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2EC0C302-B029-4DDB-AC91-000BF11006AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2EC0C302-B029-4DDB-AC91-000BF11006AD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -62,6 +70,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{AFD2E6EC-C5B0-4276-A14A-467D786D0DDA} = {87534290-A7A6-47A4-9A3A-D0D21A9AD1D4}
 		{172BD8C4-5C3E-4928-9D3F-746CF336FFEC} = {87534290-A7A6-47A4-9A3A-D0D21A9AD1D4}
+		{2EC0C302-B029-4DDB-AC91-000BF11006AD} = {A3D72E6E-4ADA-42E0-8B2A-055B1F244281}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9B5F6126-CBBA-4C3A-A3BB-26AFE56DABEC}

--- a/Ix.NET/Source/Ix.NET.sln
+++ b/Ix.NET/Source/Ix.NET.sln
@@ -7,6 +7,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{87534290
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B733D97A-F1ED-4FC3-BF8E-9AC47A89DE96}"
 	ProjectSection(SolutionItems) = preProject
+		..\..\.vsts.ix-ci.yml = ..\..\.vsts.ix-ci.yml
+		..\..\.vsts.ix-pr.yml = ..\..\.vsts.ix-pr.yml
+		..\..\.vsts.ix-shared.yml = ..\..\.vsts.ix-shared.yml
 		CodeCoverage.runsettings = CodeCoverage.runsettings
 		Directory.build.props = Directory.build.props
 		Directory.build.targets = Directory.build.targets

--- a/Ix.NET/Source/System.Interactive/Skip.cs
+++ b/Ix.NET/Source/System.Interactive/Skip.cs
@@ -8,6 +8,7 @@ namespace System.Linq
 {
     public static partial class EnumerableEx
     {
+#if !(REF_ASSM && NETCOREAPP2_0)
         /// <summary>
         ///     Bypasses a specified number of contiguous elements from the end of the sequence and returns the remaining elements.
         /// </summary>
@@ -32,6 +33,7 @@ namespace System.Linq
 
             return source.SkipLast_(count);
         }
+#endif
 
         private static IEnumerable<TSource> SkipLast_<TSource>(this IEnumerable<TSource> source, int count)
         {

--- a/Ix.NET/Source/System.Interactive/System.Interactive.csproj
+++ b/Ix.NET/Source/System.Interactive/System.Interactive.csproj
@@ -9,8 +9,26 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\refs\System.Interactive\System.Interactive.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    <!--<ProjectReference Include="..\refs\System.Interactive\System.Interactive.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />-->
     <EmbeddedResource Include="Properties\System.Interactive.rd.xml" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);GetRefs</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
+
+  <Target Name="GetRefs">
+
+    <MSBuild Condition="'$(IncludeBuildOutput)' == 'true'" Projects="..\refs\System.Interactive\System.Interactive.csproj" Targets="_GetReferenceAssemblies" Properties="TargetFramework=$(TargetFramework);">
+
+      <Output TaskParameter="TargetOutputs" ItemName="_refAssms" />
+    </MSBuild>
+
+
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="@(_refAssms)" PackagePath="ref/$(TargetFramework)" />
+    </ItemGroup>
+  </Target>
   
 </Project>

--- a/Ix.NET/Source/System.Interactive/System.Interactive.csproj
+++ b/Ix.NET/Source/System.Interactive/System.Interactive.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!--<ProjectReference Include="..\refs\System.Interactive\System.Interactive.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />-->
     <EmbeddedResource Include="Properties\System.Interactive.rd.xml" />
   </ItemGroup>
 
@@ -20,15 +19,30 @@
 
   <Target Name="GetRefs">
 
-    <MSBuild Condition="'$(IncludeBuildOutput)' == 'true'" Projects="..\refs\System.Interactive\System.Interactive.csproj" Targets="_GetReferenceAssemblies" Properties="TargetFramework=$(TargetFramework);">
+    <MSBuild Projects="..\refs\System.Interactive\System.Interactive.csproj" 
+             Targets="_GetReferenceAssemblies" 
+             Properties="TargetFramework=$(TargetFramework)">
 
       <Output TaskParameter="TargetOutputs" ItemName="_refAssms" />
     </MSBuild>
 
-
     <ItemGroup>
       <TfmSpecificPackageFile Include="@(_refAssms)" PackagePath="ref/$(TargetFramework)" />
     </ItemGroup>
+  </Target>
+
+  <Target Name="GetRefsWithoutLib" BeforeTargets="_GetPackageFiles">
+    <MSBuild Projects="..\refs\System.Interactive\System.Interactive.csproj"
+             Targets="_GetReferenceAssemblies"
+             Properties="TargetFramework=netcoreapp2.0">
+
+      <Output TaskParameter="TargetOutputs" ItemName="_refAssms20" />
+    </MSBuild>
+
+    <ItemGroup>
+      <None Include="@(_refAssms20)" PackagePath="ref/netcoreapp2.0" Pack="true" />
+    </ItemGroup>
+
   </Target>
   
 </Project>

--- a/Ix.NET/Source/System.Interactive/Take.cs
+++ b/Ix.NET/Source/System.Interactive/Take.cs
@@ -8,6 +8,7 @@ namespace System.Linq
 {
     public static partial class EnumerableEx
     {
+#if !(REF_ASSM && NETCOREAPP2_0)
         /// <summary>
         ///     Returns a specified number of contiguous elements from the end of the sequence.
         /// </summary>
@@ -29,6 +30,7 @@ namespace System.Linq
 
             return source.TakeLast_(count);
         }
+#endif
 
         private static IEnumerable<TSource> TakeLast_<TSource>(this IEnumerable<TSource> source, int count)
         {

--- a/Ix.NET/Source/refs/System.Interactive/System.Interactive.csproj
+++ b/Ix.NET/Source/refs/System.Interactive/System.Interactive.csproj
@@ -4,7 +4,7 @@
     <Description>Interactive Extensions Main Library used to express queries over enumerable sequences.</Description>
     <AssemblyTitle>Interactive Extensions - Main Library</AssemblyTitle>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>net45;netstandard1.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.0;netstandard2.0;netcoreapp2.0</TargetFrameworks>
     <PackageTags>Ix;Interactive;Extensions;Enumerable</PackageTags>
     <DefineConstants>$(DefineConstants);REF_ASSM</DefineConstants>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>

--- a/Ix.NET/Source/refs/System.Interactive/System.Interactive.csproj
+++ b/Ix.NET/Source/refs/System.Interactive/System.Interactive.csproj
@@ -6,11 +6,16 @@
     <Authors>Microsoft</Authors>
     <TargetFrameworks>net45;netstandard1.0;netstandard2.0</TargetFrameworks>
     <PackageTags>Ix;Interactive;Extensions;Enumerable</PackageTags>
+    <DefineConstants>$(DefineConstants);REF_ASSM</DefineConstants>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    <Deterministic>true</Deterministic>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\refs\System.Interactive\System.Interactive.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
-    <EmbeddedResource Include="Properties\System.Interactive.rd.xml" />
+
+    <Compile Include="..\..\System.Interactive\**\*.cs" Exclude="..\..\System.Interactive\obj\**" />
   </ItemGroup>
-  
+
+
 </Project>

--- a/Ix.NET/Source/refs/System.Interactive/System.Interactive.csproj
+++ b/Ix.NET/Source/refs/System.Interactive/System.Interactive.csproj
@@ -13,8 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\refs\System.Interactive\System.Interactive.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
-
     <Compile Include="..\..\System.Interactive\**\*.cs" Exclude="..\..\System.Interactive\obj\**" />
   </ItemGroup>
 

--- a/Ix.NET/Source/refs/System.Interactive/System.Interactive.csproj
+++ b/Ix.NET/Source/refs/System.Interactive/System.Interactive.csproj
@@ -9,6 +9,7 @@
     <DefineConstants>$(DefineConstants);REF_ASSM</DefineConstants>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <Deterministic>true</Deterministic>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Ix.NET/Source/refs/System.Interactive/System.Interactive.csproj
+++ b/Ix.NET/Source/refs/System.Interactive/System.Interactive.csproj
@@ -17,5 +17,11 @@
     <Compile Include="..\..\System.Interactive\**\*.cs" Exclude="..\..\System.Interactive\obj\**" />
   </ItemGroup>
 
+  <Target Name="_GetReferenceAssemblies" DependsOnTargets="Build" Returns="@(ReferenceAssembliesOutput)">
+    <ItemGroup>
+      <ReferenceAssembliesOutput Include="@(IntermediateRefAssembly->'%(FullPath)')" />
+      <ReferenceAssembliesOutput Include="@(DocumentationProjectOutputGroupOutput->'%(FullPath)')" />
+    </ItemGroup>
+  </Target>
 
 </Project>


### PR DESCRIPTION
This PR adds reference assemblies to Ix (not async).

This enables us to expose a lesser surface area to some tfm's, like `netcoreapp2.0` where they already have an `Enumerable.Take`.

The lib has the full impl, so people using it from a netstandard library won't be broken at runtime.