### PR TITLE
Fix Zip(IEnumerable) NullReferenceException if a source completes immediately

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Zip.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Zip.cs
@@ -661,7 +661,11 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     else
                     {
-                        _subscriptions[index].Dispose();
+                        var subscriptions = Volatile.Read(ref _subscriptions);
+                        if (subscriptions != null && subscriptions != Array.Empty<IDisposable>())
+                        {
+                            Disposable.TryDispose(ref subscriptions[index]);
+                        }
                     }
                 }
             }

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ZipTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ZipTest.cs
@@ -4448,6 +4448,41 @@ namespace ReactiveTests.Tests
 
         #endregion
 
+        [Fact]
+        public void Zip2WithImmediateReturn()
+        {
+            Observable.Zip<Unit, Unit, Unit>(
+                Observable.Return(Unit.Default), 
+                Observable.Return(Unit.Default), 
+                (_, __) => Unit.Default
+            )
+            .Subscribe(_ => {  });
+        }
+
+        [Fact]
+        public void Zip3WithImmediateReturn()
+        {
+            Observable.Zip<Unit, Unit, Unit, Unit>(
+                Observable.Return(Unit.Default),
+                Observable.Return(Unit.Default),
+                Observable.Return(Unit.Default),
+                (_, __, ___) => Unit.Default
+            )
+            .Subscribe(_ => { });
+        }
+
+        [Fact]
+        public void ZipEnumerableWithImmediateReturn()
+        {
+            Enumerable.Range(0, 100)
+                .Select(_ => Observable.Return(Unit.Default))
+                .Zip()
+                .Subscribe(_ =>
+                {
+
+                }
+                );
+        }
     }
 #pragma warning restore IDE0039 // Use local function
 }


### PR DESCRIPTION
If a source to the `Zip` operator completes immediately before the `SubscribeSafe` returned, the associated entry in `_subscriptions` would be still null, thus the `Dispose()` call fails with a `NullReferenceException`.

The fix checks if the `_subscriptions` is still valid and uses the deferred dispose approach to clean up the indexed entry.