### PR TITLE
Ix: Improve Min(), MinBy(), Max(), MaxBy() performance

### DIFF
--- a/Ix.NET/Source/Benchmarks.System.Interactive/MinMaxBenchmark.cs
+++ b/Ix.NET/Source/Benchmarks.System.Interactive/MinMaxBenchmark.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using BenchmarkDotNet.Attributes;
+
+namespace Benchmarks.System.Interactive
+{
+    [MemoryDiagnoser]
+    public class MinMaxBenchmark
+    {
+        [Params(1, 10, 100, 1000, 10000, 100000, 1000000)]
+        public int N;
+        private int _store;
+        private IList<int> _listStore;
+
+        private readonly IComparer<int> _comparer = Comparer<int>.Default;
+
+        [Benchmark]
+        public void Min()
+        {
+            Volatile.Write(ref _store, Enumerable.Range(1, N).Min(_comparer));
+        }
+
+        [Benchmark]
+        public void MinBy()
+        {
+            Volatile.Write(ref _listStore, Enumerable.Range(1, N).MinBy(v => -v, _comparer));
+        }
+
+        [Benchmark]
+        public void Max()
+        {
+            Volatile.Write(ref _store, Enumerable.Range(1, N).Max(_comparer));
+        }
+
+        [Benchmark]
+        public void MaxBy()
+        {
+            Volatile.Write(ref _listStore, Enumerable.Range(1, N).MaxBy(v => -v, _comparer));
+        }
+    }
+}

--- a/Ix.NET/Source/Benchmarks.System.Interactive/Program.cs
+++ b/Ix.NET/Source/Benchmarks.System.Interactive/Program.cs
@@ -19,6 +19,7 @@ namespace Benchmarks.System.Interactive
             var switcher = new BenchmarkSwitcher(new[] {
                 typeof(BufferCountBenchmark),
                 typeof(DeferBenchmark),
+                typeof(MinMaxBenchmark),
             });
 
             switcher.Run();

--- a/Ix.NET/Source/System.Interactive/Min.cs
+++ b/Ix.NET/Source/System.Interactive/Min.cs
@@ -27,8 +27,7 @@ namespace System.Linq
                 throw new ArgumentNullException(nameof(comparer));
             }
 
-            return MinBy(source, x => x, comparer)
-                .First();
+            return Extrema(source, x => x, comparer, -1);
         }
 
         /// <summary>
@@ -80,7 +79,7 @@ namespace System.Linq
                 throw new ArgumentNullException(nameof(comparer));
             }
 
-            return ExtremaBy(source, keySelector, (key, minValue) => -comparer.Compare(key, minValue));
+            return ExtremaBy(source, keySelector, comparer, -1);
         }
     }
 }


### PR DESCRIPTION
They practically ran on the same underlying implementation.

- dedicated `Extrema` for min/max
- instead of potentially allocating a delegate, use the original `comparer` and use a +1/-1 valued argument to flip between the max/min mode.

```
BenchmarkDotNet=v0.10.14, OS=Windows 7 SP1 (6.1.7601.0)
Intel Core i7-4770K CPU 3.50GHz (Haswell), 1 CPU, 8 logical and 4 physical cores

Frequency=3418037 Hz, Resolution=292.5656 ns, Timer=TSC
.NET Core SDK=2.1.301
  [Host]     : .NET Core 2.1.1 (CoreCLR 4.6.26606.02, CoreFX 4.6.26606.05), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.1 (CoreCLR 4.6.26606.02, CoreFX 4.6.26606.05), 64bit RyuJIT
```

#### Before

 Method |       N |             Mean |           Error |          StdDev |      Gen 0 |  Allocated |
------- |--------:|-----------------:|----------------:|----------------:|-----------:|-----------:|
Min |       1 |         28.43 ns |       0.2972 ns |       0.2780 ns |     0.0095 |       40 B |
MinBy |       1 |         64.32 ns |       1.1814 ns |       1.1051 ns |     0.0495 |      208 B |
Max |       1 |         29.05 ns |       0.6110 ns |       0.7036 ns |     0.0095 |       40 B |
MaxBy |       1 |         62.47 ns |       0.3493 ns |       0.3267 ns |     0.0495 |      208 B |
Min |      10 |         78.94 ns |       0.3535 ns |       0.3307 ns |     0.0094 |       40 B |
MinBy |      10 |        315.71 ns |       1.5478 ns |       1.4478 ns |     0.2208 |      928 B |
Max |      10 |         77.22 ns |       0.2770 ns |       0.2456 ns |     0.0094 |       40 B |
MaxBy |      10 |        162.78 ns |       0.9529 ns |       0.8913 ns |     0.0494 |      208 B |
Min |     100 |        592.02 ns |       2.4206 ns |       2.2642 ns |     0.0086 |       40 B |
MinBy |     100 |      2,704.63 ns |      12.7662 ns |      11.9415 ns |     1.9341 |     8128 B |
Max |     100 |        563.33 ns |       3.1326 ns |       2.7770 ns |     0.0086 |       40 B |
MaxBy |     100 |      1,055.06 ns |       4.7811 ns |       4.4722 ns |     0.0477 |      208 B |
Min |    1000 |      5,641.18 ns |      25.4637 ns |      23.8187 ns |     0.0076 |       40 B |
MinBy |    1000 |     26,637.07 ns |     139.1114 ns |     130.1249 ns |    19.0735 |    80128 B |
Max |    1000 |      5,373.47 ns |      24.2141 ns |      21.4652 ns |     0.0076 |       40 B |
MaxBy |    1000 |      9,985.08 ns |      33.6077 ns |      29.7923 ns |     0.0458 |      208 B |
Min |   10000 |     56,033.98 ns |     210.5804 ns |     196.9770 ns |          - |       40 B |
MinBy |   10000 |    264,776.04 ns |   1,764.1003 ns |   1,650.1404 ns |   190.4297 |   800128 B |
Max |   10000 |     53,361.27 ns |     248.1599 ns |     219.9872 ns |          - |       40 B |
MaxBy |   10000 |     98,647.28 ns |     525.4058 ns |     465.7585 ns |          - |      208 B |
Min |  100000 |    559,450.77 ns |   3,062.9852 ns |   2,865.1180 ns |          - |       40 B |
MinBy |  100000 |  2,652,126.62 ns |  11,350.1846 ns |  10,616.9687 ns |  1906.2500 |  8000128 B |
Max |  100000 |    533,240.91 ns |   2,313.6937 ns |   2,051.0290 ns |          - |       40 B |
MaxBy |  100000 |    988,760.66 ns |   3,189.3926 ns |   2,827.3132 ns |          - |      208 B |
Min | 1000000 |  5,599,676.95 ns |  23,795.9156 ns |  22,258.7121 ns |          - |        0 B |
MinBy | 1000000 | 26,430,099.92 ns | 162,711.1193 ns | 135,871.1408 ns | 19062.5000 | 80000128 B |
Max | 1000000 |  5,332,414.51 ns |  22,347.0929 ns |  20,903.4826 ns |          - |        0 B |
MaxBy | 1000000 |  9,884,072.40 ns |  22,476.7571 ns |  18,769.1083 ns |          - |      208 B |

#### After

 Method |       N |             Mean |           Error |          StdDev |Gen 0 |  Allocated |
------- |--------:|-----------------:|----------------:|----------------:|-----------:|-----------:|
Min |       1 |         28.47 ns |       0.3126 ns |       0.2924 ns |     0.0095 |       40 B |
MinBy |       1 |         57.96 ns |       1.1845 ns |       1.2164 ns |     0.0285 |      120 B |
Max |       1 |         28.51 ns |       0.2588 ns |       0.2421 ns |     0.0095 |       40 B |
MaxBy |       1 |         57.17 ns |       0.2429 ns |       0.2153 ns |     0.0286 |      120 B |
Min |      10 |         78.92 ns |       0.4186 ns |       0.3916 ns |     0.0094 |       40 B |
MinBy |      10 |        289.07 ns |       1.3572 ns |       1.0596 ns |     0.1998 |      840 B |
Max |      10 |         77.12 ns |       0.4835 ns |       0.4037 ns |     0.0094 |       40 B |
MaxBy |      10 |        148.46 ns |       0.6016 ns |       0.5627 ns |     0.0284 |      120 B |
Min |     100 |        590.14 ns |       3.6624 ns |       3.4258 ns |     0.0086 |       40 B |
MinBy |     100 |      2,448.34 ns |      18.2332 ns |      16.1633 ns |     1.9150 |     8040 B |
Max |     100 |        563.75 ns |       3.8395 ns |       3.5915 ns |     0.0086 |       40 B |
MaxBy |     100 |        930.99 ns |       8.8059 ns |       8.2371 ns |     0.0277 |      120 B |
Min |    1000 |      5,650.50 ns |      12.6410 ns |      11.8244 ns |     0.0076 |       40 B |
MinBy |    1000 |     24,444.93 ns |     125.3024 ns |     111.0773 ns |    19.0735 |    80040 B |
Max |    1000 |      5,388.29 ns |      36.9627 ns |      34.5749 ns |     0.0076 |       40 B |
MaxBy |    1000 |      8,937.38 ns |      23.6697 ns |      20.9826 ns |     0.0153 |      120 B |
Min |   10000 |     55,988.17 ns |     248.2118 ns |     232.1775 ns |          - |       40 B |
MinBy |   10000 |    241,411.32 ns |   1,211.7392 ns |     946.0462 ns |   190.6738 |   800040 B |
Max |   10000 |     53,240.10 ns |     248.3388 ns |     232.2963 ns |          - |       40 B |
MaxBy |   10000 |     87,902.58 ns |     383.8063 ns |     359.0126 ns |          - |      120 B |
Min |  100000 |    559,146.17 ns |   2,961.3670 ns |   2,770.0643 ns |          - |       40 B |
MinBy |  100000 |  2,428,412.93 ns |  11,808.9894 ns |   9,861.0400 ns |  1906.2500 |  8000040 B |
Max |  100000 |    531,859.44 ns |   2,522.9915 ns |   2,360.0076 ns |          - |       40 B |
MaxBy |  100000 |    880,737.11 ns |   4,817.2112 ns |   4,270.3318 ns |          - |      120 B |
Min | 1000000 |  5,601,959.99 ns |  26,433.6019 ns |  24,726.0052 ns |          - |        0 B |
MinBy | 1000000 | 24,325,087.63 ns | 118,330.4227 ns | 104,896.8273 ns | 19062.5000 | 80000040 B |
Max | 1000000 |  5,326,380.42 ns |  29,322.9174 ns |  27,428.6724 ns |          - |        0 B |
MaxBy | 1000000 |  8,794,140.89 ns |  25,899.6252 ns |  24,226.5232 ns |          - |        0 B |

  