### PR TITLE
Ix: Improve Defer() by removing indirection

### DIFF
--- a/Ix.NET/Source/Benchmarks.System.Interactive/DeferBenchmark.cs
+++ b/Ix.NET/Source/Benchmarks.System.Interactive/DeferBenchmark.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using BenchmarkDotNet.Attributes;
+
+namespace Benchmarks.System.Interactive
+{
+    [MemoryDiagnoser]
+    public class DeferBenchmark
+    {
+        [Params(1, 10, 100, 1000, 10000, 100000, 1000000)]
+        public int N;
+        private int _store;
+
+        [Benchmark]
+        public void Defer()
+        {
+            EnumerableEx.Defer(() => Enumerable.Range(1, N))
+                .Subscribe(v => Volatile.Write(ref _store, v));
+        }
+    }
+}

--- a/Ix.NET/Source/Benchmarks.System.Interactive/Program.cs
+++ b/Ix.NET/Source/Benchmarks.System.Interactive/Program.cs
@@ -18,6 +18,7 @@ namespace Benchmarks.System.Interactive
 
             var switcher = new BenchmarkSwitcher(new[] {
                 typeof(BufferCountBenchmark),
+                typeof(DeferBenchmark),
             });
 
             switcher.Run();

--- a/Ix.NET/Source/System.Interactive/Defer.cs
+++ b/Ix.NET/Source/System.Interactive/Defer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information. 
 
+using System.Collections;
 using System.Collections.Generic;
 
 namespace System.Linq
@@ -26,9 +27,32 @@ namespace System.Linq
 
         private static IEnumerable<TSource> Defer_<TSource>(Func<IEnumerable<TSource>> enumerableFactory)
         {
+            /*
             foreach (var item in enumerableFactory())
             {
                 yield return item;
+            }
+            */
+            return new DeferEnumerable<TSource>(enumerableFactory);
+        }
+
+        private sealed class DeferEnumerable<TSource> : IEnumerable<TSource>
+        {
+            readonly Func<IEnumerable<TSource>> _enumerableFactory;
+
+            public DeferEnumerable(Func<IEnumerable<TSource>> enumerableFactory)
+            {
+                _enumerableFactory = enumerableFactory;
+            }
+
+            public IEnumerator<TSource> GetEnumerator()
+            {
+                return _enumerableFactory().GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
             }
         }
     }


### PR DESCRIPTION
This PR improves Ix `Defer` by removing the indirection and re-emission of the generated inner `IEnumerable` by simply returning its `IEnumerator`. I don't think the operator was intended to hide the actual objects nor is there any auto-detach behavior to consider like with `Observable.Defer`.

Comparison:

```
BenchmarkDotNet=v0.10.14, OS=Windows 7 SP1 (6.1.7601.0)
Intel Core i7-4770K CPU 3.50GHz (Haswell), 1 CPU, 8 logical and 4 physical cores

Frequency=3418037 Hz, Resolution=292.5656 ns, Timer=TSC
.NET Core SDK=2.1.301
  [Host]     : .NET Core 2.1.1 (CoreCLR 4.6.26606.02, CoreFX 4.6.26606.05), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.1 (CoreCLR 4.6.26606.02, CoreFX 4.6.26606.05), 64bit RyuJIT
```

#### Before

 Method |       N |             Mean |          Error |         StdDev |  Gen 0| Allocated |
------- |--------:|-----------------:|---------------:|---------------:|-------:|----------:|
  Defer |       1 |         65.62 ns |      0.9055 ns |      0.8470 ns | 0.0533|     224 B |
  Defer |      10 |        183.77 ns |      0.6257 ns |      0.4524 ns | 0.0532|     224 B |
  Defer |     100 |      1,252.32 ns |      5.7775 ns |      5.4043 ns | 0.0515|     224 B |
  Defer |    1000 |     11,942.01 ns |     75.3339 ns |     70.4674 ns | 0.0458|     224 B |
  Defer |   10000 |    118,017.47 ns |    284.3739 ns |    237.4650 ns |      -|     224 B |
  Defer |  100000 |  1,165,466.55 ns |  4,165.4888 ns |  3,896.4004 ns |      -|     224 B |
  Defer | 1000000 | 11,583,273.92 ns | 42,846.5829 ns | 40,078.7163 ns |      -|     224 B |

#### After
  
 Method |       N |            Mean |          Error |         StdDev |  Gen 0 | Allocated |
------- |--------:|----------------:|---------------:|---------------:|-------:|----------:|
  Defer |       1 |        46.67 ns |      0.4748 ns |      0.4209 ns | 0.0457 |     192 B |
  Defer |      10 |       117.90 ns |      0.6067 ns |      0.5378 ns | 0.0455 |     192 B |
  Defer |     100 |       730.26 ns |      3.6067 ns |      3.3737 ns | 0.0448 |     192 B |
  Defer |    1000 |     6,847.45 ns |     21.1975 ns |     19.8282 ns | 0.0381 |     192 B |
  Defer |   10000 |    67,440.21 ns |    317.8071 ns |    281.7277 ns |      - |     192 B |
  Defer |  100000 |   663,421.55 ns |  2,938.9418 ns |  2,749.0877 ns |      - |     192 B |
  Defer | 1000000 | 6,592,382.80 ns | 13,738.1076 ns | 11,471.9409 ns |      - |     192 B |
