### PR TITLE
Ix: Add Benchmark subproject

### DIFF
--- a/Ix.NET/Source/Benchmarks.System.Interactive/BenchmarkInterop.cs
+++ b/Ix.NET/Source/Benchmarks.System.Interactive/BenchmarkInterop.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/Ix.NET/Source/Benchmarks.System.Interactive/BenchmarkInterop.cs
+++ b/Ix.NET/Source/Benchmarks.System.Interactive/BenchmarkInterop.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Benchmarks.System.Interactive
+{
+    /// <summary>
+    /// Some helper extension methods to allow the same pattern to be used
+    /// in both Rx and Ix benchmarks
+    /// </summary>
+    internal static class BenchmarkInterop
+    {
+        internal static void Subscribe<T>(this IEnumerable<T> enumerable, Action<T> onNext)
+        {
+            foreach (var v in enumerable)
+            {
+                onNext(v);
+            }
+        }
+
+        internal static void Subscribe<T>(this IEnumerable<T> enumerable, Action<T> onNext, Action onCompleted)
+        {
+            foreach (var v in enumerable)
+            {
+                onNext(v);
+            }
+            onCompleted();
+        }
+    }
+}

--- a/Ix.NET/Source/Benchmarks.System.Interactive/Benchmarks.System.Interactive.csproj
+++ b/Ix.NET/Source/Benchmarks.System.Interactive/Benchmarks.System.Interactive.csproj
@@ -3,11 +3,32 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <Optimize>true</Optimize>
+    <Configurations>Current Sources;Ix.net 3.1.1;Ix.net 3.2</Configurations>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ix.net 3.1.1|AnyCPU'">
+    <DefineConstants>$(DefineConstants);IX3_1_1</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ix.net 3.2|AnyCPU'">
+    <DefineConstants>$(DefineConstants);IX3_2</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Current Sources|AnyCPU'">
+    <DefineConstants>$(DefineConstants);CURRENT</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(Configuration)|$(Platform)'=='Ix.net 3.1.1|AnyCPU'">
+    <PackageReference Include="System.Interactive" Version="3.1.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(Configuration)|$(Platform)'=='Ix.net 3.2|AnyCPU'">
+    <PackageReference Include="System.Interactive" Version="3.2.0-preview.635" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Ix.NET/Source/Benchmarks.System.Interactive/Benchmarks.System.Interactive.csproj
+++ b/Ix.NET/Source/Benchmarks.System.Interactive/Benchmarks.System.Interactive.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\System.Interactive.Tests\System.Interactive.Tests.csproj" />
+  </ItemGroup>
+</Project>

--- a/Ix.NET/Source/Benchmarks.System.Interactive/BufferCountBenchmark.cs
+++ b/Ix.NET/Source/Benchmarks.System.Interactive/BufferCountBenchmark.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using BenchmarkDotNet.Attributes;
+
+namespace Benchmarks.System.Interactive
+{
+    [MemoryDiagnoser]
+    public class BufferCountBenchmark
+    {
+        private IList<int> _store;
+
+        [Benchmark]
+        public void Exact()
+        {
+            Enumerable.Range(1, 1000)
+                .Buffer(1)
+                .Subscribe(v => Volatile.Write(ref _store, v));
+        }
+
+        [Benchmark]
+        public void Skip()
+        {
+            Enumerable.Range(1, 1000)
+                .Buffer(1, 2)
+                .Subscribe(v => Volatile.Write(ref _store, v));
+        }
+
+        [Benchmark]
+        public void Overlap()
+        {
+            Enumerable.Range(1, 1000)
+                .Buffer(2, 1)
+                .Subscribe(v => Volatile.Write(ref _store, v));
+        }
+    }
+}

--- a/Ix.NET/Source/Benchmarks.System.Interactive/Program.cs
+++ b/Ix.NET/Source/Benchmarks.System.Interactive/Program.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using BenchmarkDotNet.Running;
+
+namespace Benchmarks.System.Interactive
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Effective Ix-version: " + typeof(EnumerableEx).Assembly.GetName().Version);
+
+            var switcher = new BenchmarkSwitcher(new[] {
+                typeof(BufferCountBenchmark),
+            });
+
+            switcher.Run();
+            Console.ReadLine();
+        }
+    }
+}

--- a/Ix.NET/Source/Benchmarks.System.Interactive/Program.cs
+++ b/Ix.NET/Source/Benchmarks.System.Interactive/Program.cs
@@ -14,6 +14,8 @@ namespace Benchmarks.System.Interactive
         {
             Console.WriteLine("Effective Ix-version: " + typeof(EnumerableEx).Assembly.GetName().Version);
 
+            //Available compiler directives: IX3_1_1, IX3_2, CURRENT.
+
             var switcher = new BenchmarkSwitcher(new[] {
                 typeof(BufferCountBenchmark),
             });

--- a/Ix.NET/Source/Ix.NET.sln
+++ b/Ix.NET/Source/Ix.NET.sln
@@ -37,6 +37,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Interactive", "refs\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Interactive.Providers", "refs\System.Interactive.Providers\System.Interactive.Providers.csproj", "{5DF341BE-B369-4250-AFD4-604DE8C95E45}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Benchmarks.System.Interactive", "Benchmarks.System.Interactive\Benchmarks.System.Interactive.csproj", "{3285529A-8227-4D40-B524-1A1F919F0E7B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -75,6 +77,10 @@ Global
 		{5DF341BE-B369-4250-AFD4-604DE8C95E45}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5DF341BE-B369-4250-AFD4-604DE8C95E45}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5DF341BE-B369-4250-AFD4-604DE8C95E45}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3285529A-8227-4D40-B524-1A1F919F0E7B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3285529A-8227-4D40-B524-1A1F919F0E7B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3285529A-8227-4D40-B524-1A1F919F0E7B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3285529A-8227-4D40-B524-1A1F919F0E7B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Ix.NET/Source/Ix.NET.sln
+++ b/Ix.NET/Source/Ix.NET.sln
@@ -37,7 +37,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Interactive", "refs\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Interactive.Providers", "refs\System.Interactive.Providers\System.Interactive.Providers.csproj", "{5DF341BE-B369-4250-AFD4-604DE8C95E45}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Benchmarks.System.Interactive", "Benchmarks.System.Interactive\Benchmarks.System.Interactive.csproj", "{3285529A-8227-4D40-B524-1A1F919F0E7B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Benchmarks.System.Interactive", "Benchmarks.System.Interactive\Benchmarks.System.Interactive.csproj", "{3285529A-8227-4D40-B524-1A1F919F0E7B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -77,10 +77,10 @@ Global
 		{5DF341BE-B369-4250-AFD4-604DE8C95E45}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5DF341BE-B369-4250-AFD4-604DE8C95E45}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5DF341BE-B369-4250-AFD4-604DE8C95E45}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3285529A-8227-4D40-B524-1A1F919F0E7B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3285529A-8227-4D40-B524-1A1F919F0E7B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3285529A-8227-4D40-B524-1A1F919F0E7B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3285529A-8227-4D40-B524-1A1F919F0E7B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3285529A-8227-4D40-B524-1A1F919F0E7B}.Debug|Any CPU.ActiveCfg = Current Sources|Any CPU
+		{3285529A-8227-4D40-B524-1A1F919F0E7B}.Debug|Any CPU.Build.0 = Current Sources|Any CPU
+		{3285529A-8227-4D40-B524-1A1F919F0E7B}.Release|Any CPU.ActiveCfg = Current Sources|Any CPU
+		{3285529A-8227-4D40-B524-1A1F919F0E7B}.Release|Any CPU.Build.0 = Current Sources|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This PR adds a subjproject to Ix.NET that allows running BenchmarkDotNet and enables validation for future improvements (for example, `EnumerableEx.Buffer` could be improved similarly to `Observable.Buffer`).

I've tried to add the configuration mechanism to allow comparing Ix 3.1.1 and the current sources but it didn't work. The configuration always reset to "Release" and running the program resulted in an unknown configuration error.