### PR TITLE
Prepend vs StartWith benchmark

### DIFF
--- a/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/PrependVsStartWtihBenchmark.cs
+++ b/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/PrependVsStartWtihBenchmark.cs
@@ -1,0 +1,71 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+#if (CURRENT)
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Threading;
+using BenchmarkDotNet.Attributes;
+
+namespace Benchmarks.System.Reactive
+{
+    [MemoryDiagnoser]
+    public class PrependVsStartWtihBenchmark
+    {
+        private int _store;
+
+        [Benchmark(Baseline = true)]
+        public void Prepend()
+        {
+            Observable
+                .Empty<int>()
+                .Prepend(0)
+                .Subscribe(v => Volatile.Write(ref _store, v));
+        }
+
+        [Benchmark]
+        public void Prepend_Create()
+        {
+            Observable
+                .Empty<int>()
+                .Prepend(0);
+        }
+
+
+        static readonly IObservable<int> _prependObservable = Observable.Empty<int>().Prepend(0);
+        [Benchmark]
+        public void Prepend_Subscribe()
+        {
+            _prependObservable
+                .Subscribe(v => Volatile.Write(ref _store, v));
+        }
+
+        [Benchmark]
+        public void StartWith()
+        {
+            Observable
+                .Empty<int>()
+                .StartWith(0)
+                .Subscribe(v => Volatile.Write(ref _store, v));
+        }
+
+        [Benchmark]
+        public void StartWith_Create()
+        {
+            Observable
+                .Empty<int>()
+                .StartWith(0);
+        }
+
+        static readonly IObservable<int> _startWithObservable = Observable.Empty<int>().StartWith(0);
+        [Benchmark]
+        public void StartWith_Subscribe()
+        {
+            _startWithObservable
+                .Subscribe(v => Volatile.Write(ref _store, v));
+        }
+    }
+}
+#endif

--- a/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/PrependVsStartWtihBenchmark.cs
+++ b/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/PrependVsStartWtihBenchmark.cs
@@ -15,6 +15,7 @@ namespace Benchmarks.System.Reactive
     public class PrependVsStartWtihBenchmark
     {
         private int _store;
+        private IObservable<int> _obsStore;
 
         [Benchmark(Baseline = true)]
         public void Prepend()
@@ -28,7 +29,7 @@ namespace Benchmarks.System.Reactive
         [Benchmark]
         public void Prepend_Create()
         {
-            Observable
+            _obsStore = Observable
                 .Empty<int>()
                 .Prepend(0);
         }
@@ -54,7 +55,7 @@ namespace Benchmarks.System.Reactive
         [Benchmark]
         public void StartWith_Create()
         {
-            Observable
+            _obsStore = Observable
                 .Empty<int>()
                 .StartWith(0);
         }

--- a/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/Program.cs
+++ b/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/Program.cs
@@ -30,6 +30,7 @@ namespace Benchmarks.System.Reactive
                 typeof(ComparisonAsyncBenchmark)
 #if (CURRENT)
                 ,typeof(AppendPrependBenchmark)
+                ,typeof(PrependVsStartWtihBenchmark)
 #endif
             });
 


### PR DESCRIPTION
Here is a benchmark test that compares the single item prepend and start with operator. I found the difference quite interesting. I did not expect the difference to be that enormous.

``` ini

BenchmarkDotNet=v0.10.14, OS=Windows 10.0.17134
Intel Core i5-5200U CPU 2.20GHz (Broadwell), 1 CPU, 4 logical and 2 physical cores
Frequency=2143476 Hz, Resolution=466.5319 ns, Timer=TSC
  [Host]     : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3110.0
  DefaultJob : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3110.0


```
|              Method |        Mean |     Error |    StdDev | Scaled | ScaledSD |  Gen 0 | Allocated |
|-------------------- |------------:|----------:|----------:|-------:|---------:|-------:|----------:|
|             Prepend |   706.17 ns |  9.443 ns |  8.833 ns |   1.00 |     0.00 | 0.1574 |     248 B |
|      Prepend_Create |    60.35 ns |  1.191 ns |  1.114 ns |   0.09 |     0.00 | 0.0203 |      32 B |
|   Prepend_Subscribe |   613.56 ns | 12.004 ns | 12.327 ns |   0.87 |     0.02 | 0.1364 |     216 B |
|           StartWith | 3,680.93 ns | 71.507 ns | 66.888 ns |   5.21 |     0.11 | 0.7553 |    1200 B |
|    StartWith_Create |   402.46 ns |  2.475 ns |  1.932 ns |   0.57 |     0.01 | 0.0811 |     128 B |
| StartWith_Subscribe | 3,195.40 ns | 19.593 ns | 16.361 ns |   4.53 |     0.06 | 0.6752 |    1066 B |
