### PR TITLE
Hide List<E> with .Skip(0)

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Internal/Lookup.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/Lookup.cs
@@ -46,13 +46,12 @@ namespace System.Reactive
             }
         }
 
-        private IEnumerable<E> Hide(List<E> elements)
-        {
-            foreach (var x in elements)
-            {
-                yield return x;
-            }
-        }
+        // Instead of yielding the elements in a foreach loop, zero
+        // elements are skipped. Technically the result is the same
+        // with the benefit that the LINQ implementation can internally
+        // generate a type that keeps track of count of the enumerable.
+        // Consecutive operators can benefit from that knowledge.
+        private static IEnumerable<E> Hide(List<E> elements) => elements.Skip(0);
 
         public IEnumerator<IGrouping<K, E>> GetEnumerator()
         {

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ToLookupTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ToLookupTest.cs
@@ -200,6 +200,14 @@ namespace ReactiveTests.Tests
         }
 
         [Fact]
+        public void ToLookup_Hides_Internal_List()
+        {
+            var d1 = Observable.Range(1, 10).ToLookup(x => (x % 2).ToString()).First();
+            Assert.False(d1["0"] is ICollection<int>);
+            Assert.False(d1["0"] is IList<int>);
+        }
+
+        [Fact]
         public void ToLookup_Groups()
         {
             var d1 = Observable.Range(1, 10).ToLookup(x => (x % 2).ToString()).First();


### PR DESCRIPTION
Instead of yielding the elements in a foreach loop, zero elements are skipped. Technically the result is the same with the benefit that the LINQ implementation can internally generate a type that keeps track of count of the enumerable. Consecutive operators can benefit from that knowledge.