### PR TITLE
Append/Prepend some more optimizations

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/AppendPrepend.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/AppendPrepend.cs
@@ -224,8 +224,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     {
                         //
                         // We never allow the scheduled work to be cancelled. Instead, the _disposed flag
-                        // is used to have LoopRec bail out and perform proper clean-up of the
-                        // enumerator.
+                        // is used to have PrependValues() bail out.
                         //
                         _scheduler.Schedule(this, (innerScheduler, @this) => @this.PrependValues(innerScheduler));
                     }
@@ -242,8 +241,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         _appendArray = _appends.ToReverseArray();
                         //
                         // We never allow the scheduled work to be cancelled. Instead, the _disposed flag
-                        // is used to have LoopRec bail out and perform proper clean-up of the
-                        // enumerator.
+                        // is used to have `AppendValues` bail out.
                         //
                         _scheduler.Schedule(this, (innerScheduler, @this) => @this.AppendValues(innerScheduler));
                     }
@@ -278,8 +276,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     { 
                         //
                         // We never allow the scheduled work to be cancelled. Instead, the _disposed flag
-                        // is used to have LoopRec bail out and perform proper clean-up of the
-                        // enumerator.
+                        // is used to have PrependValues() bail out.
                         //
                         scheduler.Schedule(this, (innerScheduler, @this) => @this.PrependValues(innerScheduler));
                     }
@@ -307,8 +304,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     { 
                         //
                         // We never allow the scheduled work to be cancelled. Instead, the _disposed flag
-                        // is used to have LoopRec bail out and perform proper clean-up of the
-                        // enumerator.
+                        // is used to have AppendValues() bail out.
                         //
                         scheduler.Schedule(this, (innerScheduler, @this) => @this.AppendValues(innerScheduler));
                     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Single.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Single.cs
@@ -216,7 +216,7 @@ namespace System.Reactive.Linq
                 return new AppendPrepend.AppendPrependSingleImmediate<TSource>(source, value, false);
             }
 
-            return new AppendPrepend.AppendPrependSingle<TSource>(source, value, scheduler, append: false);
+            return new AppendPrepend.SingleValue<TSource>(source, value, scheduler, append: false);
         }
 
         #endregion

--- a/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Single.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Single.cs
@@ -32,7 +32,7 @@ namespace System.Reactive.Linq
             }
             if (scheduler == ImmediateScheduler.Instance)
             {
-                return new AppendPrepend<TSource>.SingleImmediate<TSource>(source, value, true);
+                return new AppendPrepend<TSource>.SingleImmediate(source, value, append: true);
             }
             return new AppendPrepend<TSource>.SingleValue(source, value, scheduler, append: true);
         }
@@ -213,7 +213,7 @@ namespace System.Reactive.Linq
 
             if (scheduler == ImmediateScheduler.Instance)
             {
-                return new AppendPrepend.AppendPrependSingleImmediate<TSource>(source, value, false);
+                return new AppendPrepend<TSource>.SingleImmediate(source, value, append: false);
             }
 
             return new AppendPrepend<TSource>.SingleValue(source, value, scheduler, append: false);

--- a/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Single.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Single.cs
@@ -26,15 +26,15 @@ namespace System.Reactive.Linq
 
         private static IObservable<TSource> Append_<TSource>(IObservable<TSource> source, TSource value, IScheduler scheduler)
         {
-            if (source is AppendPrepend.IAppendPrepend<TSource> ap && ap.Scheduler == scheduler)
+            if (source is AppendPrepend<TSource>.IAppendPrepend ap && ap.Scheduler == scheduler)
             {
                 return ap.Append(value);
             }
             if (scheduler == ImmediateScheduler.Instance)
             {
-                return new AppendPrepend.AppendPrependSingleImmediate<TSource>(source, value, true);
+                return new AppendPrepend<TSource>.SingleImmediate<TSource>(source, value, true);
             }
-            return new AppendPrepend.AppendPrependSingle<TSource>(source, value, scheduler, append: true);
+            return new AppendPrepend<TSource>.SingleValue(source, value, scheduler, append: true);
         }
 
         #endregion
@@ -206,7 +206,7 @@ namespace System.Reactive.Linq
 
         private static IObservable<TSource> Prepend_<TSource>(IObservable<TSource> source, TSource value, IScheduler scheduler)
         {
-            if (source is AppendPrepend.IAppendPrepend<TSource> ap && ap.Scheduler == scheduler)
+            if (source is AppendPrepend<TSource>.IAppendPrepend ap && ap.Scheduler == scheduler)
             {
                 return ap.Prepend(value);
             }
@@ -216,7 +216,7 @@ namespace System.Reactive.Linq
                 return new AppendPrepend.AppendPrependSingleImmediate<TSource>(source, value, false);
             }
 
-            return new AppendPrepend.SingleValue<TSource>(source, value, scheduler, append: false);
+            return new AppendPrepend<TSource>.SingleValue(source, value, scheduler, append: false);
         }
 
         #endregion


### PR DESCRIPTION
In this PR I tried to follow the mprovements made to the `ToObersable` class. I also splitted the single `AppendPrependMultiple` class into two implementation. It made the code easier to understand. I also added a specialized version for the prepend loop. That way we save the allocation creation of the prepend array.  Now all 3 or 4 classes of the AppendPrepend familiy have a similar structure and method names.

There are a some small things missing:
  - I need to merge the latest changes to `AppendPrependSingle`
 - I want to delay the append array creation until it is realy needed, i.e., after the source completion. So the array does not need to be created when the subscription is disposed before and it is fresh in memory at the moment when it is needed.

Measurements before:

``` ini

BenchmarkDotNet=v0.10.14, OS=Windows 10.0.17134
Intel Core i5-5200U CPU 2.20GHz (Broadwell), 1 CPU, 4 logical and 2 physical cores
Frequency=2143476 Hz, Resolution=466.5319 ns, Timer=TSC
  [Host]     : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3110.0
  DefaultJob : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3110.0


```
|              Method |     N |          Mean |       Error |      StdDev | Scaled | ScaledSD |     Gen 0 |    Gen 1 |   Gen 2 |  Allocated |
|-------------------- |------ |--------------:|------------:|------------:|-------:|---------:|----------:|---------:|--------:|-----------:|
|      **StartWithArray** |     **1** |      **3.528 us** |   **0.0700 us** |   **0.0934 us** |   **1.00** |     **0.00** |    **0.9193** |        **-** |       **-** |    **1.42 KB** |
|       StartWithList |     1 |      3.983 us |   0.0837 us |   0.2442 us |   1.13 |     0.07 |    1.0223 |        - |       - |    1.57 KB |
| StartWithLinkedList |     1 |      3.717 us |   0.0907 us |   0.0891 us |   1.05 |     0.04 |    1.0605 |        - |       - |    1.64 KB |
|       AppendPrepend |     1 |      3.238 us |   0.0636 us |   0.0707 us |   0.92 |     0.03 |    1.3046 |        - |       - |    2.01 KB |
|                     |       |               |             |             |        |          |           |          |         |            |
|      **StartWithArray** |    **10** |      **7.786 us** |   **0.1843 us** |   **0.2975 us** |   **1.00** |     **0.00** |    **1.7853** |        **-** |       **-** |    **2.75 KB** |
|       StartWithList |    10 |      8.027 us |   0.0864 us |   0.0722 us |   1.03 |     0.04 |    2.1210 |        - |       - |    3.27 KB |
| StartWithLinkedList |    10 |      8.349 us |   0.0853 us |   0.0756 us |   1.07 |     0.04 |    2.5024 |        - |       - |    3.85 KB |
|       AppendPrepend |    10 |     16.528 us |   0.2417 us |   0.2261 us |   2.13 |     0.08 |    4.6387 |        - |       - |    7.16 KB |
|                     |       |               |             |             |        |          |           |          |         |            |
|      **StartWithArray** |   **100** |     **46.883 us** |   **0.5206 us** |   **0.4870 us** |   **1.00** |     **0.00** |   **10.4370** |        **-** |       **-** |   **16.12 KB** |
|       StartWithList |   100 |     52.340 us |   1.0122 us |   1.2050 us |   1.12 |     0.03 |   12.3901 |        - |       - |   19.12 KB |
| StartWithLinkedList |   100 |     52.390 us |   0.5356 us |   0.4748 us |   1.12 |     0.01 |   17.1509 |        - |       - |   26.37 KB |
|       AppendPrepend |   100 |    151.495 us |   1.3802 us |   1.2911 us |   3.23 |     0.04 |   34.6680 |        - |       - |   53.46 KB |
|                     |       |               |             |             |        |          |           |          |         |            |
|      **StartWithArray** |  **1000** |    **444.947 us** |   **8.8062 us** |  **12.0540 us** |   **1.00** |     **0.00** |   **97.1680** |        **-** |       **-** |  **149.73 KB** |
|       StartWithList |  1000 |    590.252 us |  11.0556 us |  10.3414 us |   1.33 |     0.04 |  112.3047 |        - |       - |  173.92 KB |
| StartWithLinkedList |  1000 |    505.393 us |   6.3248 us |   5.6068 us |   1.14 |     0.03 |  151.3672 |   9.7656 |       - |  251.38 KB |
|       AppendPrepend |  1000 |  1,591.257 us |  16.0398 us |  15.0037 us |   3.58 |     0.10 |  332.0313 |        - |       - |  512.74 KB |
|                     |       |               |             |             |        |          |           |          |         |            |
|      **StartWithArray** | **10000** |  **4,378.554 us** |  **46.1767 us** |  **38.5597 us** |   **1.00** |     **0.00** |  **960.9375** |        **-** |       **-** | **1485.71 KB** |
|       StartWithList | 10000 | 15,953.991 us | 182.8502 us | 162.0919 us |   3.64 |     0.05 | 1093.7500 |  31.2500 | 31.2500 | 1820.76 KB |
| StartWithLinkedList | 10000 |  6,142.251 us | 139.7508 us | 130.7230 us |   1.40 |     0.03 |  843.7500 | 257.8125 |       - | 2501.78 KB |
|       AppendPrepend | 10000 | 17,522.780 us | 238.5906 us | 223.1778 us |   4.00 |     0.06 |  968.7500 | 406.2500 |       - | 5098.99 KB |

After the switch to the light recursive scheduling:

``` ini

BenchmarkDotNet=v0.10.14, OS=Windows 10.0.17134
Intel Core i5-5200U CPU 2.20GHz (Broadwell), 1 CPU, 4 logical and 2 physical cores
Frequency=2143476 Hz, Resolution=466.5319 ns, Timer=TSC
  [Host]     : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3110.0
  DefaultJob : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3110.0


```
|              Method |     N |          Mean |      Error |     StdDev | Scaled | ScaledSD |     Gen 0 |    Gen 1 |   Gen 2 |  Allocated |
|-------------------- |------ |--------------:|-----------:|-----------:|-------:|---------:|----------:|---------:|--------:|-----------:|
|      **StartWithArray** |     **1** |      **4.283 us** |  **0.0409 us** |  **0.0383 us** |   **1.00** |     **0.00** |    **0.9155** |        **-** |       **-** |    **1.42 KB** |
|       StartWithList |     1 |      4.331 us |  0.0402 us |  0.0376 us |   1.01 |     0.01 |    1.0223 |        - |       - |    1.57 KB |
| StartWithLinkedList |     1 |      4.724 us |  0.0468 us |  0.0415 us |   1.10 |     0.01 |    1.0605 |        - |       - |    1.64 KB |
|       AppendPrepend |     1 |      3.650 us |  0.0202 us |  0.0189 us |   0.85 |     0.01 |    0.9575 |        - |       - |    1.47 KB |
|                     |       |               |            |            |        |          |           |          |         |            |
|      **StartWithArray** |    **10** |      **8.948 us** |  **0.1027 us** |  **0.0961 us** |   **1.00** |     **0.00** |    **1.7853** |        **-** |       **-** |    **2.75 KB** |
|       StartWithList |    10 |      9.637 us |  0.0825 us |  0.0732 us |   1.08 |     0.01 |    2.1210 |        - |       - |    3.27 KB |
| StartWithLinkedList |    10 |      9.538 us |  0.0900 us |  0.0797 us |   1.07 |     0.01 |    2.5024 |        - |       - |    3.85 KB |
|       AppendPrepend |    10 |     10.712 us |  0.0547 us |  0.0512 us |   1.20 |     0.01 |    3.2806 |        - |       - |    5.05 KB |
|                     |       |               |            |            |        |          |           |          |         |            |
|      **StartWithArray** |   **100** |     **56.349 us** |  **0.4865 us** |  **0.4063 us** |   **1.00** |     **0.00** |   **10.4370** |        **-** |       **-** |   **16.12 KB** |
|       StartWithList |   100 |     62.029 us |  0.4953 us |  0.4633 us |   1.10 |     0.01 |   12.3291 |        - |       - |   19.12 KB |
| StartWithLinkedList |   100 |     62.506 us |  0.5599 us |  0.4371 us |   1.11 |     0.01 |   17.0898 |        - |       - |   26.37 KB |
|       AppendPrepend |   100 |     83.353 us |  0.8382 us |  0.7431 us |   1.48 |     0.02 |   23.8037 |        - |       - |   36.66 KB |
|                     |       |               |            |            |        |          |           |          |         |            |
|      **StartWithArray** |  **1000** |    **530.851 us** |  **5.2621 us** |  **4.3941 us** |   **1.00** |     **0.00** |   **96.6797** |        **-** |       **-** |  **149.73 KB** |
|       StartWithList |  1000 |    706.448 us |  4.5027 us |  4.2118 us |   1.33 |     0.01 |  112.3047 |        - |       - |  173.92 KB |
| StartWithLinkedList |  1000 |    608.962 us |  8.6027 us |  7.6260 us |   1.15 |     0.02 |  162.1094 |   0.9766 |       - |   251.5 KB |
|       AppendPrepend |  1000 |    758.401 us | 14.8476 us | 27.5209 us |   1.43 |     0.05 |  229.4922 |        - |       - |  353.13 KB |
|                     |       |               |            |            |        |          |           |          |         |            |
|      **StartWithArray** | **10000** |  **4,430.645 us** | **29.2578 us** | **27.3677 us** |   **1.00** |     **0.00** |  **960.9375** |        **-** |       **-** | **1485.73 KB** |
|       StartWithList | 10000 | 16,078.175 us | 81.1868 us | 67.7946 us |   3.63 |     0.03 | 1093.7500 |  31.2500 | 31.2500 | 1820.76 KB |
| StartWithLinkedList | 10000 |  6,162.668 us | 28.1868 us | 24.9869 us |   1.39 |     0.01 |  843.7500 | 257.8125 |       - | 2501.78 KB |
|       AppendPrepend | 10000 |  8,515.175 us | 73.1290 us | 68.4049 us |   1.92 |     0.02 |  718.7500 | 312.5000 |       - | 3517.31 KB |

With the specialized prepend loop:

``` ini

BenchmarkDotNet=v0.10.14, OS=Windows 10.0.17134
Intel Core i5-5200U CPU 2.20GHz (Broadwell), 1 CPU, 4 logical and 2 physical cores
Frequency=2143476 Hz, Resolution=466.5319 ns, Timer=TSC
  [Host]     : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3110.0
  DefaultJob : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3110.0


```
|              Method |     N |          Mean |      Error |     StdDev | Scaled | ScaledSD |     Gen 0 |    Gen 1 |   Gen 2 |  Allocated |
|-------------------- |------ |--------------:|-----------:|-----------:|-------:|---------:|----------:|---------:|--------:|-----------:|
|      **StartWithArray** |     **1** |      **4.232 us** |  **0.0847 us** |  **0.0941 us** |   **1.00** |     **0.00** |    **0.9155** |        **-** |       **-** |    **1.42 KB** |
|       StartWithList |     1 |      4.189 us |  0.0121 us |  0.0095 us |   0.99 |     0.02 |    1.0223 |        - |       - |    1.57 KB |
| StartWithLinkedList |     1 |      4.028 us |  0.0217 us |  0.0181 us |   0.95 |     0.02 |    1.0605 |        - |       - |    1.64 KB |
|       AppendPrepend |     1 |      3.466 us |  0.0219 us |  0.0205 us |   0.82 |     0.02 |    0.9270 |        - |       - |    1.43 KB |
|                     |       |               |            |            |        |          |           |          |         |            |
|      **StartWithArray** |    **10** |      **8.760 us** |  **0.0131 us** |  **0.0109 us** |   **1.00** |     **0.00** |    **1.7853** |        **-** |       **-** |    **2.75 KB** |
|       StartWithList |    10 |      9.340 us |  0.0129 us |  0.0121 us |   1.07 |     0.00 |    2.1210 |        - |       - |    3.27 KB |
| StartWithLinkedList |    10 |      9.678 us |  0.0261 us |  0.0231 us |   1.10 |     0.00 |    2.5024 |        - |       - |    3.85 KB |
|       AppendPrepend |    10 |      9.179 us |  0.0530 us |  0.0496 us |   1.05 |     0.01 |    2.9449 |        - |       - |    4.54 KB |
|                     |       |               |            |            |        |          |           |          |         |            |
|      **StartWithArray** |   **100** |     **54.213 us** |  **0.0596 us** |  **0.0529 us** |   **1.00** |     **0.00** |   **10.4370** |        **-** |       **-** |   **16.12 KB** |
|       StartWithList |   100 |     60.062 us |  0.1947 us |  0.1821 us |   1.11 |     0.00 |   12.3901 |        - |       - |   19.12 KB |
| StartWithLinkedList |   100 |     60.878 us |  0.3439 us |  0.3217 us |   1.12 |     0.01 |   17.0898 |        - |       - |   26.37 KB |
|       AppendPrepend |   100 |     64.398 us |  0.3147 us |  0.2789 us |   1.19 |     0.01 |   20.5078 |        - |       - |   31.67 KB |
|                     |       |               |            |            |        |          |           |          |         |            |
|      **StartWithArray** |  **1000** |    **516.180 us** |  **2.5220 us** |  **2.2357 us** |   **1.00** |     **0.00** |   **96.6797** |        **-** |       **-** |  **149.73 KB** |
|       StartWithList |  1000 |    684.949 us |  2.8728 us |  2.5467 us |   1.33 |     0.01 |  112.3047 |        - |       - |  173.92 KB |
| StartWithLinkedList |  1000 |    602.670 us | 11.3540 us | 10.6206 us |   1.17 |     0.02 |  162.1094 |   0.9766 |       - |   251.5 KB |
|       AppendPrepend |  1000 |    662.919 us |  0.6880 us |  0.5746 us |   1.28 |     0.01 |  196.2891 |        - |       - |  302.36 KB |
|                     |       |               |            |            |        |          |           |          |         |            |
|      **StartWithArray** | **10000** |  **5,141.553 us** | **36.8668 us** | **34.4852 us** |   **1.00** |     **0.00** |  **960.9375** |        **-** |       **-** | **1485.73 KB** |
|       StartWithList | 10000 | 18,687.550 us | 28.6423 us | 23.9176 us |   3.63 |     0.02 | 1093.7500 |  31.2500 | 31.2500 | 1820.76 KB |
| StartWithLinkedList | 10000 |  7,104.952 us | 56.7801 us | 50.3341 us |   1.38 |     0.01 |  843.7500 | 257.8125 |       - | 2501.78 KB |
|       AppendPrepend | 10000 |  7,999.898 us | 32.5722 us | 30.4680 us |   1.56 |     0.01 |  515.6250 | 234.3750 |       - | 3009.51 KB |

