### PR TITLE
Update the license url in Ix.NET

### DIFF
--- a/Ix.NET/Source/Directory.build.props
+++ b/Ix.NET/Source/Directory.build.props
@@ -7,7 +7,7 @@
     <Authors>.NET Foundation and Contributors</Authors>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkId=261274</PackageIconUrl>
     <PackageProjectUrl>https://github.com/dotnet/reactive</PackageProjectUrl>
-    <PackageLicenseUrl>http://go.microsoft.com/fwlink/?LinkID=261272</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>    
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)ReactiveX.snk</AssemblyOriginatorKeyFile>

--- a/Ix.NET/Source/Directory.build.props
+++ b/Ix.NET/Source/Directory.build.props
@@ -7,7 +7,7 @@
     <Authors>.NET Foundation and Contributors</Authors>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkId=261274</PackageIconUrl>
     <PackageProjectUrl>https://github.com/dotnet/reactive</PackageProjectUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/Reactive-Extensions/Rx.NET/master/Ix.NET/Source/license.txt</PackageLicenseUrl>
+    <PackageLicenseUrl>http://go.microsoft.com/fwlink/?LinkID=261272</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>    
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)ReactiveX.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
The current license url is invalid (404 - Not Found).
The new url is the same as in Rx.NET/Source/Directory.build.props and it redirects to file https://github.com/dotnet/reactive/blob/master/LICENSE