### PR TITLE
Add .NET Core 3 target

### DIFF
--- a/Rx.NET/Source/Directory.build.props
+++ b/Rx.NET/Source/Directory.build.props
@@ -23,23 +23,5 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
-  
-  <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(SourceLinkEnabled)' != 'false'">
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-62925-02" PrivateAssets="All"/>
-  </ItemGroup>   
-  
-  <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23" PrivateAssets="all" />
-  </ItemGroup>
-
-  <Target Name="AddCommitHashToAssemblyAttributes" BeforeTargets="GetAssemblyAttributes">
-    <ItemGroup>
-      <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition=" '$(SourceRevisionId)' != '' ">
-        <_Parameter1>CommitHash</_Parameter1>
-        <_Parameter2>$(SourceRevisionId)</_Parameter2>
-      </AssemblyAttribute>
-    </ItemGroup>
-  </Target>
 
 </Project>

--- a/Rx.NET/Source/Directory.build.targets
+++ b/Rx.NET/Source/Directory.build.targets
@@ -1,7 +1,7 @@
 <Project>
   <!-- This props all need to be set in targets as they depend on the values set earlier -->
   <PropertyGroup Condition="'$(TargetFramework)' == 'net46'">
-    <DefineConstants>$(DefineConstants);HAS_TRACE;HAS_WINRT;PREFER_ASYNC;HAS_TPL46;DESKTOPCLR</DefineConstants>
+    <DefineConstants>$(DefineConstants);HAS_TRACE;HAS_WINRT;HAS_WINFORMS;HAS_DISPATCHER;PREFER_ASYNC;HAS_TPL46;DESKTOPCLR</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'uap10.0'">
     <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
@@ -11,7 +11,30 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'uap10.0.16299'">
     <DefineConstants>$(DefineConstants);HAS_TRACE;HAS_WINRT;PREFER_ASYNC;HAS_TPL46;NO_REMOTING;WINDOWS</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netcoreapp2.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netcoreapp2.1'">
     <DefineConstants>$(DefineConstants);HAS_TRACE;HAS_WINRT;PREFER_ASYNC;HAS_TPL46;NO_REMOTING</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <DefineConstants>$(DefineConstants);HAS_TRACE;HAS_WINRT;HAS_WINFORMS;HAS_DISPATCHER;PREFER_ASYNC;HAS_TPL46;NO_REMOTING;DESKTOPCLR</DefineConstants>
+  </PropertyGroup>
+
+
+  <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(SourceLinkEnabled)' != 'false' and '$(TargetFramework)' != 'netcoreapp3.0'">
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-62925-02" PrivateAssets="All"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.33" PrivateAssets="all" />
+  </ItemGroup>
+
+  <Target Name="AddCommitHashToAssemblyAttributes" BeforeTargets="GetAssemblyAttributes">
+    <ItemGroup>
+      <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition=" '$(SourceRevisionId)' != '' ">
+        <_Parameter1>CommitHash</_Parameter1>
+        <_Parameter2>$(SourceRevisionId)</_Parameter2>
+      </AssemblyAttribute>
+    </ItemGroup>
+  </Target>
+  
 </Project>

--- a/Rx.NET/Source/System.Reactive.sln
+++ b/Rx.NET/Source/System.Reactive.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26606.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28407.52
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Reactive", "src\System.Reactive\System.Reactive.csproj", "{01706A0F-8A63-4FD6-AF45-0BC0BED3C0D9}"
 EndProject
@@ -15,9 +15,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests.System.Reactive.Uwp.D
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{870348D0-C0A0-4352-8A02-E00AB0CCB919}"
 	ProjectSection(SolutionItems) = preProject
-		..\..\.vsts.rx-ci.yml = ..\..\.vsts.rx-ci.yml
-		..\..\.vsts.rx-pr.yml = ..\..\.vsts.rx-pr.yml
-		..\..\.vsts.rx-shared.yml = ..\..\.vsts.rx-shared.yml
+		..\..\azure-pipelines.rx.yml = ..\..\azure-pipelines.rx.yml
 		Directory.build.props = Directory.build.props
 		Directory.build.targets = Directory.build.targets
 		global.json = global.json

--- a/Rx.NET/Source/global.json
+++ b/Rx.NET/Source/global.json
@@ -1,5 +1,8 @@
 {
+  "sdk": {
+    "version": "3.0.100-preview"
+  },
   "msbuild-sdks": {
-    "MSBuild.Sdk.Extras": "1.6.65"
+    "MSBuild.Sdk.Extras": "2.0.0-preview.7"
   }
 }

--- a/Rx.NET/Source/global.json
+++ b/Rx.NET/Source/global.json
@@ -3,6 +3,6 @@
     "version": "3.0.100-preview"
   },
   "msbuild-sdks": {
-    "MSBuild.Sdk.Extras": "2.0.0-preview.7"
+    "MSBuild.Sdk.Extras": "2.0.0-preview.14"
   }
 }

--- a/Rx.NET/Source/src/Microsoft.Reactive.Testing/Microsoft.Reactive.Testing.csproj
+++ b/Rx.NET/Source/src/Microsoft.Reactive.Testing/Microsoft.Reactive.Testing.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>net46;uap10.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net46;uap10.0;netstandard2.0</TargetFrameworks>
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
     <Description>Reactive Extensions Testing Library containing interfaces and classes providing functionality to test applications and libraries built using Reactive Extensions.</Description>    
     <AssemblyTitle>Microsoft.Reactive.Testing - Testing Helper Library</AssemblyTitle>    

--- a/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
+++ b/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
@@ -1,9 +1,14 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46;uap10.0;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;netstandard2.0;net46;uap10.0;uap10.0.16299</TargetFrameworks>
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>       
     <PackageTags>Rx;Reactive;Extensions;Observable;LINQ;Events</PackageTags>
     <Description>Reactive Extensions (Rx) for .NET</Description>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
 
@@ -34,7 +39,7 @@
   </ItemGroup>
   
   <!-- Windows includes for Desktop and UWP -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' or $(TargetFramework.StartsWith('uap10.0')) ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' or $(TargetFramework.StartsWith('uap10.0')) or '$(TargetFramework)' == 'netcoreapp3.0'">
     <Compile Include="Platforms\Windows\**\*.cs" />
     <EmbeddedResource Include="Platforms\Windows\**\*.resx" />    
   </ItemGroup>
@@ -45,6 +50,9 @@
     <Reference Include="System.Windows" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="WindowsBase" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netcoreapp3.0'">
     <Compile Include="Platforms\Desktop\**\*.cs" />
   </ItemGroup>
   

--- a/Rx.NET/Source/tests/Tests.System.Reactive/DispatcherHelpers.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/DispatcherHelpers.cs
@@ -2,10 +2,11 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information. 
 
-#if NETCOREAPP1_1 || NET46 || NETCOREAPP1_0
+#if NETCOREAPP2_1 || NET46 || NETCOREAPP3_0
 using System.Threading;
 #endif
 #if HAS_DISPATCHER
+using System;
 using System.Windows.Threading;
 #endif
 

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests.System.Reactive.csproj
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests.System.Reactive.csproj
@@ -1,9 +1,15 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net46;netcoreapp2.1</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
-  
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+
   <ItemGroup>
     <Content Include="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -15,9 +21,9 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0-preview-20180610-02" />    
-    <PackageReference Include="xunit" Version="2.4.0-beta.2.build4010" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0-beta.2.build4010" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0-preview-20181205-02" />    
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <ProjectReference Include="..\..\src\System.Reactive\System.Reactive.csproj" />
     <ProjectReference Include="..\..\src\System.Reactive.Observable.Aliases\System.Reactive.Observable.Aliases.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Reactive.Testing\Microsoft.Reactive.Testing.csproj" />

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests.System.Reactive.csproj
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests.System.Reactive.csproj
@@ -4,7 +4,7 @@
     <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0' or '$(TargetFramework)' == 'net46'">
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
@@ -15,11 +15,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46'">
-    <Reference Include="System.Windows" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0-preview-20181205-02" />    
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Concurrency/SchedulerTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Concurrency/SchedulerTest.cs
@@ -375,7 +375,7 @@ namespace ReactiveTests.Tests
         }
 #endif
 
-#if DESKTOPCLR
+#if DESKTOPCLR && NET46
         [Fact]
         public void Scheduler_Periodic_HostLifecycleManagement()
         {

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/FromEventPatternTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/FromEventPatternTest.cs
@@ -474,7 +474,7 @@ namespace ReactiveTests.Tests
             );
         }
 
-#if DESKTOPCLR
+#if DESKTOPCLR && NET46
         [Fact]
         public void FromEventPattern_Reflection_Instance_MissingAccessors()
         {

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ObserveOnTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ObserveOnTest.cs
@@ -14,6 +14,15 @@ using Microsoft.Reactive.Testing;
 using ReactiveTests.Dummies;
 using Xunit;
 
+#if HAS_DISPATCHER
+using System.Windows.Threading;
+#endif
+
+#if HAS_WINFORMS
+using System.Windows.Forms;
+#endif
+
+
 namespace ReactiveTests.Tests
 {
     public class ObserveOnTest : TestBase

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/SubscribeOnTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/SubscribeOnTest.cs
@@ -10,6 +10,18 @@ using Microsoft.Reactive.Testing;
 using ReactiveTests.Dummies;
 using Xunit;
 
+#if HAS_DISPATCHER
+using System.Windows.Threading;
+using System.Reactive;
+using System.Reactive.Subjects;
+
+#endif
+
+#if HAS_WINFORMS
+using System.Windows.Forms;
+#endif
+
+
 namespace ReactiveTests.Tests
 {
     public class SubscribeOnTest : TestBase
@@ -112,6 +124,28 @@ namespace ReactiveTests.Tests
             evt.WaitOne();
             Application.Exit();
             Assert.True(okay);
+        }
+
+        private Label CreateLabel()
+        {
+            var loaded = new ManualResetEvent(false);
+            var lbl = default(Label);
+
+            var t = new Thread(() =>
+            {
+                lbl = new Label();
+                var frm = new Form { Controls = { lbl }, Width = 0, Height = 0, FormBorderStyle = FormBorderStyle.None, ShowInTaskbar = false };
+                frm.Load += (_, __) =>
+                {
+                    loaded.Set();
+                };
+                Application.Run(frm);
+            });
+            t.SetApartmentState(ApartmentState.STA);
+            t.Start();
+
+            loaded.WaitOne();
+            return lbl;
         }
 #endif
 

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -28,6 +28,10 @@ variables:
   BuildPlatform: Any CPU
     
 steps:
+- task: DotNetCoreInstaller@0
+  inputs:
+    version: '3.0.100-preview-009812'
+
 - task: DotNetCoreCLI@2  
   inputs:
     command: custom


### PR DESCRIPTION
This is needed to provide DispatcherScheduler and ControlScheduler to WPF/WinForms on .NET Core 3.

As per @terrajobst, we should include these in the .NET Core 3 surface area even though these particular types are not implemented x-plat.