### PR TITLE
Use Extras for ref assms

### DIFF
--- a/.vsts.ix-shared.yml
+++ b/.vsts.ix-shared.yml
@@ -16,13 +16,6 @@ steps:
 
 - task: DotNetCoreCLI@2
   inputs:
-    command: build
-    projects: Ix.NET/Source/refs/**/System.Interactive*.csproj
-    arguments: -c $(BuildConfiguration)   
-  displayName: Build reference assemblies
-
-- task: DotNetCoreCLI@2
-  inputs:
     command: pack
     packagesToPack: Ix.NET/Source/**/System.Interactive*.csproj;!Ix.NET/Source/**/*.Tests*.csproj
     configuration: $(BuildConfiguration)

--- a/.vsts.ix-shared.yml
+++ b/.vsts.ix-shared.yml
@@ -17,7 +17,7 @@ steps:
 - task: DotNetCoreCLI@2
   inputs:
     command: pack
-    packagesToPack: Ix.NET/Source/**/System.Interactive*.csproj;!Ix.NET/Source/**/*.Tests*.csproj
+    packagesToPack: Ix.NET/Source/**/System.Interactive*.csproj;!Ix.NET/Source/**/*.Tests*.csproj;!Ix.NET/Source/refs/**
     configuration: $(BuildConfiguration)
     packDirectory: $(Build.ArtifactStagingDirectory)\artifacts    
     verbosityPack: Minimal

--- a/Ix.NET/Source/Directory.build.targets
+++ b/Ix.NET/Source/Directory.build.targets
@@ -15,27 +15,4 @@
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
   </PropertyGroup>
 
-  <Target Name="GetRefsForPackage" BeforeTargets="_GetPackageFiles" 
-          Condition=" Exists('$(MSBuildThisFileDirectory)refs\$(MSBuildProjectName)\$(MSBuildProjectName).csproj') ">
-    
-    <MSBuild Projects="$(MSBuildThisFileDirectory)refs\$(MSBuildProjectName)\$(MSBuildProjectName).csproj" 
-             Targets="_GetTargetFrameworksOutput">
-
-      <Output TaskParameter="TargetOutputs" 
-              ItemName="_RefTargetFrameworks" />
-    </MSBuild>
-
-    <MSBuild Projects="$(MSBuildThisFileDirectory)refs\$(MSBuildProjectName)\$(MSBuildProjectName).csproj" 
-             Targets="_GetReferenceAssemblies" 
-             Properties="TargetFramework=%(_RefTargetFrameworks.Identity)">
-
-      <Output TaskParameter="TargetOutputs" 
-              ItemName="_refAssms" />
-    </MSBuild>
-
-    <ItemGroup>
-      <None Include="@(_refAssms)" PackagePath="ref/%(_refAssms.TargetFramework)" Pack="true" />
-    </ItemGroup>
-
-  </Target>
 </Project>

--- a/Ix.NET/Source/Ix.NET.sln
+++ b/Ix.NET/Source/Ix.NET.sln
@@ -33,9 +33,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Refs", "Refs", "{A3D72E6E-4
 		refs\Directory.build.props = refs\Directory.build.props
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Interactive", "refs\System.Interactive\System.Interactive.csproj", "{2EC0C302-B029-4DDB-AC91-000BF11006AD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Interactive.Ref", "refs\System.Interactive.Ref\System.Interactive.Ref.csproj", "{2EC0C302-B029-4DDB-AC91-000BF11006AD}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Interactive.Providers", "refs\System.Interactive.Providers\System.Interactive.Providers.csproj", "{5DF341BE-B369-4250-AFD4-604DE8C95E45}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Interactive.Providers.Ref", "refs\System.Interactive.Providers.Ref\System.Interactive.Providers.Ref.csproj", "{5DF341BE-B369-4250-AFD4-604DE8C95E45}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Benchmarks.System.Interactive", "Benchmarks.System.Interactive\Benchmarks.System.Interactive.csproj", "{3285529A-8227-4D40-B524-1A1F919F0E7B}"
 EndProject

--- a/Ix.NET/Source/System.Interactive.Providers/QueryableEx.cs
+++ b/Ix.NET/Source/System.Interactive.Providers/QueryableEx.cs
@@ -2425,7 +2425,7 @@ namespace System.Linq
         }
 #pragma warning restore 1591
 
-#if !(REF_ASSM && (NETCOREAPP2_0 || NETSTANDARD2_1))
+#if !(REFERENCE_ASSEMBLY && (NETCOREAPP2_0 || NETSTANDARD2_1))
         /// <summary>
         /// Returns a specified number of contiguous elements from the end of the sequence.
         /// </summary>

--- a/Ix.NET/Source/System.Interactive.Providers/System.Interactive.Providers.csproj
+++ b/Ix.NET/Source/System.Interactive.Providers/System.Interactive.Providers.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
     <Description>Interactive Extensions Providers Library used to build query providers and express queries over enumerable sequences.</Description>

--- a/Ix.NET/Source/System.Interactive.Providers/System.Interactive.Providers.csproj
+++ b/Ix.NET/Source/System.Interactive.Providers/System.Interactive.Providers.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\System.Interactive\System.Interactive.csproj" />
+    <ReferenceAssemblyProjectReference Include="..\refs\System.Interactive.Providers.Ref\System.Interactive.Providers.Ref.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0'">

--- a/Ix.NET/Source/System.Interactive/Skip.cs
+++ b/Ix.NET/Source/System.Interactive/Skip.cs
@@ -8,7 +8,7 @@ namespace System.Linq
 {
     public static partial class EnumerableEx
     {
-#if !(REF_ASSM && (NETCOREAPP2_0 || NETSTANDARD2_1))
+#if !(REFERENCE_ASSEMBLY && (NETCOREAPP2_0 || NETSTANDARD2_1))
         /// <summary>
         ///     Bypasses a specified number of contiguous elements from the end of the sequence and returns the remaining elements.
         /// </summary>

--- a/Ix.NET/Source/System.Interactive/System.Interactive.csproj
+++ b/Ix.NET/Source/System.Interactive/System.Interactive.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
     <Description>Interactive Extensions Main Library used to express queries over enumerable sequences.</Description>
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Properties\System.Interactive.rd.xml" />
+    <ReferenceAssemblyProjectReference Include="..\refs\System.Interactive.Ref\System.Interactive.Ref.csproj" />
   </ItemGroup>
-
 
 
   

--- a/Ix.NET/Source/System.Interactive/Take.cs
+++ b/Ix.NET/Source/System.Interactive/Take.cs
@@ -8,7 +8,7 @@ namespace System.Linq
 {
     public static partial class EnumerableEx
     {
-#if !(REF_ASSM && (NETCOREAPP2_0 || NETSTANDARD2_1))
+#if !(REFERENCE_ASSEMBLY && (NETCOREAPP2_0 || NETSTANDARD2_1))
         /// <summary>
         ///     Returns a specified number of contiguous elements from the end of the sequence.
         /// </summary>

--- a/Ix.NET/Source/global.json
+++ b/Ix.NET/Source/global.json
@@ -1,0 +1,5 @@
+{
+  "msbuild-sdks": {
+    "MSBuild.Sdk.Extras": "1.6.30-preview"
+  }
+}

--- a/Ix.NET/Source/refs/Directory.build.props
+++ b/Ix.NET/Source/refs/Directory.build.props
@@ -5,17 +5,6 @@
   <PropertyGroup>
     <!-- This is here so we can create a fake .NET Standard 2.1 facade -->
     <NETStandardMaximumVersion>2.1</NETStandardMaximumVersion>
-    <DefineConstants>$(DefineConstants);REF_ASSM</DefineConstants>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
-    <Deterministic>true</Deterministic>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <Target Name="_GetReferenceAssemblies" DependsOnTargets="Build" Returns="@(ReferenceAssembliesOutput)">
-    <ItemGroup>
-      <ReferenceAssembliesOutput Include="@(IntermediateRefAssembly->'%(FullPath)')" TargetFramework="$(TargetFramework)" />
-      <ReferenceAssembliesOutput Include="@(DocumentationProjectOutputGroupOutput->'%(FullPath)')" TargetFramework="$(TargetFramework)" />
-    </ItemGroup>
-  </Target>
-  
 </Project>

--- a/Ix.NET/Source/refs/System.Interactive.Providers.Ref/System.Interactive.Providers.Ref.csproj
+++ b/Ix.NET/Source/refs/System.Interactive.Providers.Ref/System.Interactive.Providers.Ref.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
     <Description>Interactive Extensions Providers Library used to build query providers and express queries over enumerable sequences.</Description>
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\System.Interactive\System.Interactive.csproj" />
+    <ProjectReference Include="..\System.Interactive.Ref\System.Interactive.Ref.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Ix.NET/Source/refs/System.Interactive.Ref/System.Interactive.Ref.csproj
+++ b/Ix.NET/Source/refs/System.Interactive.Ref/System.Interactive.Ref.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
     <Description>Interactive Extensions Main Library used to express queries over enumerable sequences.</Description>


### PR DESCRIPTION
Remove custom code for reference assemblies in favor of the SDK Extras