### PR TITLE
4.x: Fix long sequence ObserveOn StackOverflowException upon Dispose

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Internal/ScheduledObserver.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/ScheduledObserver.cs
@@ -536,7 +536,10 @@ namespace System.Reactive
 
             if (Interlocked.Decrement(ref _wip) != 0)
             {
-                return recursiveScheduler.Schedule(this, DRAIN_SHORT_RUNNING);
+                // Don't return the disposable of Schedule() because that may chain together
+                // a long string of ScheduledItems causing StackOverflowException upon Dispose()
+                var d = recursiveScheduler.Schedule(this, DRAIN_SHORT_RUNNING);
+                Disposable.TrySetMultiple(ref _task, d);
             }
             return Disposable.Empty;
         }

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ObserveOnTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ObserveOnTest.cs
@@ -645,6 +645,19 @@ namespace ReactiveTests.Tests
             );
         }
 
+        [Fact]
+        public void ObserveOn_EventLoop_Long()
+        {
+            var _scheduler1 = new EventLoopScheduler();
+            var N = 1_000_000;
+
+            var cde = new CountdownEvent(1);
+
+            Observable.Range(1, N).ObserveOn(_scheduler1)
+                .Subscribe(v => { }, () => cde.Signal());
+
+            Assert.True(cde.Wait(5000), "Timeout!");
+        }
     }
 
     internal class MyCtx : SynchronizationContext


### PR DESCRIPTION
This PR fixes the `StackOverflowException` when a long running `ObserveOn` (> 100.000 items) gets disposed due to the `ScheduledItem`s linked together when using the recursive scheduler.

The fix is to track the next recursive task's disposable directly and not allow the chaining to happen. For reference, this is the same effect that had to be considered in the improved `Range` and `ToObservable` implementations.