### PR TITLE
4.x: Benchmark Subject

### DIFF
--- a/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/Program.cs
+++ b/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/Program.cs
@@ -26,6 +26,7 @@ namespace Benchmarks.System.Reactive
                 typeof(ComparisonAsyncBenchmark),
                 typeof(ScalarScheduleBenchmark),
                 typeof(StableCompositeDisposableBenchmark),
+                typeof(SubjectBenchmark),
                 typeof(ComparisonAsyncBenchmark)
 #if (CURRENT)
                 ,typeof(AppendPrependBenchmark)

--- a/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/SubjectBenchmark.cs
+++ b/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/SubjectBenchmark.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading;
+using BenchmarkDotNet.Attributes;
+
+namespace Benchmarks.System.Reactive
+{
+    [MemoryDiagnoser]
+    public class SubjectBenchmark
+    {
+        [Params(1, 10, 100, 1000, 10000, 100000, 1000000)]
+        public int N;
+
+        [Params(0, 1, 2, 3, 4, 5)]
+        public int M;
+
+        private int _store;
+
+        [Benchmark]
+        public object SubjectPush()
+        {
+            var subj = new Subject<int>();
+            var consumers = new IDisposable[M];
+            var m = M;
+            for (var i = 0; i < m; i++)
+            {
+                consumers[i] = subj.Subscribe(v => Volatile.Write(ref _store, v));
+            }
+
+            var n = N;
+            for (var i = 0; i < n; i++)
+            {
+                subj.OnNext(i);
+            }
+
+            return consumers;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a benchmark to see the performance profile of `Subject` and provide a baseline to figure out where the additional overhead comes from compared to 3.1.1.

```
BenchmarkDotNet=v0.10.14, OS=Windows 10.0.17134
Intel Core i7-4790 CPU 3.60GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
Frequency=3513590 Hz, Resolution=284.6092 ns, Timer=TSC
[Host]     : .NET Framework 4.6.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3110.0
DefaultJob : .NET Framework 4.6.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3110.0
```

### 3.1.1

Method |       N | M |             Mean |           Error |          StdDev |  Gen 0 | Allocated |
------------ |-------- |-- |-----------------:|----------------:|----------------:|-------:|----------:|
SubjectPush |       1 | 0 |         10.45 ns |       0.1207 ns |       0.1129 ns | 0.0114 |      48 B |
SubjectPush |       1 | 1 |         51.50 ns |       0.3587 ns |       0.3355 ns | 0.0476 |     200 B |
SubjectPush |       1 | 2 |        237.58 ns |       2.4068 ns |       2.2514 ns | 0.1044 |     440 B |
SubjectPush |       1 | 3 |        393.25 ns |       2.8254 ns |       2.6429 ns | 0.1636 |     688 B |
SubjectPush |       1 | 4 |        555.49 ns |       4.2569 ns |       3.7736 ns | 0.2241 |     944 B |
SubjectPush |       1 | 5 |        720.29 ns |       5.1273 ns |       4.7960 ns | 0.2871 |    1208 B |
SubjectPush |      10 | 0 |         29.37 ns |       0.2745 ns |       0.2568 ns | 0.0114 |      48 B |
SubjectPush |      10 | 1 |         95.83 ns |       0.4785 ns |       0.4476 ns | 0.0476 |     200 B |
SubjectPush |      10 | 2 |        349.10 ns |       3.3716 ns |       3.1538 ns | 0.1044 |     440 B |
SubjectPush |      10 | 3 |        545.20 ns |       2.7319 ns |       2.5554 ns | 0.1631 |     688 B |
SubjectPush |      10 | 4 |        744.91 ns |       4.9595 ns |       4.6391 ns | 0.2241 |     944 B |
SubjectPush |      10 | 5 |        958.21 ns |       7.5902 ns |       7.0998 ns | 0.2871 |    1208 B |
SubjectPush |     100 | 0 |        233.44 ns |       1.1397 ns |       1.0104 ns | 0.0110 |      48 B |
SubjectPush |     100 | 1 |        546.75 ns |       1.4574 ns |       1.3632 ns | 0.0467 |     200 B |
SubjectPush |     100 | 2 |      1,367.59 ns |       9.0650 ns |       8.4795 ns | 0.1030 |     440 B |
SubjectPush |     100 | 3 |      1,944.20 ns |      13.5676 ns |      12.0273 ns | 0.1602 |     688 B |
SubjectPush |     100 | 4 |      2,540.99 ns |      11.9167 ns |       9.3038 ns | 0.2213 |     944 B |
SubjectPush |     100 | 5 |      3,154.45 ns |      16.5571 ns |      15.4875 ns | 0.2861 |    1208 B |
SubjectPush |    1000 | 0 |      2,102.21 ns |       9.1716 ns |       8.5791 ns | 0.0076 |      48 B |
SubjectPush |    1000 | 1 |      4,999.54 ns |      27.0699 ns |      25.3212 ns | 0.0458 |     200 B |
SubjectPush |    1000 | 2 |     11,388.14 ns |     117.0766 ns |     109.5135 ns | 0.0916 |     440 B |
SubjectPush |    1000 | 3 |     15,824.73 ns |      75.0330 ns |      66.5148 ns | 0.1526 |     688 B |
SubjectPush |    1000 | 4 |     20,343.54 ns |     133.4572 ns |     124.8359 ns | 0.2136 |     944 B |
SubjectPush |    1000 | 5 |     24,918.35 ns |     131.9883 ns |     123.4619 ns | 0.2747 |    1208 B |
SubjectPush |   10000 | 0 |     20,811.10 ns |      83.1229 ns |      73.6862 ns |      - |      48 B |
SubjectPush |   10000 | 1 |     49,193.67 ns |     253.8020 ns |     237.4065 ns |      - |     200 B |
SubjectPush |   10000 | 2 |    110,924.64 ns |   1,287.4523 ns |   1,204.2836 ns |      - |     441 B |
SubjectPush |   10000 | 3 |    153,135.94 ns |     533.5070 ns |     499.0427 ns |      - |     690 B |
SubjectPush |   10000 | 4 |    197,118.28 ns |     927.5923 ns |     867.6703 ns |      - |     946 B |
SubjectPush |   10000 | 5 |    242,399.51 ns |   1,676.4439 ns |   1,568.1465 ns |      - |    1212 B |
SubjectPush |  100000 | 0 |    207,470.12 ns |     779.5554 ns |     729.1965 ns |      - |      50 B |
SubjectPush |  100000 | 1 |    485,814.12 ns |   2,623.6182 ns |   2,454.1338 ns |      - |     208 B |
SubjectPush |  100000 | 2 |  1,101,672.22 ns |   5,883.1677 ns |   5,503.1181 ns |      - |     448 B |
SubjectPush |  100000 | 3 |  1,526,316.44 ns |   4,815.1168 ns |   4,504.0628 ns |      - |     704 B |
SubjectPush |  100000 | 4 |  1,968,242.45 ns |   6,055.6009 ns |   5,664.4123 ns |      - |     960 B |
SubjectPush |  100000 | 5 |  2,409,717.81 ns |  11,212.1018 ns |  10,487.8060 ns |      - |    1216 B |
SubjectPush | 1000000 | 0 |  2,069,249.09 ns |   9,116.0376 ns |   8,527.1464 ns |      - |      64 B |
SubjectPush | 1000000 | 1 |  4,744,820.44 ns |  34,967.1744 ns |  32,708.3134 ns |      - |     256 B |
SubjectPush | 1000000 | 2 | 10,915,153.73 ns |  67,151.1564 ns |  62,813.2272 ns |      - |     512 B |
SubjectPush | 1000000 | 3 | 15,179,871.23 ns |  62,605.9260 ns |  58,561.6164 ns |      - |     768 B |
SubjectPush | 1000000 | 4 | 19,611,917.58 ns | 121,256.5066 ns | 113,423.4005 ns |      - |    1024 B |
SubjectPush | 1000000 | 5 | 24,031,565.06 ns |  44,284.3113 ns |  41,423.5683 ns |      - |    1280 B |

#### Current sources

Method |       N | M |             Mean |           Error |          StdDev |  Gen 0 | Allocated |
------------ |-------- |-- |-----------------:|----------------:|----------------:|-------:|----------:|
SubjectPush |       1 | 0 |         11.32 ns |       0.2171 ns |       0.2031 ns | 0.0133 |      56 B |
SubjectPush |       1 | 1 |         69.47 ns |       1.4369 ns |       1.3441 ns | 0.0571 |     240 B |
SubjectPush |       1 | 2 |        128.68 ns |       1.0490 ns |       0.9812 ns | 0.1030 |     432 B |
SubjectPush |       1 | 3 |        196.85 ns |       1.0641 ns |       0.9953 ns | 0.1504 |     632 B |
SubjectPush |       1 | 4 |        263.19 ns |       1.8947 ns |       1.7723 ns | 0.1998 |     840 B |
SubjectPush |       1 | 5 |        326.86 ns |       2.1654 ns |       2.0255 ns | 0.2513 |    1056 B |
SubjectPush |      10 | 0 |         31.12 ns |       0.3221 ns |       0.3013 ns | 0.0133 |      56 B |
SubjectPush |      10 | 1 |        131.23 ns |       1.0637 ns |       0.9950 ns | 0.0570 |     240 B |
SubjectPush |      10 | 2 |        230.25 ns |       1.9067 ns |       1.7835 ns | 0.1030 |     432 B |
SubjectPush |      10 | 3 |        340.32 ns |       1.4259 ns |       1.1907 ns | 0.1502 |     632 B |
SubjectPush |      10 | 4 |        444.68 ns |       2.8181 ns |       2.4982 ns | 0.1998 |     840 B |
SubjectPush |      10 | 5 |        552.46 ns |       5.0258 ns |       4.7011 ns | 0.2508 |    1056 B |
SubjectPush |     100 | 0 |        251.17 ns |       1.8950 ns |       1.7726 ns | 0.0129 |      56 B |
SubjectPush |     100 | 1 |        652.62 ns |       3.8967 ns |       3.6450 ns | 0.0563 |     240 B |
SubjectPush |     100 | 2 |      1,172.73 ns |      11.3702 ns |      10.6357 ns | 0.1030 |     432 B |
SubjectPush |     100 | 3 |      1,696.32 ns |      10.9792 ns |      10.2700 ns | 0.1488 |     632 B |
SubjectPush |     100 | 4 |      2,203.16 ns |      17.2238 ns |      16.1112 ns | 0.1984 |     840 B |
SubjectPush |     100 | 5 |      2,710.21 ns |      11.2072 ns |      10.4832 ns | 0.2480 |    1056 B |
SubjectPush |    1000 | 0 |      2,351.67 ns |       7.6133 ns |       7.1215 ns | 0.0114 |      56 B |
SubjectPush |    1000 | 1 |      5,852.47 ns |      26.8812 ns |      25.1447 ns | 0.0534 |     240 B |
SubjectPush |    1000 | 2 |     10,578.73 ns |      44.1638 ns |      41.3109 ns | 0.0916 |     432 B |
SubjectPush |    1000 | 3 |     15,040.11 ns |      89.7528 ns |      83.9548 ns | 0.1373 |     632 B |
SubjectPush |    1000 | 4 |     19,555.20 ns |     111.4587 ns |      98.8052 ns | 0.1831 |     840 B |
SubjectPush |    1000 | 5 |     24,001.21 ns |     100.6208 ns |      89.1977 ns | 0.2441 |    1056 B |
SubjectPush |   10000 | 0 |     23,300.12 ns |     111.5983 ns |     104.3891 ns |      - |      56 B |
SubjectPush |   10000 | 1 |     57,527.22 ns |     296.3766 ns |     277.2308 ns |      - |     240 B |
SubjectPush |   10000 | 2 |    104,718.26 ns |   1,144.7964 ns |   1,070.8431 ns |      - |     433 B |
SubjectPush |   10000 | 3 |    148,480.89 ns |     576.6541 ns |     539.4025 ns |      - |     634 B |
SubjectPush |   10000 | 4 |    192,330.33 ns |     892.5833 ns |     834.9229 ns |      - |     842 B |
SubjectPush |   10000 | 5 |    241,786.77 ns |   4,228.9664 ns |   3,955.7774 ns | 0.2441 |    1056 B |
SubjectPush |  100000 | 0 |    231,989.26 ns |   1,135.9220 ns |   1,006.9652 ns |      - |      58 B |
SubjectPush |  100000 | 1 |    576,107.90 ns |   2,840.8838 ns |   2,657.3642 ns |      - |     248 B |
SubjectPush |  100000 | 2 |  1,035,572.21 ns |   6,365.2520 ns |   5,954.0601 ns |      - |     448 B |
SubjectPush |  100000 | 3 |  1,473,878.44 ns |   7,528.9764 ns |   7,042.6085 ns |      - |     640 B |
SubjectPush |  100000 | 4 |  1,914,425.10 ns |   5,420.0895 ns |   5,069.9546 ns |      - |     848 B |
SubjectPush |  100000 | 5 |  2,350,644.72 ns |   6,473.9978 ns |   5,739.0298 ns |      - |    1088 B |
SubjectPush | 1000000 | 0 |  2,324,667.71 ns |  14,194.8366 ns |  13,277.8577 ns |      - |      64 B |
SubjectPush | 1000000 | 1 |  6,163,305.19 ns | 120,611.2551 ns | 112,819.8319 ns |      - |     256 B |
SubjectPush | 1000000 | 2 | 11,125,094.90 ns | 212,119.6290 ns | 217,831.2213 ns |      - |     512 B |
SubjectPush | 1000000 | 3 | 14,913,930.31 ns | 288,690.7269 ns | 332,456.6407 ns |      - |     640 B |
SubjectPush | 1000000 | 4 | 19,120,783.66 ns |  96,596.7862 ns |  90,356.6850 ns |      - |    1024 B |
SubjectPush | 1000000 | 5 | 23,464,490.99 ns | 101,366.7913 ns |  89,859.0113 ns |      - |    1280 B |

#### Percentages

![image](https://user-images.githubusercontent.com/1269832/42385347-cdf79516-813c-11e8-82c3-2c353c5b05a1.png)
