### PR TITLE
Emit a warning if the half-serializer ignores a value in ForwardOnNext.

### DIFF
--- a/Rx.NET/Source/Directory.build.targets
+++ b/Rx.NET/Source/Directory.build.targets
@@ -1,7 +1,7 @@
 <Project>
   <!-- This props all need to be set in targets as they depend on the values set earlier -->
   <PropertyGroup Condition="'$(TargetFramework)' == 'net46'">
-    <DefineConstants>$(DefineConstants);HAS_WINRT;PREFER_ASYNC;HAS_TPL46;DESKTOPCLR</DefineConstants>
+    <DefineConstants>$(DefineConstants);HAS_TRACE;HAS_WINRT;PREFER_ASYNC;HAS_TPL46;DESKTOPCLR</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'uap10.0'">
     <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
@@ -9,9 +9,9 @@
     <DefineConstants>$(DefineConstants);NO_CODE_COVERAGE_ATTRIBUTE;HAS_WINRT;PREFER_ASYNC;HAS_TPL46;NO_REMOTING;NO_SERIALIZABLE;CRIPPLED_REFLECTION;NO_THREAD;WINDOWS</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'uap10.0.16299'">
-    <DefineConstants>$(DefineConstants);HAS_WINRT;PREFER_ASYNC;HAS_TPL46;NO_REMOTING;WINDOWS</DefineConstants>
+    <DefineConstants>$(DefineConstants);HAS_TRACE;HAS_WINRT;PREFER_ASYNC;HAS_TPL46;NO_REMOTING;WINDOWS</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netcoreapp2.0'">
-    <DefineConstants>$(DefineConstants);HAS_WINRT;PREFER_ASYNC;HAS_TPL46;NO_REMOTING</DefineConstants>
+    <DefineConstants>$(DefineConstants);HAS_TRACE;HAS_WINRT;PREFER_ASYNC;HAS_TPL46;NO_REMOTING</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/Rx.NET/Source/src/System.Reactive/Internal/HalfSerializer.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/HalfSerializer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information. 
 
+using System.Diagnostics;
 using System.Threading;
 
 namespace System.Reactive
@@ -47,6 +48,10 @@ namespace System.Reactive
                     }
                 }
             }
+#if (HAS_TRACE)
+            else if (error == null)
+                Trace.TraceWarning("OnNext called while another OnNext call was in progress on the same Observer.");
+#endif
         }
 
         /// <summary>


### PR DESCRIPTION
In case an upstream observable doesn't behave according to the protocol, the half-serializer will swallow values in ForwardOnNext. While the guidelines state that it is safe to assume that upstreams behave properly, this behaviour is different to <4.1.0 and it is fair to produce a warning.