### PR TITLE
light up the NuGet packages on GitHub

### DIFF
--- a/Ix.NET/Source/Directory.build.props
+++ b/Ix.NET/Source/Directory.build.props
@@ -6,7 +6,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>.NET Foundation and Contributors</Authors>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkId=261274</PackageIconUrl>
-    <PackageProjectUrl>http://go.microsoft.com/fwlink/?LinkId=261273</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/dotnet/reactive</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/Reactive-Extensions/Rx.NET/master/Ix.NET/Source/license.txt</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>    
     <SignAssembly>true</SignAssembly>

--- a/Rx.NET/Source/Directory.build.props
+++ b/Rx.NET/Source/Directory.build.props
@@ -6,7 +6,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>.NET Foundation and Contributors</Authors>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkId=261274</PackageIconUrl>
-    <PackageProjectUrl>http://go.microsoft.com/fwlink/?LinkId=261273</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/dotnet/reactive</PackageProjectUrl>
     <PackageLicenseUrl>http://go.microsoft.com/fwlink/?LinkID=261272</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>    
     <DebugType>embedded</DebugType>

--- a/Rx.NET/Source/facades/System.Reactive.Compatibility.nuspec
+++ b/Rx.NET/Source/facades/System.Reactive.Compatibility.nuspec
@@ -7,7 +7,7 @@
         <authors>.NET Foundation and Contributors</authors>
         <owners>Microsoft,RxTeam</owners>
         <licenseUrl>http://go.microsoft.com/fwlink/?LinkID=261272</licenseUrl>
-        <projectUrl>http://go.microsoft.com/fwlink/?LinkId=261273</projectUrl>
+        <PackageProjectUrl>https://github.com/dotnet/reactive</PackageProjectUrl>
         <iconUrl>http://go.microsoft.com/fwlink/?LinkId=261274</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Reactive Extensions (Rx) Compatibility Library for enabling v3 apps to work with v4</description>


### PR DESCRIPTION
You might have noticed [this announcement](https://blog.github.com/2018-10-16-future-of-software/#java-and-net-support-for-security-vulnerability-alerts) about adding support for NuGet packages to GitHub's security vulnerability alerts.

I tested out Octokit.net today and noticed this, and got a bit sad:

<img width="520" src="https://user-images.githubusercontent.com/359239/47040828-a4b09600-d15d-11e8-90f6-929ac6c03215.png">

Nevermind, it's easy to fix - if the `PackageProjectUrl` or `RepositoryUrl` attributes point to a GitHub repository URL (we're not following redirects, ain't nobody got time for that), these will light up differently:

<img width="399" src="https://user-images.githubusercontent.com/359239/47041030-26082880-d15e-11e8-97ac-cd2f149246fc.png">

This sadly won't be backported to the old package formats, but anyone using `System.Reactive` will get the benefit after a package update.

I'm not sure how attached to `fwlink`s you are these days, so `RepositoryUrl` might be the necessary workaroudn here if you want to keep them Just In Case™.