### PR TITLE
4.x: Expand Subjects benchmark

### DIFF
--- a/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/SubjectBenchmark.cs
+++ b/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/SubjectBenchmark.cs
@@ -37,6 +37,70 @@ namespace Benchmarks.System.Reactive
             {
                 subj.OnNext(i);
             }
+            subj.OnCompleted();
+
+            return consumers;
+        }
+
+        [Benchmark]
+        public object AsyncSubjectPush()
+        {
+            var subj = new AsyncSubject<int>();
+            var consumers = new IDisposable[M];
+            var m = M;
+            for (var i = 0; i < m; i++)
+            {
+                consumers[i] = subj.Subscribe(v => Volatile.Write(ref _store, v));
+            }
+
+            var n = N;
+            for (var i = 0; i < n; i++)
+            {
+                subj.OnNext(i);
+            }
+            subj.OnCompleted();
+
+            return consumers;
+        }
+
+        [Benchmark]
+        public object BehaviorSubjectPush()
+        {
+            var subj = new BehaviorSubject<int>(-1);
+            var consumers = new IDisposable[M];
+            var m = M;
+            for (var i = 0; i < m; i++)
+            {
+                consumers[i] = subj.Subscribe(v => Volatile.Write(ref _store, v));
+            }
+
+            var n = N;
+            for (var i = 0; i < n; i++)
+            {
+                subj.OnNext(i);
+            }
+            subj.OnCompleted();
+
+            return consumers;
+        }
+
+        [Benchmark]
+        public object ReplaySubjectPush()
+        {
+            var subj = new ReplaySubject<int>();
+            var consumers = new IDisposable[M];
+            var m = M;
+            for (var i = 0; i < m; i++)
+            {
+                consumers[i] = subj.Subscribe(v => Volatile.Write(ref _store, v));
+            }
+
+            var n = N;
+            for (var i = 0; i < n; i++)
+            {
+                subj.OnNext(i);
+            }
+            subj.OnCompleted();
 
             return consumers;
         }


### PR DESCRIPTION
This PR adds extra benchmarks to measure all 4 subject types with 7 lengths and 0-5 observers.

Raw measurement: [gist](https://gist.github.com/akarnokd/6dd2e87c0f998ac4978a4598442680ab).

![image](https://user-images.githubusercontent.com/1269832/42446938-5b3eb976-8378-11e8-9dc9-bdb66ba45bc1.png)

![image](https://user-images.githubusercontent.com/1269832/42446946-61b80262-8378-11e8-83c0-a47e563269a6.png)
