### PR TITLE
Ignore JetBrains Rider-created .idea directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,7 @@ nuget.exe
 
 # dotnet local cache
 .dotnet
+
+# JetBrains Rider adds these
+Ix.NET/Source/.idea
+Rx.NET/Source/.idea


### PR DESCRIPTION
Rider loves to add these directories and show up as changed whenever one evaluates/changes code with Rider. 

*(I personally use Rider for code coverage as it is much faster than VS+dotCover even though Rider uses the dotCover too).*