### PR TITLE
Ix: Improve the performance of Buffer exact/skip mode

### DIFF
--- a/Ix.NET/Source/Benchmarks.System.Interactive/BufferCountBenchmark.cs
+++ b/Ix.NET/Source/Benchmarks.System.Interactive/BufferCountBenchmark.cs
@@ -13,12 +13,14 @@ namespace Benchmarks.System.Interactive
     [MemoryDiagnoser]
     public class BufferCountBenchmark
     {
+        [Params(1, 10, 100, 1000, 10000, 100000, 1000000)]
+        public int N;
         private IList<int> _store;
 
         [Benchmark]
         public void Exact()
         {
-            Enumerable.Range(1, 1000)
+            Enumerable.Range(1, N)
                 .Buffer(1)
                 .Subscribe(v => Volatile.Write(ref _store, v));
         }
@@ -26,7 +28,7 @@ namespace Benchmarks.System.Interactive
         [Benchmark]
         public void Skip()
         {
-            Enumerable.Range(1, 1000)
+            Enumerable.Range(1, N)
                 .Buffer(1, 2)
                 .Subscribe(v => Volatile.Write(ref _store, v));
         }
@@ -34,7 +36,7 @@ namespace Benchmarks.System.Interactive
         [Benchmark]
         public void Overlap()
         {
-            Enumerable.Range(1, 1000)
+            Enumerable.Range(1, N)
                 .Buffer(2, 1)
                 .Subscribe(v => Volatile.Write(ref _store, v));
         }


### PR DESCRIPTION
This PR improves the performance of the exact/skipping Ix `Buffer` operator by not using a queue just for a single buffer.

Comparison:

```
BenchmarkDotNet=v0.10.14, OS=Windows 7 SP1 (6.1.7601.0)
Intel Core i7-4770K CPU 3.50GHz (Haswell), 1 CPU, 8 logical and 4 physical cores

Frequency=3418037 Hz, Resolution=292.5656 ns, Timer=TSC
.NET Core SDK=2.1.301
  [Host]     : .NET Core 2.1.1 (CoreCLR 4.6.26606.02, CoreFX 4.6.26606.05), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.1 (CoreCLR 4.6.26606.02, CoreFX 4.6.26606.05), 64bit RyuJIT
```

#### Before

Method |       N |            Mean |          Error |         StdDev |      Gen 0 |  Allocated |
-------- |--------:|----------------:|---------------:|---------------:|-----------:|-----------:|
Exact |       1 |        191.1 ns |       1.489 ns |       1.244 ns |     0.0875 |      368 B |
Skip |       1 |        192.5 ns |       3.860 ns |       3.422 ns |     0.0875 |      368 B |
Overlap |       1 |        193.1 ns |       3.666 ns |       4.075 ns |     0.0873 |      368 B |
Exact |      10 |        768.5 ns |       3.810 ns |       3.377 ns |     0.2413 |     1016 B |
Skip |      10 |        517.9 ns |       2.002 ns |       1.775 ns |     0.1554 |      656 B |
Overlap |      10 |        851.7 ns |       3.239 ns |       2.872 ns |     0.2413 |     1016 B |
Exact |     100 |      6,389.3 ns |      13.801 ns |      12.909 ns |     1.7853 |     7496 B |
Skip |     100 |      3,904.6 ns |      12.881 ns |      12.049 ns |     0.9232 |     3896 B |
Overlap |     100 |      7,399.9 ns |      33.423 ns |      27.909 ns |     1.7853 |     7496 B |
Exact |    1000 |     62,712.9 ns |     354.822 ns |     314.541 ns |    17.2119 |    72296 B |
Skip |    1000 |     37,847.9 ns |     110.030 ns |     102.922 ns |     8.6060 |    36296 B |
Overlap |    1000 |     72,566.4 ns |     188.640 ns |     157.523 ns |    17.2119 |    72296 B |
Exact |   10000 |    623,704.0 ns |   1,607.347 ns |   1,424.871 ns |   170.8984 |   720296 B |
Skip |   10000 |    377,130.3 ns |     534.768 ns |     446.556 ns |    85.4492 |   360296 B |
Overlap |   10000 |    727,202.8 ns |   1,796.002 ns |   1,499.743 ns |   170.8984 |   720296 B |
Exact |  100000 |  6,248,655.0 ns |  19,025.788 ns |  16,865.864 ns |  1710.9375 |  7200296 B |
Skip |  100000 |  3,770,172.5 ns |   5,407.719 ns |   4,793.802 ns |   855.4688 |  3600296 B |
Overlap |  100000 |  7,273,699.7 ns |  15,098.295 ns |  13,384.244 ns |  1710.9375 |  7200296 B |
Exact | 1000000 | 62,469,292.5 ns | 105,752.810 ns |  93,747.102 ns | 17125.0000 | 72000296 B |
Skip | 1000000 | 37,726,881.3 ns | 145,511.557 ns | 136,111.588 ns |  8562.5000 | 36000296 B |
Overlap | 1000000 | 72,816,652.9 ns | 124,102.350 ns | 103,631.073 ns | 17125.0000 | 72000296 B |

#### After

Method |       N |             Mean |           Error |          StdDev |      Gen 0 |  Allocated |
-------- |--------:|-----------------:|----------------:|----------------:|-----------:|-----------:|
Exact |       1 |         92.44 ns |       0.7067 ns |       0.6610 ns |     0.0590 |      248 B |
Skip |       1 |         91.95 ns |       0.9855 ns |       0.8229 ns |     0.0628 |      264 B |
Overlap |       1 |        197.52 ns |       0.7002 ns |       0.6550 ns |     0.0875 |      368 B |
Exact |      10 |        441.90 ns |       1.0275 ns |       0.9611 ns |     0.2303 |      968 B |
Skip |      10 |        282.14 ns |       1.4844 ns |       1.3885 ns |     0.1392 |      584 B |
Overlap |      10 |        896.40 ns |       3.1176 ns |       2.9162 ns |     0.2413 |     1016 B |
Exact |     100 |      3,788.63 ns |       9.3188 ns |       8.7169 ns |     1.9455 |     8168 B |
Skip |     100 |      2,236.53 ns |       8.6092 ns |       8.0530 ns |     0.9956 |     4184 B |
Overlap |     100 |      7,741.35 ns |      43.9827 ns |      41.1415 ns |     1.7853 |     7496 B |
Exact |    1000 |     37,046.95 ns |     176.8450 ns |     165.4209 ns |    19.1040 |    80168 B |
Skip |    1000 |     21,713.78 ns |      38.3841 ns |      32.0525 ns |     9.5520 |    40184 B |
Overlap |    1000 |     75,901.27 ns |     276.0594 ns |     258.2261 ns |    17.2119 |    72296 B |
Exact |   10000 |    375,792.63 ns |   1,216.7267 ns |   1,138.1268 ns |   190.4297 |   800168 B |
Skip |   10000 |    215,409.63 ns |     398.1316 ns |     332.4579 ns |    95.2148 |   400184 B |
Overlap |   10000 |    758,921.05 ns |   5,585.3973 ns |   4,951.3087 ns |   170.8984 |   720296 B |
Exact |  100000 |  3,716,398.48 ns |  17,391.9091 ns |  16,268.4010 ns |  1906.2500 |  8000168 B |
Skip |  100000 |  2,168,700.31 ns |   8,996.5773 ns |   8,415.4032 ns |   953.1250 |  4000184 B |
Overlap |  100000 |  7,548,420.59 ns |  28,966.4490 ns |  27,095.2317 ns |  1710.9375 |  7200296 B |
Exact | 1000000 | 37,232,813.26 ns | 179,357.9447 ns | 167,771.5165 ns | 19062.5000 | 80000168 B |
Skip | 1000000 | 21,655,601.10 ns |  57,838.8130 ns |  54,102.4563 ns |  9531.2500 | 40000184 B |
Overlap | 1000000 | 75,701,393.08 ns | 214,815.3429 ns | 200,938.3855 ns | 17125.0000 | 72000296 B |

Remarks: 

- The original and unchanged **Overlap** was consistently slower on in the **after** measure, which is likely due to additional noise on my machine
- On longer flows, the new algorithms consume slightly more memory, not sure why. Maybe the compiler built state machine allocates something extra?