### PR TITLE
Change the license url in Ix.NET/Source/Directory.build.props

### DIFF
--- a/Ix.NET/Source/Directory.build.props
+++ b/Ix.NET/Source/Directory.build.props
@@ -7,7 +7,7 @@
     <Authors>.NET Foundation and Contributors</Authors>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkId=261274</PackageIconUrl>
     <PackageProjectUrl>http://go.microsoft.com/fwlink/?LinkId=261273</PackageProjectUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/Reactive-Extensions/Rx.NET/master/Ix.NET/Source/license.txt</PackageLicenseUrl>
+    <PackageLicenseUrl>http://go.microsoft.com/fwlink/?LinkID=261272</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>    
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)ReactiveX.snk</AssemblyOriginatorKeyFile>

--- a/Ix.NET/Source/version.json
+++ b/Ix.NET/Source/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.2.0",
+  "version": "3.2.1-preview.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
     "^refs/heads/rel/v\\d+\\.\\d+" // we also release branches starting with vN.N

--- a/Ix.NET/Source/version.json
+++ b/Ix.NET/Source/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.2.0-preview.{height}",
+  "version": "3.2.0",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
     "^refs/heads/rel/v\\d+\\.\\d+" // we also release branches starting with vN.N


### PR DESCRIPTION
The current license url is invalid (Http 404 - Not Found).
The new url (http://go.microsoft.com/fwlink/?LinkID=261272) is the same as in Rx.NET/Source/Directory.build.props and it redirects to file https://github.com/dotnet/reactive/blob/master/LICENSE