### PR TITLE
Handle Windows Desktop for .NET Core 3 in a way that works for Linux/non-Windows Desktop

### DIFF
--- a/Rx.NET/Integration/IntegrationTests.sln
+++ b/Rx.NET/Integration/IntegrationTests.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.28407.52
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LinuxTests", "LinuxTests\LinuxTests.csproj", "{E5607740-EAAC-4A42-B59C-3B2387582559}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WindowsDesktopTests", "WindowsDesktopTests\WindowsDesktopTests.csproj", "{EFAFAEC1-AB20-4B16-8D6C-005052866B3F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{E5607740-EAAC-4A42-B59C-3B2387582559}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E5607740-EAAC-4A42-B59C-3B2387582559}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E5607740-EAAC-4A42-B59C-3B2387582559}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EFAFAEC1-AB20-4B16-8D6C-005052866B3F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EFAFAEC1-AB20-4B16-8D6C-005052866B3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EFAFAEC1-AB20-4B16-8D6C-005052866B3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EFAFAEC1-AB20-4B16-8D6C-005052866B3F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Rx.NET/Integration/LinuxTests.sln
+++ b/Rx.NET/Integration/LinuxTests.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28407.52
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LinuxTests", "LinuxTests\LinuxTests.csproj", "{E5607740-EAAC-4A42-B59C-3B2387582559}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E5607740-EAAC-4A42-B59C-3B2387582559}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E5607740-EAAC-4A42-B59C-3B2387582559}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E5607740-EAAC-4A42-B59C-3B2387582559}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E5607740-EAAC-4A42-B59C-3B2387582559}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {2ABA1A1F-6AEE-4AB5-A710-4D7474576023}
+	EndGlobalSection
+EndGlobal

--- a/Rx.NET/Integration/LinuxTests/LinuxTests.csproj
+++ b/Rx.NET/Integration/LinuxTests/LinuxTests.csproj
@@ -2,14 +2,31 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.0;netcoreapp2.1</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
+    <LangVersion>latest</LangVersion>
+    <AssemblyName>Tests.System.Reactive</AssemblyName>
+    <RootNamespace>Tests.System.Reactive</RootNamespace>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\Source\ReactiveX.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0' ">
+    <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+  
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netcoreapp2.1'">
+    <DefineConstants>$(DefineConstants);HAS_TRACE;HAS_WINRT;PREFER_ASYNC;HAS_TPL46;NO_REMOTING</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <DefineConstants>$(DefineConstants);HAS_TRACE;HAS_WINRT;HAS_WINFORMS;HAS_DISPATCHER;PREFER_ASYNC;HAS_TPL46;NO_REMOTING;DESKTOPCLR;LINUX</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
     <Content Include="..\..\Source\tests\Tests.System.Reactive\xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Compile Include="..\..\Source\tests\Tests.System.Reactive\**\*.cs" 
-             Exclude="..\..\Source\tests\Tests.System.Reactive\obj\**" />
+    <Compile Include="..\..\Source\tests\Tests.System.Reactive\**\*.cs" Exclude="..\..\Source\tests\Tests.System.Reactive\obj\**" />
   </ItemGroup>
 
   <ItemGroup>
@@ -18,6 +35,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="System.Reactive" Version="4.2.0-preview.63" />
     <PackageReference Include="Microsoft.Reactive.Testing" Version="4.2.0-preview.63" />
-    <PackageReference Include="System.Reactive.Observable.Aliases Version="4.2.0-preview.63" />
+    <PackageReference Include="System.Reactive.Observable.Aliases" Version="4.2.0-preview.63" />
   </ItemGroup>
 </Project>

--- a/Rx.NET/Integration/LinuxTests/LinuxTests.csproj
+++ b/Rx.NET/Integration/LinuxTests/LinuxTests.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="MSBuild.Sdk.Extras">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp2.1</TargetFrameworks>
+    <NoWarn>$(NoWarn);CS0618</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="..\..\Source\tests\Tests.System.Reactive\xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Compile Include="..\..\Source\tests\Tests.System.Reactive\**\*.cs" 
+             Exclude="..\..\Source\tests\Tests.System.Reactive\obj\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0-preview-20181205-02" />    
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="System.Reactive" Version="4.2.0-preview.63" />
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="4.2.0-preview.63" />
+    <PackageReference Include="System.Reactive.Observable.Aliases Version="4.2.0-preview.63" />
+  </ItemGroup>
+</Project>

--- a/Rx.NET/Integration/LinuxTests/LinuxTests.csproj
+++ b/Rx.NET/Integration/LinuxTests/LinuxTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.0;netcoreapp2.1</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
@@ -8,18 +8,12 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Source\ReactiveX.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0' ">
-    <UseWPF>true</UseWPF>
-    <UseWindowsForms>true</UseWindowsForms>
-  </PropertyGroup>
-
   
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netcoreapp2.1'">
     <DefineConstants>$(DefineConstants);HAS_TRACE;HAS_WINRT;PREFER_ASYNC;HAS_TPL46;NO_REMOTING</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
-    <DefineConstants>$(DefineConstants);HAS_TRACE;HAS_WINRT;HAS_WINFORMS;HAS_DISPATCHER;PREFER_ASYNC;HAS_TPL46;NO_REMOTING;DESKTOPCLR;LINUX</DefineConstants>
+    <DefineConstants>$(DefineConstants);HAS_TRACE;HAS_WINRT;PREFER_ASYNC;HAS_TPL46;NO_REMOTING;LINUX</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Rx.NET/Integration/LocalPackages/.keepme
+++ b/Rx.NET/Integration/LocalPackages/.keepme
@@ -1,0 +1,1 @@
+Placeholder to keep this directory

--- a/Rx.NET/Integration/NuGet.Config
+++ b/Rx.NET/Integration/NuGet.Config
@@ -4,6 +4,6 @@
     <add key="myget.org rxnet" value="https://dotnet.myget.org/F/rx/api/v3/index.json" />
     <add key="Build Packages" value="https://www.myget.org/F/c037199d-41df-4567-b966-25ff65324688/api/v3/index.json" />
     <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="Local Packages" value=".\LocalPackages" />
+    <add key="Local Packages" value="./LocalPackages" />
   </packageSources>  
 </configuration>

--- a/Rx.NET/Integration/NuGet.Config
+++ b/Rx.NET/Integration/NuGet.Config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <packageSources>    
-    <add key="AppVeyor (CI) rxnet" value="https://ci.appveyor.com/nuget/rx-net-ljfp6fos5bxs" />
+  <packageSources>
     <add key="myget.org rxnet" value="https://dotnet.myget.org/F/rx/api/v3/index.json" />
     <add key="Build Packages" value="https://www.myget.org/F/c037199d-41df-4567-b966-25ff65324688/api/v3/index.json" />
-    <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />        
+    <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="Local Packages" value=".\LocalPackages" />
   </packageSources>  
 </configuration>

--- a/Rx.NET/Integration/WindowsDesktopTests/WindowsDesktopTests.csproj
+++ b/Rx.NET/Integration/WindowsDesktopTests/WindowsDesktopTests.csproj
@@ -1,0 +1,34 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <NoWarn>$(NoWarn);CS0618</NoWarn>
+    <LangVersion>latest</LangVersion>
+    <AssemblyName>Tests.System.Reactive</AssemblyName>
+    <RootNamespace>Tests.System.Reactive</RootNamespace>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\Source\ReactiveX.snk</AssemblyOriginatorKeyFile>
+    <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+  
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <DefineConstants>$(DefineConstants);HAS_TRACE;HAS_WINRT;PREFER_ASYNC;HAS_TPL46;NO_REMOTING;HAS_WINFORMS;HAS_DISPATCHER;DESKTOPCLR</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="..\..\Source\tests\Tests.System.Reactive\xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Compile Include="..\..\Source\tests\Tests.System.Reactive\**\*.cs" Exclude="..\..\Source\tests\Tests.System.Reactive\obj\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0-preview-20190203-03" />    
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="System.Reactive" Version="4.2.0-preview.63" />
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="4.2.0-preview.63" />
+    <PackageReference Include="System.Reactive.Observable.Aliases" Version="4.2.0-preview.63" />
+  </ItemGroup>
+</Project>

--- a/Rx.NET/Integration/global.json
+++ b/Rx.NET/Integration/global.json
@@ -1,0 +1,8 @@
+{
+  "sdk": {
+    "version": "3.0.100-preview"
+  },
+  "msbuild-sdks": {
+    "MSBuild.Sdk.Extras": "2.0.0-preview.14"
+  }
+}

--- a/Rx.NET/Source/Directory.build.props
+++ b/Rx.NET/Source/Directory.build.props
@@ -22,7 +22,6 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <LangVersion>latest</LangVersion>
-    <ExtrasUwpMetaPackageVersion>6.1.9</ExtrasUwpMetaPackageVersion>
   </PropertyGroup>
 
 </Project>

--- a/Rx.NET/Source/Directory.build.props
+++ b/Rx.NET/Source/Directory.build.props
@@ -12,7 +12,7 @@
     <DebugType>embedded</DebugType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)ReactiveX.snk</AssemblyOriginatorKeyFile>
-    <NoWarn>$(NoWarn);1701;1702;CS1591</NoWarn>
+    <NoWarn>$(NoWarn);1701;1702;CS1591;NU5105</NoWarn>
     <DefaultLanguage>en-US</DefaultLanguage>
     <IncludeSymbols>false</IncludeSymbols>
     <IsTestProject>$(MSBuildProjectName.Contains('Tests'))</IsTestProject>

--- a/Rx.NET/Source/Directory.build.props
+++ b/Rx.NET/Source/Directory.build.props
@@ -22,6 +22,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <LangVersion>latest</LangVersion>
+    <ExtrasUwpMetaPackageVersion>6.1.9</ExtrasUwpMetaPackageVersion>
   </PropertyGroup>
 
 </Project>

--- a/Rx.NET/Source/Directory.build.props
+++ b/Rx.NET/Source/Directory.build.props
@@ -1,6 +1,5 @@
 <Project>    
   <PropertyGroup>
-    <Product>$(AssemblyName) ($(TargetFramework))</Product>
     <Copyright>Copyright (c) .NET Foundation and Contributors.</Copyright>
     <MinClientVersion>2.12</MinClientVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Rx.NET/Source/Directory.build.targets
+++ b/Rx.NET/Source/Directory.build.targets
@@ -15,17 +15,17 @@
     <DefineConstants>$(DefineConstants);HAS_TRACE;HAS_WINRT;PREFER_ASYNC;HAS_TPL46;NO_REMOTING</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
-    <DefineConstants>$(DefineConstants);HAS_TRACE;HAS_WINRT;HAS_WINFORMS;HAS_DISPATCHER;PREFER_ASYNC;HAS_TPL46;NO_REMOTING;DESKTOPCLR</DefineConstants>
+    <DefineConstants>$(DefineConstants);HAS_TRACE;HAS_WINRT;PREFER_ASYNC;HAS_TPL46;NO_REMOTING;HAS_WINFORMS;HAS_DISPATCHER;DESKTOPCLR</DefineConstants>
   </PropertyGroup>
 
 
   <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(SourceLinkEnabled)' != 'false' and '$(TargetFramework)' != 'netcoreapp3.0'">
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All"/>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.38" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.105" PrivateAssets="all" />
   </ItemGroup>
 
   <Target Name="AddCommitHashToAssemblyAttributes" BeforeTargets="GetAssemblyAttributes">

--- a/Rx.NET/Source/Directory.build.targets
+++ b/Rx.NET/Source/Directory.build.targets
@@ -21,11 +21,11 @@
 
   <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(SourceLinkEnabled)' != 'false' and '$(TargetFramework)' != 'netcoreapp3.0'">
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-62925-02" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All"/>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.36" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.38" PrivateAssets="all" />
   </ItemGroup>
 
   <Target Name="AddCommitHashToAssemblyAttributes" BeforeTargets="GetAssemblyAttributes">

--- a/Rx.NET/Source/Directory.build.targets
+++ b/Rx.NET/Source/Directory.build.targets
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.33" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.36" PrivateAssets="all" />
   </ItemGroup>
 
   <Target Name="AddCommitHashToAssemblyAttributes" BeforeTargets="GetAssemblyAttributes">

--- a/Rx.NET/Source/Directory.build.targets
+++ b/Rx.NET/Source/Directory.build.targets
@@ -4,12 +4,13 @@
     <DefineConstants>$(DefineConstants);HAS_TRACE;HAS_WINRT;HAS_WINFORMS;HAS_DISPATCHER;PREFER_ASYNC;HAS_TPL46;DESKTOPCLR</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'uap10.0'">
-    <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
     <DefineConstants>$(DefineConstants);NO_CODE_COVERAGE_ATTRIBUTE;HAS_WINRT;PREFER_ASYNC;HAS_TPL46;NO_REMOTING;NO_SERIALIZABLE;CRIPPLED_REFLECTION;NO_THREAD;WINDOWS</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'uap10.0.16299'">
     <DefineConstants>$(DefineConstants);HAS_TRACE;HAS_WINRT;PREFER_ASYNC;HAS_TPL46;NO_REMOTING;WINDOWS</DefineConstants>
+    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netcoreapp2.1'">
     <DefineConstants>$(DefineConstants);HAS_TRACE;HAS_WINRT;PREFER_ASYNC;HAS_TPL46;NO_REMOTING</DefineConstants>

--- a/Rx.NET/Source/Directory.build.targets
+++ b/Rx.NET/Source/Directory.build.targets
@@ -19,6 +19,11 @@
     <DefineConstants>$(DefineConstants);HAS_TRACE;HAS_WINRT;PREFER_ASYNC;HAS_TPL46;NO_REMOTING;HAS_WINFORMS;HAS_DISPATCHER;DESKTOPCLR</DefineConstants>
   </PropertyGroup>
 
+  <ItemGroup>
+    <!-- Workaround https://github.com/dotnet/sdk/issues/2976 -->
+    <PackageReference Update="Microsoft.NETCore.Platforms" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(SourceLinkEnabled)' != 'false' and '$(TargetFramework)' != 'netcoreapp3.0'">
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />

--- a/Rx.NET/Source/Directory.build.targets
+++ b/Rx.NET/Source/Directory.build.targets
@@ -1,5 +1,10 @@
 <Project>
   <!-- This props all need to be set in targets as they depend on the values set earlier -->
+  
+  <PropertyGroup>  
+    <Product>$(AssemblyName) ($(TargetFramework))</Product>
+  </PropertyGroup>
+    
   <PropertyGroup Condition="'$(TargetFramework)' == 'net46'">
     <DefineConstants>$(DefineConstants);HAS_TRACE;HAS_WINRT;HAS_WINFORMS;HAS_DISPATCHER;PREFER_ASYNC;HAS_TPL46;DESKTOPCLR</DefineConstants>
   </PropertyGroup>

--- a/Rx.NET/Source/global.json
+++ b/Rx.NET/Source/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.0.100-preview"
+    "version": "3.0.100-preview4"
   },
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "2.0.0-preview.21"

--- a/Rx.NET/Source/global.json
+++ b/Rx.NET/Source/global.json
@@ -3,6 +3,6 @@
     "version": "3.0.100-preview"
   },
   "msbuild-sdks": {
-    "MSBuild.Sdk.Extras": "2.0.0-preview.14"
+    "MSBuild.Sdk.Extras": "2.0.0-preview.21"
   }
 }

--- a/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
+++ b/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
@@ -66,20 +66,26 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);RemoveNetCoreApp3FromNuGet</TargetsForTfmSpecificBuildOutput>
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);RemoveNetCoreApp3FromNuGet</TargetsForTfmSpecificBuildOutput>  
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddNetCore3ToNuGet</TargetsForTfmSpecificContentInPackage>  
   </PropertyGroup>
 
   <!-- We remove the output from the nuget so it doesn't wind up in the \lib folder -->
   <Target Name="RemoveNetCoreApp3FromNuGet" DependsOnTargets="BuiltProjectOutputGroup;DocumentationProjectOutputGroup" Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
-
     <ItemGroup>      
       <!-- Before clearing the output groups, add them to None for packing -->
-      <None Include="@(BuiltProjectOutputGroupOutput);@(DocumentationProjectOutputGroupOutput)" PackagePath="build\netcoreapp3.0" Pack="true" />      
+      <ItemsToAddToNuGet Include="@(BuiltProjectOutputGroupOutput);@(DocumentationProjectOutputGroupOutput)" PackagePath="build\netcoreapp3.0" />      
       
       <BuiltProjectOutputGroupOutput Remove="@(BuiltProjectOutputGroupOutput)" />
       <DocumentationProjectOutputGroupOutput Remove="@(DocumentationProjectOutputGroupOutput)" />      
     </ItemGroup>
-
+  </Target>
+  
+  <Target Name="AddNetCore3ToNuGet" Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <ItemGroup>      
+      <!-- Add the removed build output to the build\netcoreapp3.0 folder -->
+      <TfmSpecificPackageFileWithRecursiveDir Include="@(ItemsToAddToNuGet)" PackagePath="build\netcoreapp3.0" />      
+    </ItemGroup>
   </Target>
   
   <ItemGroup>

--- a/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
+++ b/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
@@ -29,7 +29,7 @@
   
   <!-- UWP -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">      
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="System.ComponentModel" Version="4.0.1" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.0.11" />
     <PackageReference Include="System.Linq.Queryable" Version="4.0.1" />    
@@ -46,7 +46,7 @@
   
   <!-- Desktop -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46'">
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <Reference Include="System.Windows" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="WindowsBase" />

--- a/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
+++ b/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
@@ -81,10 +81,11 @@
 
 
   <ItemGroup>
-    <None Include="bin\$(Configuration)\netcoreapp3.0\*.xml" PackagePath="buildTransitive\netcoreapp3.0" Pack="true" />
-    <None Include="bin\$(Configuration)\netcoreapp3.0\*.dll" PackagePath="buildTransitive\netcoreapp3.0" Pack="true" />
+    <None Include="bin\$(Configuration)\netcoreapp3.0\*.xml" PackagePath="payload\netcoreapp3.0" Pack="true" />
+    <None Include="bin\$(Configuration)\netcoreapp3.0\*.dll" PackagePath="payload\netcoreapp3.0" Pack="true" />
     <None Include="build\_._" PackagePath="lib\netcoreapp3.0" Pack="true" />
     <None Include="build\System.Reactive.targets" PackagePath="buildTransitive\netcoreapp3.0" Pack="true" />
+    <None Include="build\System.Reactive.targets" PackagePath="build\netcoreapp3.0" Pack="true" />
   </ItemGroup>
   
 </Project>

--- a/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
+++ b/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
@@ -72,17 +72,17 @@
   <!-- We remove the output from the nuget so it doesn't wind up in the \lib folder -->
   <Target Name="RemoveNetCoreApp3FromNuGet" DependsOnTargets="BuiltProjectOutputGroup;DocumentationProjectOutputGroup" Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
 
-    <ItemGroup>
+    <ItemGroup>      
+      <!-- Before clearing the output groups, add them to None for packing -->
+      <None Include="@(BuiltProjectOutputGroupOutput);@(DocumentationProjectOutputGroupOutput)" PackagePath="build\netcoreapp3.0" Pack="true" />      
+      
       <BuiltProjectOutputGroupOutput Remove="@(BuiltProjectOutputGroupOutput)" />
-      <DocumentationProjectOutputGroupOutput Remove="@(DocumentationProjectOutputGroupOutput)" />
+      <DocumentationProjectOutputGroupOutput Remove="@(DocumentationProjectOutputGroupOutput)" />      
     </ItemGroup>
 
   </Target>
-
-
+  
   <ItemGroup>
-    <None Include="bin\$(Configuration)\netcoreapp3.0\*.xml" PackagePath="build\netcoreapp3.0" Pack="true" />
-    <None Include="bin\$(Configuration)\netcoreapp3.0\*.dll" PackagePath="build\netcoreapp3.0" Pack="true" />
     <None Include="build\_._" PackagePath="lib\netcoreapp3.0" Pack="true" />
     <None Include="build\System.Reactive.targets" PackagePath="buildTransitive\netcoreapp3.0" Pack="true" />
     <None Include="build\System.Reactive.targets" PackagePath="build\netcoreapp3.0" Pack="true" />

--- a/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
+++ b/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>netcoreapp3.0;netstandard2.0;net46;uap10.0;uap10.0.16299</TargetFrameworks>
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>       
     <PackageTags>Rx;Reactive;Extensions;Observable;LINQ;Events</PackageTags>
-    <Description>Reactive Extensions (Rx) for .NET</Description>
+    <Description>Reactive Extensions (Rx) for .NET</Description>    
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">

--- a/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
+++ b/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
@@ -9,6 +9,7 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
 
 
@@ -62,6 +63,28 @@
     <Compile Update="Linq\Observable\CombineLatest.Generated.cs" DesignTime="True" AutoGen="True" DependentUpon="CombineLatest.Generated.tt" />
     <None Update="Linq\Observable\Zip.Generated.tt" Generator="TextTemplatingFileGenerator" LastGenOutput="Zip.Generated.cs" />
     <Compile Update="Linq\Observable\Zip.Generated.cs" DesignTime="True" AutoGen="True" DependentUpon="Zip.Generated.tt" />   
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);RemoveNetCoreApp3FromNuGet</TargetsForTfmSpecificBuildOutput>
+  </PropertyGroup>
+
+  <!-- We remove the output from the nuget so it doesn't wind up in the \lib folder -->
+  <Target Name="RemoveNetCoreApp3FromNuGet" DependsOnTargets="BuiltProjectOutputGroup;DocumentationProjectOutputGroup" Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+
+    <ItemGroup>
+      <BuiltProjectOutputGroupOutput Remove="@(BuiltProjectOutputGroupOutput)" />
+      <DocumentationProjectOutputGroupOutput Remove="@(DocumentationProjectOutputGroupOutput)" />
+    </ItemGroup>
+
+  </Target>
+
+
+  <ItemGroup>
+    <None Include="bin\$(Configuration)\netcoreapp3.0\*.xml" PackagePath="buildTransitive\netcoreapp3.0" Pack="true" />
+    <None Include="bin\$(Configuration)\netcoreapp3.0\*.dll" PackagePath="buildTransitive\netcoreapp3.0" Pack="true" />
+    <None Include="build\_._" PackagePath="lib\netcoreapp3.0" Pack="true" />
+    <None Include="build\System.Reactive.targets" PackagePath="buildTransitive\netcoreapp3.0" Pack="true" />
   </ItemGroup>
   
 </Project>

--- a/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
+++ b/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
@@ -81,8 +81,8 @@
 
 
   <ItemGroup>
-    <None Include="bin\$(Configuration)\netcoreapp3.0\*.xml" PackagePath="payload\netcoreapp3.0" Pack="true" />
-    <None Include="bin\$(Configuration)\netcoreapp3.0\*.dll" PackagePath="payload\netcoreapp3.0" Pack="true" />
+    <None Include="bin\$(Configuration)\netcoreapp3.0\*.xml" PackagePath="build\netcoreapp3.0" Pack="true" />
+    <None Include="bin\$(Configuration)\netcoreapp3.0\*.dll" PackagePath="build\netcoreapp3.0" Pack="true" />
     <None Include="build\_._" PackagePath="lib\netcoreapp3.0" Pack="true" />
     <None Include="build\System.Reactive.targets" PackagePath="buildTransitive\netcoreapp3.0" Pack="true" />
     <None Include="build\System.Reactive.targets" PackagePath="build\netcoreapp3.0" Pack="true" />

--- a/Rx.NET/Source/src/System.Reactive/build/System.Reactive.targets
+++ b/Rx.NET/Source/src/System.Reactive/build/System.Reactive.targets
@@ -4,7 +4,7 @@
     <UseWindowsRxVersion Condition="'$(UseWindowsVersion)' == '' " >false</UseWindowsRxVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Condition="'$(UseWindowsRxVersion)' == 'true' "  Include="$(MSBuildThisFileDirectory)System.Reactive.dll" />
+    <Reference Condition="'$(UseWindowsRxVersion)' == 'true' "  Include="$(MSBuildThisFileDirectory)..\..\payload\netcoreapp3.0\System.Reactive.dll" />
     <Reference Condition="'$(UseWindowsRxVersion)' != 'true' "  Include="$(MSBuildThisFileDirectory)..\..\lib\netstandard2.0\System.Reactive.dll" />
   </ItemGroup>
 </Project>

--- a/Rx.NET/Source/src/System.Reactive/build/System.Reactive.targets
+++ b/Rx.NET/Source/src/System.Reactive/build/System.Reactive.targets
@@ -1,10 +1,10 @@
 <Project>
   <PropertyGroup>
     <UseWindowsRxVersion Condition="'$(UseWpf)' == 'true' OR '$(UseWindowsForms)' == 'true'" >true</UseWindowsRxVersion>
-    <UseWindowsRxVersion Condition="'$(UseWindowsVersion)' == '' " >false</UseWindowsRxVersion>
+    <UseWindowsRxVersion Condition="'$(UseWindowsRxVersion)' == '' " >false</UseWindowsRxVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Condition="'$(UseWindowsRxVersion)' == 'true' "  Include="$(MSBuildThisFileDirectory)..\..\payload\netcoreapp3.0\System.Reactive.dll" />
+    <Reference Condition="'$(UseWindowsRxVersion)' == 'true' "  Include="$(MSBuildThisFileDirectory)..\..\build\netcoreapp3.0\System.Reactive.dll" />
     <Reference Condition="'$(UseWindowsRxVersion)' != 'true' "  Include="$(MSBuildThisFileDirectory)..\..\lib\netstandard2.0\System.Reactive.dll" />
   </ItemGroup>
 </Project>

--- a/Rx.NET/Source/src/System.Reactive/build/System.Reactive.targets
+++ b/Rx.NET/Source/src/System.Reactive/build/System.Reactive.targets
@@ -1,0 +1,10 @@
+<Project>
+  <PropertyGroup>
+    <UseWindowsRxVersion Condition="'$(UseWpf)' == 'true' OR '$(UseWindowsForms)' == 'true'" >true</UseWindowsRxVersion>
+    <UseWindowsRxVersion Condition="'$(UseWindowsVersion)' == '' " >false</UseWindowsRxVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Condition="'$(UseWindowsRxVersion)' == 'true' "  Include="$(MSBuildThisFileDirectory)System.Reactive.dll" />
+    <Reference Condition="'$(UseWindowsRxVersion)' != 'true' "  Include="$(MSBuildThisFileDirectory)..\..\lib\netstandard2.0\System.Reactive.dll" />
+  </ItemGroup>
+</Project>

--- a/Rx.NET/Source/tests/Tests.System.Reactive.Uwp.DeviceRunner/Tests.System.Reactive.Uwp.DeviceRunner.csproj
+++ b/Rx.NET/Source/tests/Tests.System.Reactive.Uwp.DeviceRunner/Tests.System.Reactive.Uwp.DeviceRunner.csproj
@@ -90,9 +90,9 @@
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.5" />
-    <PackageReference Include="xunit" Version="2.4.0-beta.2.build4010" />
-    <PackageReference Include="xunit.runner.devices" Version="2.4.0-build.27" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.devices" Version="2.5.25" />
   </ItemGroup>
   <ItemGroup>
     <!-- A reference to the entire .Net Framework and Windows SDK are automatically included -->

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -177,5 +177,5 @@ jobs:
     inputs:
       command: test
       projects: $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LinuxTests/LinuxTests.csproj
-      arguments: -c $(BuildConfiguration) -f netcoreapp2.1
+      arguments: -c $(BuildConfiguration) -f netcoreapp2.1 /p:TargetFrameworks=netcoreapp2.1
     displayName: Run 2.1 Tests on Linux

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -32,7 +32,7 @@ jobs:
   steps:
   - task: DotNetCoreInstaller@0
     inputs:
-      version: '3.0.100-preview-009812'
+      version: '3.0.100-preview-010184'
 
   - task: DotNetCoreCLI@2  
     inputs:
@@ -114,7 +114,7 @@ jobs:
   steps:
   - task: DotNetCoreInstaller@0
     inputs:
-      version: '2.2.100'
+      version: '2.2.103'
 
   - task: DotNetCoreCLI@2  
     inputs:
@@ -128,7 +128,7 @@ jobs:
 
   - task: DotNetCoreInstaller@0
     inputs:
-      version: '3.0.100-preview-009812'
+      version: '3.0.100-preview-010184'
 
   - task: DownloadBuildArtifacts@0
     displayName: 'Download Build Artifacts'

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -51,8 +51,7 @@ jobs:
     displayName: Build System.Reactive.sln
     inputs:
       solution: Rx.NET/Source/System.Reactive.sln    
-      msbuildArguments: /restore /t:build /p:CreatePackage=true /p:NoPackageAnalysis=true /p:PackageOutputPath=$(Build.ArtifactStagingDirectory)\artifacts /bl:$(Build.ArtifactStagingDirectory)\artifacts\build.binlog
-      platform: $(BuildPlatform)
+      msbuildArguments: /restore /t:build /p:CreatePackage=true /p:NoPackageAnalysis=true /p:PackageOutputPath=$(Build.ArtifactStagingDirectory)\artifacts
       configuration: $(BuildConfiguration)
       maximumCpuCount: true
 

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -116,10 +116,6 @@ jobs:
     inputs:
       version: '2.2.100'
 
-  - task: DotNetCoreInstaller@0
-    inputs:
-      version: '3.0.100-preview-009812'
-
   - task: DotNetCoreCLI@2  
     inputs:
       command: custom
@@ -129,6 +125,10 @@ jobs:
 
   - script: ./nbgv cloud -a -p Rx.NET/Source
     displayName: Set Version
+
+  - task: DotNetCoreInstaller@0
+    inputs:
+      version: '3.0.100-preview-009812'
 
   - task: DownloadBuildArtifacts@0
     displayName: 'Download Build Artifacts'

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -114,6 +114,10 @@ jobs:
   steps:
   - task: DotNetCoreInstaller@0
     inputs:
+      version: '2.2.100'
+
+  - task: DotNetCoreInstaller@0
+    inputs:
       version: '3.0.100-preview-009812'
 
   - task: DotNetCoreCLI@2  

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -48,7 +48,7 @@ jobs:
     displayName: Build System.Reactive.sln
     inputs:
       solution: Rx.NET/Source/System.Reactive.sln    
-      msbuildArguments: /restore /t:build /p:CreatePackage=true /p:NoPackageAnalysis=true /p:PackageOutputPath=$(Build.ArtifactStagingDirectory)\artifacts
+      msbuildArguments: /restore /t:build /p:CreatePackage=true /p:NoPackageAnalysis=true /p:PackageOutputPath=$(Build.ArtifactStagingDirectory)\artifacts /bl:$(Build.ArtifactStagingDirectory)\artifacts\build.binlog
       platform: $(BuildPlatform)
       configuration: $(BuildConfiguration)
       maximumCpuCount: true
@@ -82,9 +82,6 @@ jobs:
       arguments: -c $(BuildConfiguration) --no-build --no-restore 
     displayName: Run Api Approvals Tests
 
-  - task: whitesource.ws-bolt.bolt.wss.WhiteSource Bolt@18
-    displayName: 'WhiteSource Bolt'
-    enabled: false
     
   - task: PowerShell@2
     displayName: Authenticode Sign Packages
@@ -101,6 +98,7 @@ jobs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)\artifacts
       ArtifactName: artifacts
       publishLocation: Container
+    condition: always()
 
 - job: Linux_Test
   dependsOn: Build

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -114,7 +114,7 @@ jobs:
   steps:
   - task: DotNetCoreInstaller@0
     inputs:
-      version: '2.2.103'
+      version: '2.2.104'
 
   - task: DotNetCoreCLI@2  
     inputs:
@@ -128,7 +128,7 @@ jobs:
 
   - task: DotNetCoreInstaller@0
     inputs:
-      version: '3.0.100-preview-010184'
+      version: '3.0.100-preview4-010374'
 
   - task: DownloadBuildArtifacts@0
     displayName: 'Download Build Artifacts'

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -32,7 +32,7 @@ jobs:
   steps:
   - task: DotNetCoreInstaller@0
     inputs:
-      version: '3.0.100-preview-010184'
+      version: '3.0.100-preview4-010374'
 
   - task: DotNetCoreCLI@2  
     inputs:

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -41,7 +41,7 @@ jobs:
       arguments: install --tool-path . nbgv
     displayName: Install NBGV tool
 
-  - script: nbgv cloud -a -p Rx.NET\Source
+  - script: ./nbgv cloud -a -p Rx.NET/Source
     displayName: Set Version
 
   - task: MSBuild@1

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -20,83 +20,145 @@ pr:
       - .editorconfig
       - azure-pipelines.rx.yml
 
-pool:
-  vmImage: vs2017-win2016
+jobs:
+- job: Build
+  pool:
+    vmImage: vs2017-win2016
 
-variables: 
-  BuildConfiguration: Release
-  BuildPlatform: Any CPU
+  variables: 
+    BuildConfiguration: Release
+    BuildPlatform: Any CPU
+      
+  steps:
+  - task: DotNetCoreInstaller@0
+    inputs:
+      version: '3.0.100-preview-009812'
+
+  - task: DotNetCoreCLI@2  
+    inputs:
+      command: custom
+      custom: tool
+      arguments: install --tool-path . nbgv
+    displayName: Install NBGV tool
+
+  - script: nbgv cloud -a -p Rx.NET\Source
+    displayName: Set Version
+
+  - task: MSBuild@1
+    displayName: Build System.Reactive.sln
+    inputs:
+      solution: Rx.NET/Source/System.Reactive.sln    
+      msbuildArguments: /restore /t:build /p:CreatePackage=true /p:NoPackageAnalysis=true /p:PackageOutputPath=$(Build.ArtifactStagingDirectory)\artifacts
+      platform: $(BuildPlatform)
+      configuration: $(BuildConfiguration)
+      maximumCpuCount: true
+
+  - task: NuGetCommand@2
+    displayName: Pack compatibility package
+    inputs:
+      command: custom
+      arguments: pack Rx.NET/Source/facades/System.Reactive.Compatibility.nuspec -Version $(NBGV_NuGetPackageVersion) -MinClientVersion 2.12 -NoPackageAnalysis -outputdirectory $(Build.ArtifactStagingDirectory)\artifacts
     
-steps:
-- task: DotNetCoreInstaller@0
-  inputs:
-    version: '3.0.100-preview-009812'
+  - task: MSBuild@1
+    displayName: Build for Test (ppdb) workaround
+    inputs:
+      solution: Rx.NET/Source/System.Reactive.sln    
+      msbuildArguments: /t:build /p:DebugType=portable
+      platform: $(BuildPlatform)
+      configuration: $(BuildConfiguration)
+      maximumCpuCount: true
 
-- task: DotNetCoreCLI@2  
-  inputs:
-    command: custom
-    custom: tool
-    arguments: install --tool-path . nbgv
-  displayName: Install NBGV tool
+  - task: DotNetCoreCLI@2
+    inputs:
+      command: test
+      projects: Rx.NET/Source/tests/Tests.System.Reactive/*.csproj
+      arguments: -c $(BuildConfiguration) --no-build --no-restore --filter "SkipCI!=true" --collect:"Code Coverage" -s $(System.DefaultWorkingDirectory)/Rx.NET/Source/CodeCoverage.runsettings
+    displayName: Run Unit Tests
 
-- script: nbgv cloud -a -p Rx.NET\Source
-  displayName: Set Version
+  - task: DotNetCoreCLI@2
+    inputs:
+      command: test
+      projects: Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Tests.System.Reactive.ApiApprovals.csproj
+      arguments: -c $(BuildConfiguration) --no-build --no-restore 
+    displayName: Run Api Approvals Tests
 
-- task: MSBuild@1
-  displayName: Build System.Reactive.sln
-  inputs:
-    solution: Rx.NET/Source/System.Reactive.sln    
-    msbuildArguments: /restore /t:build /p:CreatePackage=true /p:NoPackageAnalysis=true /p:PackageOutputPath=$(Build.ArtifactStagingDirectory)\artifacts
-    platform: $(BuildPlatform)
-    configuration: $(BuildConfiguration)
-    maximumCpuCount: true
+  - task: whitesource.ws-bolt.bolt.wss.WhiteSource Bolt@18
+    displayName: 'WhiteSource Bolt'
+    enabled: false
+    
+  - task: PowerShell@2
+    displayName: Authenticode Sign Packages
+    inputs:
+      filePath: Rx.NET/Source/build/Sign-Package.ps1
+    env:
+      SignClientUser: $(SignClientUser)
+      SignClientSecret: $(SignClientSecret)
+      ArtifactDirectory: $(Build.ArtifactStagingDirectory)\artifacts
+    condition: and(succeeded(), not(eq(variables['build.reason'], 'PullRequest')), not(eq(variables['SignClientSecret'], '')), not(eq(variables['SignClientUser'], '')))
 
-- task: NuGetCommand@2
-  displayName: Pack compatibility package
-  inputs:
-    command: custom
-    arguments: pack Rx.NET/Source/facades/System.Reactive.Compatibility.nuspec -Version $(NBGV_NuGetPackageVersion) -MinClientVersion 2.12 -NoPackageAnalysis -outputdirectory $(Build.ArtifactStagingDirectory)\artifacts
+  - task: PublishBuildArtifacts@1
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)\artifacts
+      ArtifactName: artifacts
+      publishLocation: Container
+
+- job: Linux_Test
+  dependsOn: Build
+  pool:
+    vmImage: ubuntu-16.04
   
-- task: MSBuild@1
-  displayName: Build for Test (ppdb) workaround
-  inputs:
-    solution: Rx.NET/Source/System.Reactive.sln    
-    msbuildArguments: /t:build /p:DebugType=portable
-    platform: $(BuildPlatform)
-    configuration: $(BuildConfiguration)
-    maximumCpuCount: true
-
-- task: DotNetCoreCLI@2
-  inputs:
-    command: test
-    projects: Rx.NET/Source/tests/Tests.System.Reactive/*.csproj
-    arguments: -c $(BuildConfiguration) --no-build --no-restore --filter "SkipCI!=true" --collect:"Code Coverage" -s $(System.DefaultWorkingDirectory)/Rx.NET/Source/CodeCoverage.runsettings
-  displayName: Run Unit Tests
-
-- task: DotNetCoreCLI@2
-  inputs:
-    command: test
-    projects: Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Tests.System.Reactive.ApiApprovals.csproj
-    arguments: -c $(BuildConfiguration) --no-build --no-restore 
-  displayName: Run Api Approvals Tests
-
-- task: whitesource.ws-bolt.bolt.wss.WhiteSource Bolt@18
-  displayName: 'WhiteSource Bolt'
-  enabled: false
+  variables: 
+    BuildConfiguration: Release
+    BuildPlatform: Any CPU
   
-- task: PowerShell@2
-  displayName: Authenticode Sign Packages
-  inputs:
-    filePath: Rx.NET/Source/build/Sign-Package.ps1
-  env:
-    SignClientUser: $(SignClientUser)
-    SignClientSecret: $(SignClientSecret)
-    ArtifactDirectory: $(Build.ArtifactStagingDirectory)\artifacts
-  condition: and(succeeded(), not(eq(variables['build.reason'], 'PullRequest')), not(eq(variables['SignClientSecret'], '')), not(eq(variables['SignClientUser'], '')))
+  steps:
+  - task: DotNetCoreInstaller@0
+    inputs:
+      version: '3.0.100-preview-009812'
 
-- task: PublishBuildArtifacts@1
-  inputs:
-    PathtoPublish: $(Build.ArtifactStagingDirectory)\artifacts
-    ArtifactName: artifacts
-    publishLocation: Container
+  - task: DotNetCoreCLI@2  
+    inputs:
+      command: custom
+      custom: tool
+      arguments: install --tool-path . nbgv
+    displayName: Install NBGV tool
 
+  - script: nbgv cloud -a -p Rx.NET\Source
+    displayName: Set Version
+
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download Build Artifacts'
+    inputs:
+      artifactName: artifacts
+      downloadPath: $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LocalPackages
+
+  - task: DotNetCoreCLI@2
+    displayName: Update Rx
+    inputs:
+      command: custom
+      projects: $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LinuxTests/LinuxTests.csproj
+      custom: add
+      arguments: package System.Reactive -v $(NBGV_NuGetPackageVersion) -s $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LocalPackages
+
+  - task: DotNetCoreCLI@2
+    displayName: Update Aliases
+    inputs:
+      command: custom
+      projects: $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LinuxTests/LinuxTests.csproj
+      custom: add
+      arguments: package System.Reactive.Observable.Aliases -v $(NBGV_NuGetPackageVersion) -s $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LocalPackages
+
+  - task: DotNetCoreCLI@2
+    displayName: Update Testing
+    inputs:
+      command: custom
+      projects: $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LinuxTests/LinuxTests.csproj
+      custom: add
+      arguments: package Microsoft.Reactive.Testing -v $(NBGV_NuGetPackageVersion) -s $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LocalPackages
+
+  - task: DotNetCoreCLI@2
+    inputs:
+      command: test
+      projects: $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LinuxTests/LinuxTests.csproj
+      arguments: -c $(BuildConfiguration)
+    displayName: Run Tests on Linux

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -166,5 +166,16 @@ jobs:
     inputs:
       command: test
       projects: $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LinuxTests/LinuxTests.csproj
-      arguments: -c $(BuildConfiguration)
-    displayName: Run Tests on Linux
+      arguments: -c $(BuildConfiguration) -f netcoreapp3.0
+    displayName: Run 3.0 Tests on Linux
+
+  - task: DotNetCoreInstaller@0
+    inputs:
+      version: '2.2.104'
+
+  - task: DotNetCoreCLI@2
+    inputs:
+      command: test
+      projects: $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LinuxTests/LinuxTests.csproj
+      arguments: -c $(BuildConfiguration) -f netcoreapp2.1
+    displayName: Run 2.1 Tests on Linux

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -41,7 +41,7 @@ jobs:
       arguments: install --tool-path . nbgv
     displayName: Install NBGV tool
 
-  - script: ./nbgv cloud -a -p Rx.NET/Source
+  - script: nbgv cloud -a -p Rx.NET/Source
     displayName: Set Version
 
   - task: MSBuild@1
@@ -123,7 +123,7 @@ jobs:
       arguments: install --tool-path . nbgv
     displayName: Install NBGV tool
 
-  - script: nbgv cloud -a -p Rx.NET\Source
+  - script: ./nbgv cloud -a -p Rx.NET\Source
     displayName: Set Version
 
   - task: DownloadBuildArtifacts@0

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -137,6 +137,7 @@ jobs:
       downloadPath: $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LocalPackages
       
   - script: mv $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LocalPackages/artifacts/*.* $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LocalPackages
+    displayName: Move packages to LocalPackages directory
 
   - task: DotNetCoreCLI@2
     displayName: Update Rx
@@ -211,6 +212,7 @@ jobs:
       downloadPath: $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LocalPackages
       
   - powershell: mv $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LocalPackages/artifacts/*.* $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LocalPackages
+    displayName: Move packages to LocalPackages directory
 
   - task: DotNetCoreCLI@2
     displayName: Update Rx

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -44,6 +44,9 @@ jobs:
   - script: nbgv cloud -a -p Rx.NET/Source
     displayName: Set Version
 
+  - powershell: iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/onovotny/UpdateVsOnAgent/master/Fix-VisualStudioPreviewNuGetSdk.ps1'))
+    displayName: VS Preview workaround
+
   - task: MSBuild@1
     displayName: Build System.Reactive.sln
     inputs:

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -102,7 +102,7 @@ jobs:
       publishLocation: Container
     condition: always()
 
-- job: Linux_Test
+- job: Integration_Linux_Tests
   dependsOn: Build
   pool:
     vmImage: ubuntu-16.04
@@ -179,3 +179,66 @@ jobs:
       projects: $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LinuxTests/LinuxTests.csproj
       arguments: -c $(BuildConfiguration) -f netcoreapp2.1 /p:TargetFrameworks=netcoreapp2.1
     displayName: Run 2.1 Tests on Linux
+
+- job: Integration_WindowsDesktop_Tests
+  dependsOn: Build
+  pool:
+    vmImage: windows-2019
+  
+  variables: 
+    BuildConfiguration: Release
+    BuildPlatform: Any CPU
+  
+  steps:  
+  - task: DotNetCoreInstaller@0
+    inputs:
+      version: '3.0.100-preview4-010374'
+
+  - task: DotNetCoreCLI@2  
+    inputs:
+      command: custom
+      custom: tool
+      arguments: install --tool-path . nbgv
+    displayName: Install NBGV tool
+
+  - script: ./nbgv cloud -a -p Rx.NET/Source
+    displayName: Set Version
+
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download Build Artifacts'
+    inputs:
+      artifactName: artifacts
+      downloadPath: $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LocalPackages
+      
+  - powershell: mv $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LocalPackages/artifacts/*.* $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LocalPackages
+
+  - task: DotNetCoreCLI@2
+    displayName: Update Rx
+    inputs:
+      command: custom
+      projects: $(System.DefaultWorkingDirectory)/Rx.NET/Integration/WindowsDesktopTests/WindowsDesktopTests.csproj
+      custom: add
+      arguments: package System.Reactive -v $(NBGV_NuGetPackageVersion) -s $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LocalPackages
+
+  - task: DotNetCoreCLI@2
+    displayName: Update Aliases
+    inputs:
+      command: custom
+      projects: $(System.DefaultWorkingDirectory)/Rx.NET/Integration/WindowsDesktopTests/WindowsDesktopTests.csproj
+      custom: add
+      arguments: package System.Reactive.Observable.Aliases -v $(NBGV_NuGetPackageVersion) -s $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LocalPackages
+
+  - task: DotNetCoreCLI@2
+    displayName: Update Testing
+    inputs:
+      command: custom
+      projects: $(System.DefaultWorkingDirectory)/Rx.NET/Integration/WindowsDesktopTests/WindowsDesktopTests.csproj
+      custom: add
+      arguments: package Microsoft.Reactive.Testing -v $(NBGV_NuGetPackageVersion) -s $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LocalPackages
+
+  - task: DotNetCoreCLI@2
+    inputs:
+      command: test
+      projects: $(System.DefaultWorkingDirectory)/Rx.NET/Integration/WindowsDesktopTests/WindowsDesktopTests.csproj
+      arguments: -c $(BuildConfiguration) 
+    displayName: Run 3.0 Tests on WindowDesktop

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -23,7 +23,7 @@ pr:
 jobs:
 - job: Build
   pool:
-    vmImage: vs2017-win2016
+    vmImage: windows-2019
 
   variables: 
     BuildConfiguration: Release

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -123,7 +123,7 @@ jobs:
       arguments: install --tool-path . nbgv
     displayName: Install NBGV tool
 
-  - script: ./nbgv cloud -a -p Rx.NET\Source
+  - script: ./nbgv cloud -a -p Rx.NET/Source
     displayName: Set Version
 
   - task: DownloadBuildArtifacts@0

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -201,7 +201,7 @@ jobs:
       arguments: install --tool-path . nbgv
     displayName: Install NBGV tool
 
-  - script: ./nbgv cloud -a -p Rx.NET/Source
+  - script: nbgv cloud -a -p Rx.NET/Source
     displayName: Set Version
 
   - task: DownloadBuildArtifacts@0

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -135,6 +135,8 @@ jobs:
     inputs:
       artifactName: artifacts
       downloadPath: $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LocalPackages
+      
+  - script: mv $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LocalPackages/artifacts/*.* $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LocalPackages
 
   - task: DotNetCoreCLI@2
     displayName: Update Rx


### PR DESCRIPTION
Fixes #858, #864 

Adds integration tests for Linux and Windows Desktop to test the build targets.

Uses targets to determine what assembly gets referenced based on `UseWpf` or `UseWindowsForms` properties.