### PR TITLE
Sink.Dispose should only call Dispose(true) once.

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Internal/Sink.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/Sink.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information. 
 
 using System.Reactive.Disposables;
+using System.Threading;
 
 namespace System.Reactive
 {
@@ -25,12 +26,16 @@ namespace System.Reactive
 
         public void Dispose()
         {
-            Dispose(true);
+            if (_observer != NopObserver<TTarget>.Instance && Interlocked.Exchange(ref _observer, NopObserver<TTarget>.Instance) != NopObserver<TTarget>.Instance)
+                Dispose(true);
         }
 
         protected virtual void Dispose(bool disposing)
         {
-            _observer = NopObserver<TTarget>.Instance;
+            //Calling base.Dispose(true) is not a proper disposal, so we can omit the assignment here.
+            //Sink is internal so this can pretty much be enforced.
+            //_observer = NopObserver<TTarget>.Instance;
+
             Disposable.TryDispose(ref _upstream);
         }
 

--- a/Rx.NET/Source/src/System.Reactive/Internal/Sink.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/Sink.cs
@@ -26,7 +26,7 @@ namespace System.Reactive
 
         public void Dispose()
         {
-            if (_observer != NopObserver<TTarget>.Instance && Interlocked.Exchange(ref _observer, NopObserver<TTarget>.Instance) != NopObserver<TTarget>.Instance)
+            if (Interlocked.Exchange(ref _observer, NopObserver<TTarget>.Instance) != NopObserver<TTarget>.Instance)
                 Dispose(true);
         }
 


### PR DESCRIPTION
This is part of a a two part fix for #768. Dispose.Create has been inlined in 6ecc899a4ba35db5834f55dcfde019e19b431940, which, for RefCount, will lead to garbage if Sink.Dispose is called multiple times. This PR makes Sink.Dispose a nop from the second call on.

Note: This is not enough to fix #768, although the expectation of the OP about the behaviour is incorrect, there is another bug that will be fixed in a following PR.