### PR TITLE
4.x: Fix 3+ arg Zip not working with immediate sources

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Zip.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Zip.cs
@@ -524,7 +524,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         public override void OnCompleted()
         {
-            Dispose();
+            base.Dispose(true);
 
             lock (_gate)
             {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Zip.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Zip.cs
@@ -524,6 +524,9 @@ namespace System.Reactive.Linq.ObservableImpl
 
         public override void OnCompleted()
         {
+            // Calling Dispose() here would clear the queue prematurely.
+            // We only need to dispose the IDisposable of the upstream,
+            // which is done by SafeObserver.Dispose(bool).
             base.Dispose(true);
 
             lock (_gate)

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ZipTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ZipTest.cs
@@ -4462,13 +4462,17 @@ namespace ReactiveTests.Tests
         [Fact]
         public void Zip3WithImmediateReturn()
         {
-            Observable.Zip<Unit, Unit, Unit, Unit>(
-                Observable.Return(Unit.Default),
-                Observable.Return(Unit.Default),
-                Observable.Return(Unit.Default),
-                (_, __, ___) => Unit.Default
+            int result = 0;
+
+            Observable.Zip<int, int, int, int>(
+                Observable.Return(1),
+                Observable.Return(2),
+                Observable.Return(4),
+                (a, b, c) => a + b + c
             )
-            .Subscribe(_ => { });
+            .Subscribe(v => result = v);
+
+            Assert.Equal(7, result);
         }
 
         [Fact]


### PR DESCRIPTION
This PR fixes the issue with the 3+ argument `Zip` operator not producing anything with an immediate `Observable.Return` source(s).

The problem was that the per-source `OnCompleted` called the `Dispose` method which then called the overridden `Dispose(bool)` method inside `ZipObservable` that cleared the queue, thus the operator could never make a full row. The fix is to call the original `Dispose(bool)` which only disposes the upstream but leaves the queue alone.

Fixes: #824