### PR TITLE
Ix 4.0: Add shared state/concurrency tests

### DIFF
--- a/Ix.NET/Source/System.Linq.Async.Tests/SharedState.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/SharedState.cs
@@ -26,7 +26,7 @@ namespace Tests
         {
             using (Use())
             {
-                await Task.Yield();
+                await Task.Delay(TimeSpan.FromMilliseconds(10));
             }
         }
 

--- a/Ix.NET/Source/System.Linq.Async.Tests/SharedState.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/SharedState.cs
@@ -10,12 +10,16 @@ namespace Tests
         private readonly object _locker = new object();
         private bool _inUse = false;
 
+        public int ConcurrentAccessCount { get; private set; }
+
         public IDisposable Use()
         {
             lock (_locker)
             {
                 if (_inUse)
-                    throw new InvalidOperationException("Iterator already in use");
+                {
+                    ConcurrentAccessCount++;
+                }
                 _inUse = true;
             }
 

--- a/Ix.NET/Source/System.Linq.Async.Tests/SharedState.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/SharedState.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Tests
+{
+    public class SharedState
+    {
+        private readonly object _locker = new object();
+        private bool _inUse = false;
+
+        public IDisposable Use()
+        {
+            lock (_locker)
+            {
+                if (_inUse)
+                    throw new InvalidOperationException("Iterator already in use");
+                _inUse = true;
+            }
+
+            return new UnlockDisposable(this);
+        }
+
+        public async ValueTask GetTask()
+        {
+            using (Use())
+            {
+                await Task.Yield();
+            }
+        }
+
+        public async ValueTask<T> GetTask<T>(T value)
+        {
+            using (Use())
+            {
+                await Task.Yield();
+                return value;
+            }
+        }
+
+        private class UnlockDisposable : IDisposable
+        {
+            private SharedState _state;
+
+            public UnlockDisposable(SharedState state)
+            {
+                _state = state;
+            }
+            
+            public void Dispose()
+            {
+                lock (_state._locker)
+                {
+                    _state._inUse = false;
+                }
+            }
+        }
+    }
+}

--- a/Ix.NET/Source/System.Linq.Async.Tests/SharedStateAsyncEnumerable.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/SharedStateAsyncEnumerable.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using System.Linq;
+
+namespace Tests
+{
+    static public class TestExts
+    {
+        public static IAsyncEnumerable<T> ToSharedStateAsyncEnumerable<T>(this IEnumerable<T> enumerable, SharedState state = null)
+        {
+            return new SharedStateAsyncEnumerable<T>(enumerable.ToAsyncEnumerable(), state ?? new SharedState());
+        }
+
+        public static IAsyncEnumerable<T> ToSharedStateAsyncEnumerable<T>(this IAsyncEnumerable<T> enumerable, SharedState state = null)
+        {
+            return new SharedStateAsyncEnumerable<T>(enumerable, state ?? new SharedState());
+        }
+
+        private class SharedStateAsyncEnumerable<T> : IAsyncEnumerable<T>
+        {
+            private readonly IAsyncEnumerable<T> _enumerable;
+            private readonly SharedState _state;
+
+            public SharedStateAsyncEnumerable(IAsyncEnumerable<T> enumerable, SharedState sharedState)
+            {
+                _enumerable = enumerable;
+                _state = sharedState;
+            }
+
+            public IAsyncEnumerator<T> GetAsyncEnumerator() => new Enumerator(_enumerable.GetAsyncEnumerator(), _state);
+
+            private class Enumerator : IAsyncEnumerator<T>
+            {
+                private readonly IAsyncEnumerator<T> _enumerator;
+                private readonly SharedState _state;
+
+                public Enumerator(IAsyncEnumerator<T> asyncEnumerator, SharedState state)
+                {
+                    _enumerator = asyncEnumerator;
+                    _state = state;
+                }
+
+                public T Current => _enumerator.Current;
+
+                public async ValueTask DisposeAsync()
+                {
+                    using (_state.Use())
+                    {
+                        await Task.Yield();
+                        await _enumerator.DisposeAsync();
+                    }
+                }
+
+                public async ValueTask<bool> MoveNextAsync()
+                {
+                    using (_state.Use())
+                    { 
+                        await Task.Yield();
+                        return await _enumerator.MoveNextAsync();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Ix.NET/Source/System.Linq.Async.Tests/SharedStateAsyncEnumerable.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/SharedStateAsyncEnumerable.cs
@@ -9,14 +9,14 @@ namespace Tests
 {
     static public class TestExts
     {
-        public static IAsyncEnumerable<T> ToSharedStateAsyncEnumerable<T>(this IEnumerable<T> enumerable, SharedState state = null)
+        public static IAsyncEnumerable<T> ToSharedStateAsyncEnumerable<T>(this IEnumerable<T> enumerable, SharedState state)
         {
-            return new SharedStateAsyncEnumerable<T>(enumerable.ToAsyncEnumerable(), state ?? new SharedState());
+            return new SharedStateAsyncEnumerable<T>(enumerable.ToAsyncEnumerable(), state);
         }
 
-        public static IAsyncEnumerable<T> ToSharedStateAsyncEnumerable<T>(this IAsyncEnumerable<T> enumerable, SharedState state = null)
+        public static IAsyncEnumerable<T> ToSharedStateAsyncEnumerable<T>(this IAsyncEnumerable<T> enumerable, SharedState state)
         {
-            return new SharedStateAsyncEnumerable<T>(enumerable, state ?? new SharedState());
+            return new SharedStateAsyncEnumerable<T>(enumerable, state);
         }
 
         private class SharedStateAsyncEnumerable<T> : IAsyncEnumerable<T>

--- a/Ix.NET/Source/System.Linq.Async.Tests/SharedStateAsyncEnumerable.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/SharedStateAsyncEnumerable.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using System.Linq;
+using System.Threading;
 
 namespace Tests
 {
@@ -29,7 +30,7 @@ namespace Tests
                 _state = sharedState;
             }
 
-            public IAsyncEnumerator<T> GetAsyncEnumerator() => new Enumerator(_enumerable.GetAsyncEnumerator(), _state);
+            public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken ca) => new Enumerator(_enumerable.GetAsyncEnumerator(ca), _state);
 
             private class Enumerator : IAsyncEnumerator<T>
             {

--- a/Ix.NET/Source/System.Linq.Async.Tests/SharedStateTests.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/SharedStateTests.cs
@@ -17,9 +17,9 @@ namespace Tests
             var t1 = state.GetTask();
             var t2 = state.GetTask();
 
-            Task f() => Task.WhenAll(t1.AsTask(), t2.AsTask());
+            await Task.WhenAll(t1.AsTask(), t2.AsTask());
 
-            await Assert.ThrowsAsync<InvalidOperationException>(f);
+            Assert.Equal(1, state.ConcurrentAccessCount);
         }
 
         [Fact]
@@ -27,13 +27,10 @@ namespace Tests
         {
             var state = new SharedState();
 
-            async Task f()
-            {
-                await state.GetTask();
-                await state.GetTask();
-            }
+            await state.GetTask();
+            await state.GetTask();
 
-            await f(); // Should not throw
+            Assert.Equal(0, state.ConcurrentAccessCount);
         }
 
         [Fact]
@@ -50,9 +47,9 @@ namespace Tests
             var t1 = e1.MoveNextAsync();
             var t2 = e2.MoveNextAsync();
 
-            Task f() => Task.WhenAll(t1.AsTask(), t2.AsTask());
+            await Task.WhenAll(t1.AsTask(), t2.AsTask());
 
-            await Assert.ThrowsAsync<InvalidOperationException>(f);
+            Assert.Equal(1, state.ConcurrentAccessCount);
         }
 
         [Fact]
@@ -66,13 +63,10 @@ namespace Tests
             var e1 = seq1.GetAsyncEnumerator();
             var e2 = seq2.GetAsyncEnumerator();
 
-            async Task f()
-            {
-                await e1.MoveNextAsync();
-                await e2.MoveNextAsync();
-            }
+            await e1.MoveNextAsync();
+            await e2.MoveNextAsync();
 
-            await f(); // Should not throw
+            Assert.Equal(0, state.ConcurrentAccessCount);
         }
 
         [Fact]
@@ -89,9 +83,9 @@ namespace Tests
             var t1 = e1.DisposeAsync();
             var t2 = e2.DisposeAsync();
 
-            Task f() => Task.WhenAll(t1.AsTask(), t2.AsTask());
+            await Task.WhenAll(t1.AsTask(), t2.AsTask());
 
-            await Assert.ThrowsAsync<InvalidOperationException>(f);
+            Assert.Equal(1, state.ConcurrentAccessCount);
         }
 
         [Fact]
@@ -105,13 +99,10 @@ namespace Tests
             var e1 = seq1.GetAsyncEnumerator();
             var e2 = seq2.GetAsyncEnumerator();
 
-            async Task f()
-            {
-                await e1.DisposeAsync();
-                await e2.DisposeAsync();
-            }
+            await e1.DisposeAsync();
+            await e2.DisposeAsync();
 
-            await f(); // Should not throw
+            Assert.Equal(0, state.ConcurrentAccessCount);
         }
     }
 }

--- a/Ix.NET/Source/System.Linq.Async.Tests/SharedStateTests.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/SharedStateTests.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Tests
+{
+    public class SharedStateTests
+    {
+        [Fact]
+        public async Task ConcurrentTask()
+        {
+            var state = new SharedState();
+
+            var t1 = state.GetTask();
+            var t2 = state.GetTask();
+
+            Task f() => Task.WhenAll(t1.AsTask(), t2.AsTask());
+
+            await Assert.ThrowsAsync<InvalidOperationException>(f);
+        }
+
+        [Fact]
+        public async Task SequentialTask()
+        {
+            var state = new SharedState();
+
+            async Task f()
+            {
+                await state.GetTask();
+                await state.GetTask();
+            }
+
+            await f(); // Should not throw
+        }
+
+        [Fact]
+        public async Task ConcurrentMoveNextAsync()
+        {
+            var state = new SharedState();
+
+            var seq1 = AsyncEnumerable.Range(0, 10).ToSharedStateAsyncEnumerable(state);
+            var seq2 = AsyncEnumerable.Range(0, 10).ToSharedStateAsyncEnumerable(state);
+
+            var e1 = seq1.GetAsyncEnumerator();
+            var e2 = seq2.GetAsyncEnumerator();
+
+            var t1 = e1.MoveNextAsync();
+            var t2 = e2.MoveNextAsync();
+
+            Task f() => Task.WhenAll(t1.AsTask(), t2.AsTask());
+
+            await Assert.ThrowsAsync<InvalidOperationException>(f);
+        }
+
+        [Fact]
+        public async Task SequentialMoveNextAsync()
+        {
+            var state = new SharedState();
+
+            var seq1 = AsyncEnumerable.Range(0, 10).ToSharedStateAsyncEnumerable(state);
+            var seq2 = AsyncEnumerable.Range(0, 10).ToSharedStateAsyncEnumerable(state);
+
+            var e1 = seq1.GetAsyncEnumerator();
+            var e2 = seq2.GetAsyncEnumerator();
+
+            async Task f()
+            {
+                await e1.MoveNextAsync();
+                await e2.MoveNextAsync();
+            }
+
+            await f(); // Should not throw
+        }
+
+        [Fact]
+        public async Task ConcurrentDisposeAsync()
+        {
+            var state = new SharedState();
+
+            var seq1 = AsyncEnumerable.Range(0, 10).ToSharedStateAsyncEnumerable(state);
+            var seq2 = AsyncEnumerable.Range(0, 10).ToSharedStateAsyncEnumerable(state);
+
+            var e1 = seq1.GetAsyncEnumerator();
+            var e2 = seq2.GetAsyncEnumerator();
+
+            var t1 = e1.DisposeAsync();
+            var t2 = e2.DisposeAsync();
+
+            Task f() => Task.WhenAll(t1.AsTask(), t2.AsTask());
+
+            await Assert.ThrowsAsync<InvalidOperationException>(f);
+        }
+
+        [Fact]
+        public async Task SequentialDisposeAsync()
+        {
+            var state = new SharedState();
+
+            var seq1 = AsyncEnumerable.Range(0, 10).ToSharedStateAsyncEnumerable(state);
+            var seq2 = AsyncEnumerable.Range(0, 10).ToSharedStateAsyncEnumerable(state);
+
+            var e1 = seq1.GetAsyncEnumerator();
+            var e2 = seq2.GetAsyncEnumerator();
+
+            async Task f()
+            {
+                await e1.DisposeAsync();
+                await e2.DisposeAsync();
+            }
+
+            await f(); // Should not throw
+        }
+    }
+}

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Concat.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Concat.cs
@@ -132,5 +132,18 @@ namespace Tests
 
             Assert.Equal(8, await c.CountAsync());
         }
+
+        [Fact]
+        public async Task Concat_Concurrency()
+        {
+            var state = new SharedState();
+            var xs = new[] { 1, 2, 3 }.ToSharedStateAsyncEnumerable(state);
+            var ys = new[] { 4, 5 }.ToSharedStateAsyncEnumerable(state);
+            var zs = new[] { 6, 7, 8 }.ToSharedStateAsyncEnumerable(state);
+
+            async Task f() => await xs.Concat(ys).Concat(zs).Last();
+
+            await f(); // Should not throw
+        }
     }
 }

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Concat.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Concat.cs
@@ -141,7 +141,7 @@ namespace Tests
             var ys = new[] { 4, 5 }.ToSharedStateAsyncEnumerable(state);
             var zs = new[] { 6, 7, 8 }.ToSharedStateAsyncEnumerable(state);
 
-            async Task f() => await xs.Concat(ys).Concat(zs).Last();
+            async Task f() => await xs.Concat(ys).Concat(zs).LastAsync();
 
             await f(); // Should not throw
         }

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Concat.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Concat.cs
@@ -141,9 +141,9 @@ namespace Tests
             var ys = new[] { 4, 5 }.ToSharedStateAsyncEnumerable(state);
             var zs = new[] { 6, 7, 8 }.ToSharedStateAsyncEnumerable(state);
 
-            async Task f() => await xs.Concat(ys).Concat(zs).LastAsync();
+            await xs.Concat(ys).Concat(zs).LastAsync();
 
-            await f(); // Should not throw
+            Assert.Equal(0, state.ConcurrentAccessCount);
         }
     }
 }

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Except.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Except.cs
@@ -56,6 +56,18 @@ namespace Tests
             await SequenceIdentity(res);
         }
 
+        [Fact]
+        public async Task Except_Concurrency()
+        {
+            var state = new SharedState();
+            var xs = new[] { 1, 2, 3 }.ToSharedStateAsyncEnumerable(state);
+            var ys = new[] { 3, 5, 1, 4 }.ToSharedStateAsyncEnumerable(state);
+
+            async Task f() => await xs.Except(ys).Last();
+
+            await f(); // Should not throw
+        }
+
         private sealed class Eq : IEqualityComparer<int>
         {
             public bool Equals(int x, int y)

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Except.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Except.cs
@@ -63,7 +63,7 @@ namespace Tests
             var xs = new[] { 1, 2, 3 }.ToSharedStateAsyncEnumerable(state);
             var ys = new[] { 3, 5, 1, 4 }.ToSharedStateAsyncEnumerable(state);
 
-            async Task f() => await xs.Except(ys).Last();
+            async Task f() => await xs.Except(ys).LastAsync();
 
             await f(); // Should not throw
         }

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Except.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Except.cs
@@ -63,9 +63,9 @@ namespace Tests
             var xs = new[] { 1, 2, 3 }.ToSharedStateAsyncEnumerable(state);
             var ys = new[] { 3, 5, 1, 4 }.ToSharedStateAsyncEnumerable(state);
 
-            async Task f() => await xs.Except(ys).LastAsync();
+            await xs.Except(ys).LastAsync();
 
-            await f(); // Should not throw
+            Assert.Equal(0, state.ConcurrentAccessCount);
         }
 
         private sealed class Eq : IEqualityComparer<int>

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/GroupJoin.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/GroupJoin.cs
@@ -136,7 +136,7 @@ namespace Tests
             var xs = new[] { 0, 1, 2 }.ToSharedStateAsyncEnumerable(state);
             var ys = new[] { 3, 6, 4 }.ToSharedStateAsyncEnumerable(state);
 
-            async Task f() => await xs.GroupJoin(ys, x => x % 3, y => y % 3, (x, i) => x + " - " + i.Aggregate("", (s, j) => s + j).Result).Last();
+            async Task f() => await xs.GroupJoin(ys, x => x % 3, y => y % 3, (x, i) => x + " - " + i.AggregateAsync("", (s, j) => s + j).Result).LastAsync();
 
             await f(); // Should not throw
         }

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/GroupJoin.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/GroupJoin.cs
@@ -136,9 +136,9 @@ namespace Tests
             var xs = new[] { 0, 1, 2 }.ToSharedStateAsyncEnumerable(state);
             var ys = new[] { 3, 6, 4 }.ToSharedStateAsyncEnumerable(state);
 
-            async Task f() => await xs.GroupJoin(ys, x => x % 3, y => y % 3, (x, i) => x + " - " + i.AggregateAsync("", (s, j) => s + j).Result).LastAsync();
+            await xs.GroupJoin(ys, x => x % 3, y => y % 3, (x, i) => x + " - " + i.AggregateAsync("", (s, j) => s + j).Result).LastAsync();
 
-            await f(); // Should not throw
+            Assert.Equal(0, state.ConcurrentAccessCount);
         }
     }
 }

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/GroupJoin.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/GroupJoin.cs
@@ -128,5 +128,17 @@ namespace Tests
             await HasNextAsync(e, "0 - 36");
             await AssertThrowsAsync(e.MoveNextAsync(), ex);
         }
+
+        [Fact]
+        public async Task GroupJoin_Concurrency()
+        {
+            var state = new SharedState();
+            var xs = new[] { 0, 1, 2 }.ToSharedStateAsyncEnumerable(state);
+            var ys = new[] { 3, 6, 4 }.ToSharedStateAsyncEnumerable(state);
+
+            async Task f() => await xs.GroupJoin(ys, x => x % 3, y => y % 3, (x, i) => x + " - " + i.Aggregate("", (s, j) => s + j).Result).Last();
+
+            await f(); // Should not throw
+        }
     }
 }

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Intersect.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Intersect.cs
@@ -65,9 +65,9 @@ namespace Tests
             var xs = new[] { 1, 2, 3 }.ToSharedStateAsyncEnumerable(state);
             var ys = new[] { 3, 5, 1, 4 }.ToSharedStateAsyncEnumerable(state);
 
-            async Task f() => await xs.Intersect(ys).LastAsync();
+            await xs.Intersect(ys).LastAsync();
 
-            await f(); // Should not throw
+            Assert.Equal(0, state.ConcurrentAccessCount);
         }
 
         private sealed class Eq : IEqualityComparer<int>

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Intersect.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Intersect.cs
@@ -58,6 +58,18 @@ namespace Tests
             await SequenceIdentity(res);
         }
 
+        [Fact]
+        public async Task Intersect_Concurrency()
+        {
+            var state = new SharedState();
+            var xs = new[] { 1, 2, 3 }.ToSharedStateAsyncEnumerable(state);
+            var ys = new[] { 3, 5, 1, 4 }.ToSharedStateAsyncEnumerable(state);
+
+            async Task f() => await xs.Intersect(ys).Last();
+
+            await f(); // Should not throw
+        }
+
         private sealed class Eq : IEqualityComparer<int>
         {
             public bool Equals(int x, int y)

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Intersect.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Intersect.cs
@@ -65,7 +65,7 @@ namespace Tests
             var xs = new[] { 1, 2, 3 }.ToSharedStateAsyncEnumerable(state);
             var ys = new[] { 3, 5, 1, 4 }.ToSharedStateAsyncEnumerable(state);
 
-            async Task f() => await xs.Intersect(ys).Last();
+            async Task f() => await xs.Intersect(ys).LastAsync();
 
             await f(); // Should not throw
         }

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Join.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Join.cs
@@ -236,7 +236,7 @@ namespace Tests
             var xs = new[] { 0, 1, 2 }.ToSharedStateAsyncEnumerable(state);
             var ys = new[] { 3, 6, 4 }.ToSharedStateAsyncEnumerable(state);
 
-            async Task f() => await xs.Join(ys, x => x % 3, y => y % 3, (x, y) => x + y).Last();
+            async Task f() => await xs.Join(ys, x => x % 3, y => y % 3, (x, y) => x + y).LastAsync();
 
             await f(); // Should not throw
         }

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Join.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Join.cs
@@ -229,6 +229,18 @@ namespace Tests
             await NoNextAsync(e);
         }
 
+        [Fact]
+        public async Task Join_Concurrency()
+        {
+            var state = new SharedState();
+            var xs = new[] { 0, 1, 2 }.ToSharedStateAsyncEnumerable(state);
+            var ys = new[] { 3, 6, 4 }.ToSharedStateAsyncEnumerable(state);
+
+            async Task f() => await xs.Join(ys, x => x % 3, y => y % 3, (x, y) => x + y).Last();
+
+            await f(); // Should not throw
+        }
+
         public class Customer
         {
             public string CustomerId { get; set; }

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Join.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Join.cs
@@ -236,9 +236,9 @@ namespace Tests
             var xs = new[] { 0, 1, 2 }.ToSharedStateAsyncEnumerable(state);
             var ys = new[] { 3, 6, 4 }.ToSharedStateAsyncEnumerable(state);
 
-            async Task f() => await xs.Join(ys, x => x % 3, y => y % 3, (x, y) => x + y).LastAsync();
+            await xs.Join(ys, x => x % 3, y => y % 3, (x, y) => x + y).LastAsync();
 
-            await f(); // Should not throw
+            Assert.Equal(0, state.ConcurrentAccessCount);
         }
 
         public class Customer

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/OrderBy.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/OrderBy.cs
@@ -220,7 +220,7 @@ namespace Tests
 
             async Task f() => await xs
                 .OrderBy(async x => await state.GetTask(x))
-                .ThenBy(async x => await state.GetTask(x)).Last();
+                .ThenBy(async x => await state.GetTask(x)).LastAsync();
 
             await f(); // Should not throw
         }

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/OrderBy.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/OrderBy.cs
@@ -211,5 +211,18 @@ namespace Tests
 
             Assert.True(ress.SequenceEqual(resa.ToEnumerable()));
         }
+
+        [Fact]
+        public async Task OrderBy_Concurrency()
+        {
+            var state = new SharedState();
+            var xs = new[] { 2, 6, 1, 5, 7, 8, 9, 3, 4, 0 }.ToSharedStateAsyncEnumerable(state);
+
+            async Task f() => await xs
+                .OrderBy(async x => await state.GetTask(x))
+                .ThenBy(async x => await state.GetTask(x)).Last();
+
+            await f(); // Should not throw
+        }
     }
 }

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/OrderBy.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/OrderBy.cs
@@ -218,11 +218,11 @@ namespace Tests
             var state = new SharedState();
             var xs = new[] { 2, 6, 1, 5, 7, 8, 9, 3, 4, 0 }.ToSharedStateAsyncEnumerable(state);
 
-            async Task f() => await xs
+            await xs
                 .OrderBy(async x => await state.GetTask(x))
                 .ThenBy(async x => await state.GetTask(x)).LastAsync();
 
-            await f(); // Should not throw
+            Assert.Equal(0, state.ConcurrentAccessCount);
         }
     }
 }

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/SequenceEqual.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/SequenceEqual.cs
@@ -181,7 +181,7 @@ namespace Tests
         public async Task SequenceEqual_Concurrency()
         {
             var xs = new[] { 1, 2, 3, 4 }.ToSharedStateAsyncEnumerable();
-            async Task f() => await xs.SequenceEqual(xs);
+            async Task f() => await xs.SequenceEqualAsync(xs);
             await f(); // Should not throw
         }
 

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/SequenceEqual.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/SequenceEqual.cs
@@ -180,9 +180,12 @@ namespace Tests
         [Fact]
         public async Task SequenceEqual_Concurrency()
         {
-            var xs = new[] { 1, 2, 3, 4 }.ToSharedStateAsyncEnumerable();
-            async Task f() => await xs.SequenceEqualAsync(xs);
-            await f(); // Should not throw
+            var state = new SharedState();
+            var xs = new[] { 1, 2, 3, 4 }.ToSharedStateAsyncEnumerable(state);
+
+            await xs.SequenceEqualAsync(xs);
+
+            Assert.Equal(0, state.ConcurrentAccessCount);
         }
 
         private sealed class EqEx : IEqualityComparer<int>

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/SequenceEqual.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/SequenceEqual.cs
@@ -177,6 +177,14 @@ namespace Tests
             await AssertThrowsAsync<NotImplementedException>(res);
         }
 
+        [Fact]
+        public void SequenceEqual_SharedState()
+        {
+            var xs = new[] { 1, 2, 3, 4 }.ToSharedStateAsyncEnumerable();
+            var res = xs.SequenceEqual(xs);
+            Assert.True(res.Result);
+        }
+
         private sealed class EqEx : IEqualityComparer<int>
         {
             public bool Equals(int x, int y)

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/SequenceEqual.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/SequenceEqual.cs
@@ -178,11 +178,11 @@ namespace Tests
         }
 
         [Fact]
-        public void SequenceEqual_SharedState()
+        public async Task SequenceEqual_Concurrency()
         {
             var xs = new[] { 1, 2, 3, 4 }.ToSharedStateAsyncEnumerable();
-            var res = xs.SequenceEqual(xs);
-            Assert.True(res.Result);
+            async Task f() => await xs.SequenceEqual(xs);
+            await f(); // Should not throw
         }
 
         private sealed class EqEx : IEqualityComparer<int>

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Union.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Union.cs
@@ -72,6 +72,19 @@ namespace Tests
             await NoNextAsync(e);
         }
 
+        [Fact]
+        public async Task Union_Concurrency()
+        {
+            var state = new SharedState();
+            var xs = new[] { 1, 2, 3 }.ToSharedStateAsyncEnumerable(state);
+            var ys = new[] { 3, 5, 1, 4 }.ToSharedStateAsyncEnumerable(state);
+            var zs = new[] { 5, 7, 8, 1 }.ToSharedStateAsyncEnumerable(state);
+
+            async Task f() => await xs.Union(ys).Union(zs).Last();
+
+            await f(); // Should not throw
+        }
+
         private sealed class Eq : IEqualityComparer<int>
         {
             public bool Equals(int x, int y)

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Union.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Union.cs
@@ -80,7 +80,7 @@ namespace Tests
             var ys = new[] { 3, 5, 1, 4 }.ToSharedStateAsyncEnumerable(state);
             var zs = new[] { 5, 7, 8, 1 }.ToSharedStateAsyncEnumerable(state);
 
-            async Task f() => await xs.Union(ys).Union(zs).Last();
+            async Task f() => await xs.Union(ys).Union(zs).LastAsync();
 
             await f(); // Should not throw
         }

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Union.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Union.cs
@@ -80,9 +80,9 @@ namespace Tests
             var ys = new[] { 3, 5, 1, 4 }.ToSharedStateAsyncEnumerable(state);
             var zs = new[] { 5, 7, 8, 1 }.ToSharedStateAsyncEnumerable(state);
 
-            async Task f() => await xs.Union(ys).Union(zs).LastAsync();
+            await xs.Union(ys).Union(zs).LastAsync();
 
-            await f(); // Should not throw
+            Assert.Equal(0, state.ConcurrentAccessCount);
         }
 
         private sealed class Eq : IEqualityComparer<int>

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Zip.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Zip.cs
@@ -106,5 +106,16 @@ namespace Tests
 
             await SequenceIdentity(res);
         }
+
+        [Fact]
+        public async Task Zip_SharedState()
+        {
+            var xs = new[] { 1, 2, 3 }.ToSharedStateAsyncEnumerable();
+            var res = xs.Zip(xs, (x, y) => x * y);
+
+            var ret = await res.Last();
+
+            Assert.Equal(9, ret);
+        }
     }
 }

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Zip.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Zip.cs
@@ -108,14 +108,14 @@ namespace Tests
         }
 
         [Fact]
-        public async Task Zip_SharedState()
+        public async Task Zip_Concurrency()
         {
             var xs = new[] { 1, 2, 3 }.ToSharedStateAsyncEnumerable();
             var res = xs.Zip(xs, (x, y) => x * y);
 
-            var ret = await res.Last();
+            async Task f() => await res.Last();
 
-            Assert.Equal(9, ret);
+            await f(); // Should not throw
         }
     }
 }

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Zip.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Zip.cs
@@ -110,12 +110,13 @@ namespace Tests
         [Fact]
         public async Task Zip_Concurrency()
         {
-            var xs = new[] { 1, 2, 3 }.ToSharedStateAsyncEnumerable();
+            var state = new SharedState();
+            var xs = new[] { 1, 2, 3 }.ToSharedStateAsyncEnumerable(state);
             var res = xs.Zip(xs, (x, y) => x * y);
 
-            async Task f() => await res.LastAsync();
+            await res.LastAsync();
 
-            await f(); // Should not throw
+            Assert.Equal(0, state.ConcurrentAccessCount);
         }
     }
 }

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Zip.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Zip.cs
@@ -113,7 +113,7 @@ namespace Tests
             var xs = new[] { 1, 2, 3 }.ToSharedStateAsyncEnumerable();
             var res = xs.Zip(xs, (x, y) => x * y);
 
-            async Task f() => await res.Last();
+            async Task f() => await res.LastAsync();
 
             await f(); // Should not throw
         }


### PR DESCRIPTION
The PR adds concurrency tests for System.Linq.Async (see https://github.com/dotnet/corefx/issues/32640). Currently there are only tests for `SequenceEqual` and `Zip`; more will follow.