### PR TITLE
Ix: Improve IgnoreElements() performance

### DIFF
--- a/Ix.NET/Source/Benchmarks.System.Interactive/IgnoreElementsBenchmark.cs
+++ b/Ix.NET/Source/Benchmarks.System.Interactive/IgnoreElementsBenchmark.cs
@@ -18,12 +18,43 @@ namespace Benchmarks.System.Interactive
 
         private int _store;
 
+        private int[] _array;
+        private List<int> _list;
+
         [Benchmark]
         public void Ignore()
         {
             Enumerable.Range(1, N)
                 .IgnoreElements()
                 .Subscribe(v => Volatile.Write(ref _store, v));
+        }
+
+        [Benchmark]
+        public void IgnoreList()
+        {
+            _list
+                .IgnoreElements()
+                .Subscribe(v => Volatile.Write(ref _store, v));
+        }
+
+        [Benchmark]
+        public void IgnoreArray()
+        {
+            _array
+                .IgnoreElements()
+                .Subscribe(v => Volatile.Write(ref _store, v));
+        }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _array = new int[N];
+            _list = new List<int>(N);
+            for (var i = 0; i < N; i++)
+            {
+                _array[i] = i;
+                _list.Add(i);
+            }
         }
     }
 }

--- a/Ix.NET/Source/Benchmarks.System.Interactive/IgnoreElementsBenchmark.cs
+++ b/Ix.NET/Source/Benchmarks.System.Interactive/IgnoreElementsBenchmark.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using BenchmarkDotNet.Attributes;
+
+namespace Benchmarks.System.Interactive
+{
+    [MemoryDiagnoser]
+    public class IgnoreElementsBenchmark
+    {
+        [Params(1, 10, 100, 1000, 10000, 100000, 1000000)]
+        public int N;
+
+        private int _store;
+
+        [Benchmark]
+        public void Ignore()
+        {
+            Enumerable.Range(1, N)
+                .IgnoreElements()
+                .Subscribe(v => Volatile.Write(ref _store, v));
+        }
+    }
+}

--- a/Ix.NET/Source/Benchmarks.System.Interactive/Program.cs
+++ b/Ix.NET/Source/Benchmarks.System.Interactive/Program.cs
@@ -18,6 +18,7 @@ namespace Benchmarks.System.Interactive
 
             var switcher = new BenchmarkSwitcher(new[] {
                 typeof(BufferCountBenchmark),
+                typeof(IgnoreElementsBenchmark),
             });
 
             switcher.Run();

--- a/Ix.NET/Source/System.Interactive/IgnoreElements.cs
+++ b/Ix.NET/Source/System.Interactive/IgnoreElements.cs
@@ -28,10 +28,8 @@ namespace System.Linq
         {
             using (var enumerator = source.GetEnumerator())
             {
-
                 while (enumerator.MoveNext()) ;
             }
-
             yield break;
         }
     }

--- a/Ix.NET/Source/System.Interactive/IgnoreElements.cs
+++ b/Ix.NET/Source/System.Interactive/IgnoreElements.cs
@@ -26,9 +26,11 @@ namespace System.Linq
 
         private static IEnumerable<TSource> IgnoreElements_<TSource>(this IEnumerable<TSource> source)
         {
-            var enumerator = source.GetEnumerator();
+            using (var enumerator = source.GetEnumerator())
+            {
 
-            while (enumerator.MoveNext()) ;
+                while (enumerator.MoveNext()) ;
+            }
 
             yield break;
         }

--- a/Ix.NET/Source/System.Interactive/IgnoreElements.cs
+++ b/Ix.NET/Source/System.Interactive/IgnoreElements.cs
@@ -26,10 +26,9 @@ namespace System.Linq
 
         private static IEnumerable<TSource> IgnoreElements_<TSource>(this IEnumerable<TSource> source)
         {
-            foreach (var item in source)
-            {
-                ;
-            }
+            var enumerator = source.GetEnumerator();
+
+            while (enumerator.MoveNext()) ;
 
             yield break;
         }


### PR DESCRIPTION
This PR reduces the overhead in Ix `IgnoreElements` by not doing a full `foreach` but only `MoveNext` on the upstream's `IEnumerator`.

```
BenchmarkDotNet=v0.10.14, OS=Windows 7 SP1 (6.1.7601.0)
Intel Core i7-4770K CPU 3.50GHz (Haswell), 1 CPU, 8 logical and 4 physical cores

Frequency=3418037 Hz, Resolution=292.5656 ns, Timer=TSC
.NET Core SDK=2.1.301
  [Host]     : .NET Core 2.1.1 (CoreCLR 4.6.26606.02, CoreFX 4.6.26606.05), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.1 (CoreCLR 4.6.26606.02, CoreFX 4.6.26606.05), 64bit RyuJIT
```

#### Before

 Method |       N |            Mean |          Error |         StdDev |  Gen 0 | Allocated |
------- |--------:|----------------:|---------------:|---------------:|-------:|----------:|
 Ignore |       1 |        50.70 ns |      0.4997 ns |      0.4674 ns | 0.0362 |     152 B |
 Ignore |      10 |        93.22 ns |      0.2499 ns |      0.2215 ns | 0.0361 |     152 B |
 Ignore |     100 |       516.74 ns |      1.9667 ns |      1.8397 ns | 0.0353 |     152 B |
 Ignore |    1000 |     4,685.37 ns |     16.8983 ns |     15.8067 ns | 0.0305 |     152 B |
 Ignore |   10000 |    46,111.36 ns |     97.3665 ns |     91.0766 ns |      - |     152 B |
 Ignore |  100000 |   460,584.23 ns |  1,447.6994 ns |  1,354.1788 ns |      - |     152 B |
 Ignore | 1000000 | 4,601,262.98 ns | 23,059.4917 ns | 21,569.8607 ns |      - |     152 B |
 
#### After
 
 Method |       N |            Mean |          Error |         StdDev |  Gen 0 | Allocated |
------- |--------:|----------------:|---------------:|---------------:|-------:|----------:|
 Ignore |       1 |        50.08 ns |      0.4549 ns |      0.4033 ns | 0.0362 |     152 B |
 Ignore |      10 |        77.11 ns |      0.4092 ns |      0.3628 ns | 0.0361 |     152 B |
 Ignore |     100 |       352.52 ns |      1.5889 ns |      1.4862 ns | 0.0358 |     152 B |
 Ignore |    1000 |     3,058.96 ns |     18.0046 ns |     15.0346 ns | 0.0343 |     152 B |
 Ignore |   10000 |    29,961.48 ns |    101.0439 ns |     89.5728 ns | 0.0305 |     152 B |
 Ignore |  100000 |   297,692.90 ns |  1,586.6047 ns |  1,484.1109 ns |      - |     152 B |
 Ignore | 1000000 | 2,982,819.68 ns | 11,058.0834 ns | 10,343.7370 ns |      - |     152 B |
