### PR TITLE
Fix for TaskObservableExtensions.Subscribe

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Threading/Tasks/TaskObservableExtensions.cs
+++ b/Rx.NET/Source/src/System.Reactive/Threading/Tasks/TaskObservableExtensions.cs
@@ -114,7 +114,7 @@ namespace System.Reactive.Threading.Tasks
                 observer, 
                 cts.Token, 
                 TaskContinuationOptions.ExecuteSynchronously, 
-                TaskScheduler.Default);
+                TaskScheduler.Current);
 
             return cts;
         }
@@ -250,7 +250,7 @@ namespace System.Reactive.Threading.Tasks
                 observer, 
                 cts.Token, 
                 TaskContinuationOptions.ExecuteSynchronously, 
-                TaskScheduler.Default);
+                TaskScheduler.Current);
 
             return cts;
         }


### PR DESCRIPTION
According to https://github.com/dotnet/coreclr/blob/master/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs#L3611, the default-TaskScheduler is not TaskScheduler.Default but TaskScheduler.Current.