### PR TITLE
Fix Latest

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Latest.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Latest.cs
@@ -116,7 +116,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 switch (kind)
                 {
                     case NotificationKind.OnNext:
-                        current = _value;
+                        current = value;
                         return true;
                     case NotificationKind.OnError:
                         error.Throw();


### PR DESCRIPTION
There is an unused field in Latest that is only assigned to. On the other hand, access to the _value field happens once inside a lock and once outside. It's most probably a bug and the temporary variable should be used instead.