### PR TITLE
Discussion: IObservable/IObserver hybrid class similar to AsyncIterator.

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Internal/Pipe.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/Pipe.cs
@@ -1,0 +1,145 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information. 
+
+using System.Reactive.Disposables;
+using System.Threading;
+
+namespace System.Reactive
+{
+    /// <summary>
+    /// Base class for implementation of query operators.
+    /// </summary>
+    /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
+    /// <typeparam name="TResult">The type of the elements in the result sequence.</typeparam>
+    internal abstract class Pipe<TSource, TResult> : Producer<TResult, Pipe<TSource, TResult>>, IObserver<TSource>, ISink<TResult>, IDisposable
+    {
+        protected readonly IObservable<TSource> _source;
+
+        private IDisposable _upstream;
+        private volatile IObserver<TResult> _downstream;
+
+        public Pipe(IObservable<TSource> source)
+        {
+            _source = source;
+        }
+
+        protected override Pipe<TSource, TResult> CreateSink(IObserver<TResult> observer)
+        {
+            if (Interlocked.CompareExchange(ref _downstream, observer, null) == null)
+                return this;
+            else
+            {
+                var pipe = Clone();
+                pipe._downstream = observer;
+                return pipe;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _downstream, NopObserver<TResult>.Instance) != NopObserver<TResult>.Instance)
+                Dispose(true);
+        }
+
+        protected abstract Pipe<TSource, TResult> Clone();
+
+        protected override void Run(Pipe<TSource, TResult> sink)
+        {
+            sink.SetUpstream(_source.SubscribeSafe(sink));
+        }
+
+        /// <summary>
+        /// Override this method to dispose additional resources.
+        /// The method is guaranteed to be called at most once.
+        /// </summary>
+        /// <param name="disposing">If true, the method was called from <see cref="Dispose()"/>.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            //Calling base.Dispose(true) is not a proper disposal, so we can omit the assignment here.
+            //Sink is internal so this can pretty much be enforced.
+            //_observer = NopObserver<TTarget>.Instance;
+
+            Disposable.TryDispose(ref _upstream);
+        }
+
+        public void ForwardOnNext(TResult value)
+        {
+            _downstream.OnNext(value);
+        }
+
+        public void ForwardOnCompleted()
+        {
+            _downstream.OnCompleted();
+            Dispose();
+        }
+
+        public void ForwardOnError(Exception error)
+        {
+            _downstream.OnError(error);
+            Dispose();
+        }
+
+        protected void SetUpstream(IDisposable upstream)
+        {
+            Disposable.SetSingle(ref _upstream, upstream);
+        }
+
+        protected void DisposeUpstream()
+        {
+            Disposable.TryDispose(ref _upstream);
+        }
+
+
+        public abstract void OnNext(TSource value);
+
+        public virtual void OnError(Exception error)
+        {
+            ForwardOnError(error);
+        }
+
+        public virtual void OnCompleted()
+        {
+            ForwardOnCompleted();
+        }
+
+        public IObserver<TResult> GetForwarder() => new _(this);
+
+        private sealed class _ : IObserver<TResult>
+        {
+            private readonly ISink<TResult> _forward;
+
+            public _(ISink<TResult> forward)
+            {
+                _forward = forward;
+            }
+
+            public void OnNext(TResult value)
+            {
+                _forward.ForwardOnNext(value);
+            }
+
+            public void OnError(Exception error)
+            {
+                _forward.ForwardOnError(error);
+            }
+
+            public void OnCompleted()
+            {
+                _forward.ForwardOnCompleted();
+            }
+        }
+    }
+
+    internal abstract class Pipe<TSource> : Pipe<TSource, TSource>
+    {
+        internal Pipe(IObservable<TSource> source) : base(source)
+        {
+        }
+
+        public override void OnNext(TSource value)
+        {
+            ForwardOnNext(value);
+        }
+    }
+}

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Aggregate.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Aggregate.cs
@@ -4,107 +4,28 @@
 
 namespace System.Reactive.Linq.ObservableImpl
 {
-    internal sealed class Aggregate<TSource> : Producer<TSource, Aggregate<TSource>._>
+    internal sealed class Aggregate<TSource> : Pipe<TSource>
     {
-        private readonly IObservable<TSource> _source;
         private readonly Func<TSource, TSource, TSource> _accumulator;
 
-        public Aggregate(IObservable<TSource> source, Func<TSource, TSource, TSource> accumulator)
+        private TSource _accumulation;
+        private bool _hasAccumulation;
+
+        public Aggregate(IObservable<TSource> source, Func<TSource, TSource, TSource> accumulator) : base(source)
         {
-            _source = source;
             _accumulator = accumulator;
         }
 
-        protected override _ CreateSink(IObserver<TSource> observer) => new _(_accumulator, observer);
+        protected override Pipe<TSource, TSource> Clone() => new Aggregate<TSource>(_source, _accumulator);
 
-        protected override void Run(_ sink) => sink.Run(_source);
-
-        internal sealed class _ : IdentitySink<TSource>
+        public override void OnNext(TSource value)
         {
-            private readonly Func<TSource, TSource, TSource> _accumulator;
-            private TSource _accumulation;
-            private bool _hasAccumulation;
-
-            public _(Func<TSource, TSource, TSource> accumulator, IObserver<TSource> observer)
-                : base(observer)
+            if (!_hasAccumulation)
             {
-                _accumulator = accumulator;
+                _accumulation = value;
+                _hasAccumulation = true;
             }
-
-            public override void OnNext(TSource value)
-            {
-                if (!_hasAccumulation)
-                {
-                    _accumulation = value;
-                    _hasAccumulation = true;
-                }
-                else
-                {
-                    try
-                    {
-                        _accumulation = _accumulator(_accumulation, value);
-                    }
-                    catch (Exception exception)
-                    {
-                        _accumulation = default;
-                        ForwardOnError(exception);
-                    }
-                }
-            }
-
-            public override void OnError(Exception error)
-            {
-                _accumulation = default;
-                ForwardOnError(error);
-            }
-
-            public override void OnCompleted()
-            {
-                if (!_hasAccumulation)
-                {
-                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
-                }
-                else
-                {
-                    var accumulation = _accumulation;
-                    _accumulation = default;
-                    ForwardOnNext(accumulation);
-                    ForwardOnCompleted();
-                }
-            }
-        }
-    }
-
-    internal sealed class Aggregate<TSource, TAccumulate> : Producer<TAccumulate, Aggregate<TSource, TAccumulate>._>
-    {
-        private readonly IObservable<TSource> _source;
-        private readonly TAccumulate _seed;
-        private readonly Func<TAccumulate, TSource, TAccumulate> _accumulator;
-
-        public Aggregate(IObservable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, TAccumulate> accumulator)
-        {
-            _source = source;
-            _seed = seed;
-            _accumulator = accumulator;
-        }
-
-        protected override _ CreateSink(IObserver<TAccumulate> observer) => new _(_seed, _accumulator, observer);
-
-        protected override void Run(_ sink) => sink.Run(_source);
-
-        internal sealed class _ : Sink<TSource, TAccumulate>
-        {
-            private readonly Func<TAccumulate, TSource, TAccumulate> _accumulator;
-            private TAccumulate _accumulation;
-
-            public _(TAccumulate seed, Func<TAccumulate, TSource, TAccumulate> accumulator, IObserver<TAccumulate> observer)
-                : base(observer)
-            {
-                _accumulator = accumulator;
-                _accumulation = seed;
-            }
-
-            public override void OnNext(TSource value)
+            else
             {
                 try
                 {
@@ -116,14 +37,21 @@ namespace System.Reactive.Linq.ObservableImpl
                     ForwardOnError(exception);
                 }
             }
+        }
 
-            public override void OnError(Exception error)
+        public override void OnError(Exception error)
+        {
+            _accumulation = default;
+            ForwardOnError(error);
+        }
+
+        public override void OnCompleted()
+        {
+            if (!_hasAccumulation)
             {
-                _accumulation = default;
-                ForwardOnError(error);
+                ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
             }
-
-            public override void OnCompleted()
+            else
             {
                 var accumulation = _accumulation;
                 _accumulation = default;
@@ -133,74 +61,102 @@ namespace System.Reactive.Linq.ObservableImpl
         }
     }
 
-    internal sealed class Aggregate<TSource, TAccumulate, TResult> : Producer<TResult, Aggregate<TSource, TAccumulate, TResult>._>
+    internal sealed class Aggregate<TSource, TAccumulate> : Pipe<TSource, TAccumulate>
     {
-        private readonly IObservable<TSource> _source;
+        private readonly TAccumulate _seed;
+        private readonly Func<TAccumulate, TSource, TAccumulate> _accumulator;
+
+        private TAccumulate _accumulation;
+
+        public Aggregate(IObservable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, TAccumulate> accumulator)
+            : base(source)
+        {
+            _seed = seed;
+            _accumulator = accumulator;
+            _accumulation = seed;
+        }
+
+        protected override Pipe<TSource, TAccumulate> Clone() => new Aggregate<TSource, TAccumulate>(_source, _seed, _accumulator);
+
+        public override void OnNext(TSource value)
+        {
+            try
+            {
+                _accumulation = _accumulator(_accumulation, value);
+            }
+            catch (Exception exception)
+            {
+                _accumulation = default;
+                ForwardOnError(exception);
+            }
+        }
+
+        public override void OnError(Exception error)
+        {
+            _accumulation = default;
+            ForwardOnError(error);
+        }
+
+        public override void OnCompleted()
+        {
+            var accumulation = _accumulation;
+            _accumulation = default;
+            ForwardOnNext(accumulation);
+            ForwardOnCompleted();
+        }
+    }
+
+    internal sealed class Aggregate<TSource, TAccumulate, TResult> : Pipe<TSource, TResult>
+    {
         private readonly TAccumulate _seed;
         private readonly Func<TAccumulate, TSource, TAccumulate> _accumulator;
         private readonly Func<TAccumulate, TResult> _resultSelector;
 
+        private TAccumulate _accumulation;
+
         public Aggregate(IObservable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, TAccumulate> accumulator, Func<TAccumulate, TResult> resultSelector)
+            : base(source)
         {
-            _source = source;
             _seed = seed;
             _accumulator = accumulator;
             _resultSelector = resultSelector;
+            _accumulation = seed;
         }
 
-        protected override _ CreateSink(IObserver<TResult> observer) => new _(this, observer);
+        protected override Pipe<TSource, TResult> Clone() => new Aggregate<TSource, TAccumulate, TResult>(_source, _seed, _accumulator, _resultSelector);
 
-        protected override void Run(_ sink) => sink.Run(_source);
-
-        internal sealed class _ : Sink<TSource, TResult>
+        public override void OnNext(TSource value)
         {
-            private readonly Func<TAccumulate, TSource, TAccumulate> _accumulator;
-            private readonly Func<TAccumulate, TResult> _resultSelector;
-
-            private TAccumulate _accumulation;
-
-            public _(Aggregate<TSource, TAccumulate, TResult> parent, IObserver<TResult> observer)
-                : base(observer)
+            try
             {
-                _accumulator = parent._accumulator;
-                _resultSelector = parent._resultSelector;
+                _accumulation = _accumulator(_accumulation, value);
+            }
+            catch (Exception exception)
+            {
+                ForwardOnError(exception);
+            }
+        }
 
-                _accumulation = parent._seed;
+        public override void OnError(Exception error)
+        {
+            ForwardOnError(error);
+        }
+
+        public override void OnCompleted()
+        {
+            var result = default(TResult);
+            try
+            {
+                result = _resultSelector(_accumulation);
+            }
+            catch (Exception exception)
+            {
+                ForwardOnError(exception);
+                return;
             }
 
-            public override void OnNext(TSource value)
-            {
-                try
-                {
-                    _accumulation = _accumulator(_accumulation, value);
-                }
-                catch (Exception exception)
-                {
-                    ForwardOnError(exception);
-                }
-            }
-
-            public override void OnError(Exception error)
-            {
-                ForwardOnError(error);
-            }
-
-            public override void OnCompleted()
-            {
-                var result = default(TResult);
-                try
-                {
-                    result = _resultSelector(_accumulation);
-                }
-                catch (Exception exception)
-                {
-                    ForwardOnError(exception);
-                    return;
-                }
-
-                ForwardOnNext(result);
-                ForwardOnCompleted();
-            }
+            ForwardOnNext(result);
+            ForwardOnCompleted();
         }
     }
 }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/DistinctUntilChanged.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/DistinctUntilChanged.cs
@@ -6,71 +6,56 @@ using System.Collections.Generic;
 
 namespace System.Reactive.Linq.ObservableImpl
 {
-    internal sealed class DistinctUntilChanged<TSource, TKey> : Producer<TSource, DistinctUntilChanged<TSource, TKey>._>
+    internal sealed class DistinctUntilChanged<TSource, TKey> : Pipe<TSource>
     {
-        private readonly IObservable<TSource> _source;
         private readonly Func<TSource, TKey> _keySelector;
         private readonly IEqualityComparer<TKey> _comparer;
 
+        private TKey _currentKey;
+        private bool _hasCurrentKey;
+
         public DistinctUntilChanged(IObservable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+            : base(source)
         {
-            _source = source;
             _keySelector = keySelector;
             _comparer = comparer;
         }
 
-        protected override _ CreateSink(IObserver<TSource> observer) => new _(this, observer);
+        protected override Pipe<TSource, TSource> Clone() => new DistinctUntilChanged<TSource, TKey>(_source, _keySelector, _comparer);
+        
 
-        protected override void Run(_ sink) => sink.Run(_source);
-
-        internal sealed class _ : IdentitySink<TSource>
+        public override void OnNext(TSource value)
         {
-            private readonly Func<TSource, TKey> _keySelector;
-            private readonly IEqualityComparer<TKey> _comparer;
-
-            private TKey _currentKey;
-            private bool _hasCurrentKey;
-
-            public _(DistinctUntilChanged<TSource, TKey> parent, IObserver<TSource> observer)
-                : base(observer)
+            var key = default(TKey);
+            try
             {
-                _keySelector = parent._keySelector;
-                _comparer = parent._comparer;
+                key = _keySelector(value);
+            }
+            catch (Exception exception)
+            {
+                ForwardOnError(exception);
+                return;
             }
 
-            public override void OnNext(TSource value)
+            var comparerEquals = false;
+            if (_hasCurrentKey)
             {
-                var key = default(TKey);
                 try
                 {
-                    key = _keySelector(value);
+                    comparerEquals = _comparer.Equals(_currentKey, key);
                 }
                 catch (Exception exception)
                 {
                     ForwardOnError(exception);
                     return;
                 }
+            }
 
-                var comparerEquals = false;
-                if (_hasCurrentKey)
-                {
-                    try
-                    {
-                        comparerEquals = _comparer.Equals(_currentKey, key);
-                    }
-                    catch (Exception exception)
-                    {
-                        ForwardOnError(exception);
-                        return;
-                    }
-                }
-
-                if (!_hasCurrentKey || !comparerEquals)
-                {
-                    _hasCurrentKey = true;
-                    _currentKey = key;
-                    ForwardOnNext(value);
-                }
+            if (!_hasCurrentKey || !comparerEquals)
+            {
+                _hasCurrentKey = true;
+                _currentKey = key;
+                ForwardOnNext(value);
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Max.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Max.cs
@@ -6,45 +6,84 @@ using System.Collections.Generic;
 
 namespace System.Reactive.Linq.ObservableImpl
 {
-    internal sealed class Max<TSource> : Producer<TSource, Max<TSource>._>
+    internal sealed class Max<TSource> : Pipe<TSource>
     {
-        private readonly IObservable<TSource> _source;
         private readonly IComparer<TSource> _comparer;
 
-        public Max(IObservable<TSource> source, IComparer<TSource> comparer)
+        private bool _hasValue;
+        private TSource _lastValue;
+
+        public Max(IObservable<TSource> source, IComparer<TSource> comparer) : base(source)
         {
-            _source = source;
             _comparer = comparer;
         }
 
-        protected override _ CreateSink(IObserver<TSource> observer) => default(TSource) == null ? (_)new Null(_comparer, observer) : new NonNull(_comparer, observer);
+        protected override Pipe<TSource, TSource> Clone() => new Max<TSource>(_source, _comparer);
 
-        protected override void Run(_ sink) => sink.Run(_source);
-
-        internal abstract class _ : IdentitySink<TSource>
+        public override void OnNext(TSource value)
         {
-            protected readonly IComparer<TSource> _comparer;
-
-            protected _(IComparer<TSource> comparer, IObserver<TSource> observer)
-                : base(observer)
+            if (_hasValue)
             {
-                _comparer = comparer;
+                var comparison = 0;
+
+                try
+                {
+                    comparison = _comparer.Compare(value, _lastValue);
+                }
+                catch (Exception ex)
+                {
+                    ForwardOnError(ex);
+                    return;
+                }
+
+                if (comparison > 0)
+                {
+                    _lastValue = value;
+                }
+            }
+            else
+            {
+                _hasValue = true;
+                _lastValue = value;
             }
         }
 
-        private sealed class NonNull : _
+        public override void OnCompleted()
         {
-            private bool _hasValue;
-            private TSource _lastValue;
-
-            public NonNull(IComparer<TSource> comparer, IObserver<TSource> observer)
-                : base(comparer, observer)
+            if (!_hasValue)
             {
+                ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
             }
-
-            public override void OnNext(TSource value)
+            else
             {
-                if (_hasValue)
+                ForwardOnNext(_lastValue);
+                ForwardOnCompleted();
+            }
+        }
+    }
+
+    internal sealed class MaxNullable<TSource> : Pipe<TSource>
+    {
+        private readonly IComparer<TSource> _comparer;
+
+        private TSource _lastValue;
+
+        public MaxNullable(IObservable<TSource> source, IComparer<TSource> comparer) : base(source)
+        {
+            _comparer = comparer;
+        }
+
+        protected override Pipe<TSource, TSource> Clone() => new Max<TSource>(_source, _comparer);
+
+        public override void OnNext(TSource value)
+        {
+            if (value != null)
+            {
+                if (_lastValue == null)
+                {
+                    _lastValue = value;
+                }
+                else
                 {
                     var comparison = 0;
 
@@ -63,72 +102,55 @@ namespace System.Reactive.Linq.ObservableImpl
                         _lastValue = value;
                     }
                 }
-                else
-                {
-                    _hasValue = true;
-                    _lastValue = value;
-                }
-            }
-
-            public override void OnCompleted()
-            {
-                if (!_hasValue)
-                {
-                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
-                }
-                else
-                {
-                    ForwardOnNext(_lastValue);
-                    ForwardOnCompleted();
-                }
             }
         }
 
-        private sealed class Null : _
+        public override void OnError(Exception error)
         {
-            private TSource _lastValue;
+            ForwardOnError(error);
+        }
 
-            public Null(IComparer<TSource> comparer, IObserver<TSource> observer)
-                : base(comparer, observer)
-            {
-            }
+        public override void OnCompleted()
+        {
+            ForwardOnNext(_lastValue);
+            ForwardOnCompleted();
+        }
+    }
 
-            public override void OnNext(TSource value)
+    internal sealed class MaxDouble : Pipe<double>
+    {
+        private bool _hasValue;
+        private double _lastValue;
+
+        public MaxDouble(IObservable<double> source) : base(source)
+        {
+        }
+
+        protected override Pipe<double, double> Clone() => new MaxDouble(_source);
+
+        public override void OnNext(double value)
+        {
+            if (_hasValue)
             {
-                if (value != null)
+                if (value > _lastValue || double.IsNaN(value))
                 {
-                    if (_lastValue == null)
-                    {
-                        _lastValue = value;
-                    }
-                    else
-                    {
-                        var comparison = 0;
-
-                        try
-                        {
-                            comparison = _comparer.Compare(value, _lastValue);
-                        }
-                        catch (Exception ex)
-                        {
-                            ForwardOnError(ex);
-                            return;
-                        }
-
-                        if (comparison > 0)
-                        {
-                            _lastValue = value;
-                        }
-                    }
+                    _lastValue = value;
                 }
             }
-
-            public override void OnError(Exception error)
+            else
             {
-                ForwardOnError(error);
+                _lastValue = value;
+                _hasValue = true;
             }
+        }
 
-            public override void OnCompleted()
+        public override void OnCompleted()
+        {
+            if (!_hasValue)
+            {
+                ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+            }
+            else
             {
                 ForwardOnNext(_lastValue);
                 ForwardOnCompleted();
@@ -136,319 +158,40 @@ namespace System.Reactive.Linq.ObservableImpl
         }
     }
 
-    internal sealed class MaxDouble : Producer<double, MaxDouble._>
+    internal sealed class MaxSingle : Pipe<float>
     {
-        private readonly IObservable<double> _source;
+        private bool _hasValue;
+        private float _lastValue;
 
-        public MaxDouble(IObservable<double> source)
+        public MaxSingle(IObservable<float> source) : base(source)
         {
-            _source = source;
         }
 
-        protected override _ CreateSink(IObserver<double> observer) => new _(observer);
+        protected override Pipe<float, float> Clone() => new MaxSingle(_source);
 
-        protected override void Run(_ sink) => sink.Run(_source);
-
-        internal sealed class _ : IdentitySink<double>
+        public override void OnNext(float value)
         {
-            private bool _hasValue;
-            private double _lastValue;
-
-            public _(IObserver<double> observer)
-                : base(observer)
+            if (_hasValue)
             {
-            }
-
-            public override void OnNext(double value)
-            {
-                if (_hasValue)
-                {
-                    if (value > _lastValue || double.IsNaN(value))
-                    {
-                        _lastValue = value;
-                    }
-                }
-                else
-                {
-                    _lastValue = value;
-                    _hasValue = true;
-                }
-            }
-
-            public override void OnCompleted()
-            {
-                if (!_hasValue)
-                {
-                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
-                }
-                else
-                {
-                    ForwardOnNext(_lastValue);
-                    ForwardOnCompleted();
-                }
-            }
-        }
-    }
-
-    internal sealed class MaxSingle : Producer<float, MaxSingle._>
-    {
-        private readonly IObservable<float> _source;
-
-        public MaxSingle(IObservable<float> source)
-        {
-            _source = source;
-        }
-
-        protected override _ CreateSink(IObserver<float> observer) => new _(observer);
-
-        protected override void Run(_ sink) => sink.Run(_source);
-
-        internal sealed class _ : IdentitySink<float>
-        {
-            private bool _hasValue;
-            private float _lastValue;
-
-            public _(IObserver<float> observer)
-                : base(observer)
-            {
-            }
-
-            public override void OnNext(float value)
-            {
-                if (_hasValue)
-                {
-                    if (value > _lastValue || float.IsNaN(value))
-                    {
-                        _lastValue = value;
-                    }
-                }
-                else
-                {
-                    _lastValue = value;
-                    _hasValue = true;
-                }
-            }
-
-            public override void OnCompleted()
-            {
-                if (!_hasValue)
-                {
-                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
-                }
-                else
-                {
-                    ForwardOnNext(_lastValue);
-                    ForwardOnCompleted();
-                }
-            }
-        }
-    }
-
-    internal sealed class MaxDecimal : Producer<decimal, MaxDecimal._>
-    {
-        private readonly IObservable<decimal> _source;
-
-        public MaxDecimal(IObservable<decimal> source)
-        {
-            _source = source;
-        }
-
-        protected override _ CreateSink(IObserver<decimal> observer) => new _(observer);
-
-        protected override void Run(_ sink) => sink.Run(_source);
-
-        internal sealed class _ : IdentitySink<decimal>
-        {
-            private bool _hasValue;
-            private decimal _lastValue;
-
-            public _(IObserver<decimal> observer)
-                : base(observer)
-            {
-            }
-
-            public override void OnNext(decimal value)
-            {
-                if (_hasValue)
-                {
-                    if (value > _lastValue)
-                    {
-                        _lastValue = value;
-                    }
-                }
-                else
-                {
-                    _lastValue = value;
-                    _hasValue = true;
-                }
-            }
-
-            public override void OnCompleted()
-            {
-                if (!_hasValue)
-                {
-                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
-                }
-                else
-                {
-                    ForwardOnNext(_lastValue);
-                    ForwardOnCompleted();
-                }
-            }
-        }
-    }
-
-    internal sealed class MaxInt32 : Producer<int, MaxInt32._>
-    {
-        private readonly IObservable<int> _source;
-
-        public MaxInt32(IObservable<int> source)
-        {
-            _source = source;
-        }
-
-        protected override _ CreateSink(IObserver<int> observer) => new _(observer);
-
-        protected override void Run(_ sink) => sink.Run(_source);
-
-        internal sealed class _ : IdentitySink<int>
-        {
-            private bool _hasValue;
-            private int _lastValue;
-
-            public _(IObserver<int> observer)
-                : base(observer)
-            {
-            }
-
-            public override void OnNext(int value)
-            {
-                if (_hasValue)
-                {
-                    if (value > _lastValue)
-                    {
-                        _lastValue = value;
-                    }
-                }
-                else
-                {
-                    _lastValue = value;
-                    _hasValue = true;
-                }
-            }
-
-            public override void OnCompleted()
-            {
-                if (!_hasValue)
-                {
-                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
-                }
-                else
-                {
-                    ForwardOnNext(_lastValue);
-                    ForwardOnCompleted();
-                }
-            }
-        }
-    }
-
-    internal sealed class MaxInt64 : Producer<long, MaxInt64._>
-    {
-        private readonly IObservable<long> _source;
-
-        public MaxInt64(IObservable<long> source)
-        {
-            _source = source;
-        }
-
-        protected override _ CreateSink(IObserver<long> observer) => new _(observer);
-
-        protected override void Run(_ sink) => sink.Run(_source);
-
-        internal sealed class _ : IdentitySink<long>
-        {
-            private bool _hasValue;
-            private long _lastValue;
-
-            public _(IObserver<long> observer)
-                : base(observer)
-            {
-            }
-
-            public override void OnNext(long value)
-            {
-                if (_hasValue)
-                {
-                    if (value > _lastValue)
-                    {
-                        _lastValue = value;
-                    }
-                }
-                else
-                {
-                    _lastValue = value;
-                    _hasValue = true;
-                }
-            }
-
-            public override void OnCompleted()
-            {
-                if (!_hasValue)
-                {
-                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
-                }
-                else
-                {
-                    ForwardOnNext(_lastValue);
-                    ForwardOnCompleted();
-                }
-            }
-        }
-    }
-
-    internal sealed class MaxDoubleNullable : Producer<double?, MaxDoubleNullable._>
-    {
-        private readonly IObservable<double?> _source;
-
-        public MaxDoubleNullable(IObservable<double?> source)
-        {
-            _source = source;
-        }
-
-        protected override _ CreateSink(IObserver<double?> observer) => new _(observer);
-
-        protected override void Run(_ sink) => sink.Run(_source);
-
-        internal sealed class _ : IdentitySink<double?>
-        {
-            private double? _lastValue;
-
-            public _(IObserver<double?> observer)
-                : base(observer)
-            {
-            }
-
-            public override void OnNext(double? value)
-            {
-                if (!value.HasValue)
-                {
-                    return;
-                }
-
-                if (_lastValue.HasValue)
-                {
-                    if (value > _lastValue || double.IsNaN((double)value))
-                    {
-                        _lastValue = value;
-                    }
-                }
-                else
+                if (value > _lastValue || float.IsNaN(value))
                 {
                     _lastValue = value;
                 }
             }
+            else
+            {
+                _lastValue = value;
+                _hasValue = true;
+            }
+        }
 
-            public override void OnCompleted()
+        public override void OnCompleted()
+        {
+            if (!_hasValue)
+            {
+                ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+            }
+            else
             {
                 ForwardOnNext(_lastValue);
                 ForwardOnCompleted();
@@ -456,49 +199,40 @@ namespace System.Reactive.Linq.ObservableImpl
         }
     }
 
-    internal sealed class MaxSingleNullable : Producer<float?, MaxSingleNullable._>
+    internal sealed class MaxDecimal : Pipe<decimal>
     {
-        private readonly IObservable<float?> _source;
+        private bool _hasValue;
+        private decimal _lastValue;
 
-        public MaxSingleNullable(IObservable<float?> source)
+        public MaxDecimal(IObservable<decimal> source) : base(source)
         {
-            _source = source;
         }
 
-        protected override _ CreateSink(IObserver<float?> observer) => new _(observer);
+        protected override Pipe<decimal, decimal> Clone() => new MaxDecimal(_source);
 
-        protected override void Run(_ sink) => sink.Run(_source);
-
-        internal sealed class _ : IdentitySink<float?>
+        public override void OnNext(decimal value)
         {
-            private float? _lastValue;
-
-            public _(IObserver<float?> observer)
-                : base(observer)
+            if (_hasValue)
             {
-            }
-
-            public override void OnNext(float? value)
-            {
-                if (!value.HasValue)
-                {
-                    return;
-                }
-
-                if (_lastValue.HasValue)
-                {
-                    if (value > _lastValue || float.IsNaN((float)value))
-                    {
-                        _lastValue = value;
-                    }
-                }
-                else
+                if (value > _lastValue)
                 {
                     _lastValue = value;
                 }
             }
+            else
+            {
+                _lastValue = value;
+                _hasValue = true;
+            }
+        }
 
-            public override void OnCompleted()
+        public override void OnCompleted()
+        {
+            if (!_hasValue)
+            {
+                ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+            }
+            else
             {
                 ForwardOnNext(_lastValue);
                 ForwardOnCompleted();
@@ -506,49 +240,40 @@ namespace System.Reactive.Linq.ObservableImpl
         }
     }
 
-    internal sealed class MaxDecimalNullable : Producer<decimal?, MaxDecimalNullable._>
+    internal sealed class MaxInt32 : Pipe<int>
     {
-        private readonly IObservable<decimal?> _source;
+        private bool _hasValue;
+        private int _lastValue;
 
-        public MaxDecimalNullable(IObservable<decimal?> source)
+        public MaxInt32(IObservable<int> source) : base(source)
         {
-            _source = source;
         }
 
-        protected override _ CreateSink(IObserver<decimal?> observer) => new _(observer);
+        protected override Pipe<int, int> Clone() => new MaxInt32(_source);
 
-        protected override void Run(_ sink) => sink.Run(_source);
-
-        internal sealed class _ : IdentitySink<decimal?>
+        public override void OnNext(int value)
         {
-            private decimal? _lastValue;
-
-            public _(IObserver<decimal?> observer)
-                : base(observer)
+            if (_hasValue)
             {
-            }
-
-            public override void OnNext(decimal? value)
-            {
-                if (!value.HasValue)
-                {
-                    return;
-                }
-
-                if (_lastValue.HasValue)
-                {
-                    if (value > _lastValue)
-                    {
-                        _lastValue = value;
-                    }
-                }
-                else
+                if (value > _lastValue)
                 {
                     _lastValue = value;
                 }
             }
+            else
+            {
+                _lastValue = value;
+                _hasValue = true;
+            }
+        }
 
-            public override void OnCompleted()
+        public override void OnCompleted()
+        {
+            if (!_hasValue)
+            {
+                ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+            }
+            else
             {
                 ForwardOnNext(_lastValue);
                 ForwardOnCompleted();
@@ -556,49 +281,40 @@ namespace System.Reactive.Linq.ObservableImpl
         }
     }
 
-    internal sealed class MaxInt32Nullable : Producer<int?, MaxInt32Nullable._>
+    internal sealed class MaxInt64 : Pipe<long>
     {
-        private readonly IObservable<int?> _source;
+        private bool _hasValue;
+        private long _lastValue;
 
-        public MaxInt32Nullable(IObservable<int?> source)
+        public MaxInt64(IObservable<long> source) : base(source)
         {
-            _source = source;
         }
 
-        protected override _ CreateSink(IObserver<int?> observer) => new _(observer);
+        protected override Pipe<long, long> Clone() => new MaxInt64(_source);
 
-        protected override void Run(_ sink) => sink.Run(_source);
-
-        internal sealed class _ : IdentitySink<int?>
+        public override void OnNext(long value)
         {
-            private int? _lastValue;
-
-            public _(IObserver<int?> observer)
-                : base(observer)
+            if (_hasValue)
             {
-            }
-
-            public override void OnNext(int? value)
-            {
-                if (!value.HasValue)
-                {
-                    return;
-                }
-
-                if (_lastValue.HasValue)
-                {
-                    if (value > _lastValue)
-                    {
-                        _lastValue = value;
-                    }
-                }
-                else
+                if (value > _lastValue)
                 {
                     _lastValue = value;
                 }
             }
+            else
+            {
+                _lastValue = value;
+                _hasValue = true;
+            }
+        }
 
-            public override void OnCompleted()
+        public override void OnCompleted()
+        {
+            if (!_hasValue)
+            {
+                ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+            }
+            else
             {
                 ForwardOnNext(_lastValue);
                 ForwardOnCompleted();
@@ -606,53 +322,188 @@ namespace System.Reactive.Linq.ObservableImpl
         }
     }
 
-    internal sealed class MaxInt64Nullable : Producer<long?, MaxInt64Nullable._>
+    internal sealed class MaxDoubleNullable : Pipe<double?>
     {
-        private readonly IObservable<long?> _source;
+        private double? _lastValue;
 
-        public MaxInt64Nullable(IObservable<long?> source)
+        public MaxDoubleNullable(IObservable<double?> source) : base(source)
         {
-            _source = source;
         }
 
-        protected override _ CreateSink(IObserver<long?> observer) => new _(observer);
+        protected override Pipe<double?, double?> Clone() => new MaxDoubleNullable(_source);
 
-        protected override void Run(_ sink) => sink.Run(_source);
-
-        internal sealed class _ : IdentitySink<long?>
+        public override void OnNext(double? value)
         {
-            private long? _lastValue;
-
-            public _(IObserver<long?> observer)
-                : base(observer)
+            if (!value.HasValue)
             {
+                return;
             }
 
-            public override void OnNext(long? value)
+            if (_lastValue.HasValue)
             {
-                if (!value.HasValue)
-                {
-                    return;
-                }
-
-                if (_lastValue.HasValue)
-                {
-                    if (value > _lastValue)
-                    {
-                        _lastValue = value;
-                    }
-                }
-                else
+                if (value > _lastValue || double.IsNaN((double)value))
                 {
                     _lastValue = value;
                 }
             }
-
-            public override void OnCompleted()
+            else
             {
-                ForwardOnNext(_lastValue);
-                ForwardOnCompleted();
+                _lastValue = value;
             }
+        }
+
+        public override void OnCompleted()
+        {
+            ForwardOnNext(_lastValue);
+            ForwardOnCompleted();
+        }
+    }
+
+    internal sealed class MaxSingleNullable : Pipe<float?>
+    {
+        private float? _lastValue;
+
+        public MaxSingleNullable(IObservable<float?> source) : base(source)
+        {
+        }
+
+        protected override Pipe<float?, float?> Clone() => new MaxSingleNullable(_source);
+
+        public override void OnNext(float? value)
+        {
+            if (!value.HasValue)
+            {
+                return;
+            }
+
+            if (_lastValue.HasValue)
+            {
+                if (value > _lastValue || float.IsNaN((float)value))
+                {
+                    _lastValue = value;
+                }
+            }
+            else
+            {
+                _lastValue = value;
+            }
+        }
+
+        public override void OnCompleted()
+        {
+            ForwardOnNext(_lastValue);
+            ForwardOnCompleted();
+        }
+    }
+
+    internal sealed class MaxDecimalNullable : Pipe<decimal?>
+    {
+        private decimal? _lastValue;
+
+        public MaxDecimalNullable(IObservable<decimal?> source) : base(source)
+        {
+        }
+
+        protected override Pipe<decimal?, decimal?> Clone() => new MaxDecimalNullable(_source);
+
+        public override void OnNext(decimal? value)
+        {
+            if (!value.HasValue)
+            {
+                return;
+            }
+
+            if (_lastValue.HasValue)
+            {
+                if (value > _lastValue)
+                {
+                    _lastValue = value;
+                }
+            }
+            else
+            {
+                _lastValue = value;
+            }
+        }
+
+        public override void OnCompleted()
+        {
+            ForwardOnNext(_lastValue);
+            ForwardOnCompleted();
+        }
+    }
+
+    internal sealed class MaxInt32Nullable : Pipe<int?>
+    {
+        private int? _lastValue;
+
+        public MaxInt32Nullable(IObservable<int?> source) : base(source)
+        {
+        }
+
+        protected override Pipe<int?, int?> Clone() => new MaxInt32Nullable(_source);
+
+        public override void OnNext(int? value)
+        {
+            if (!value.HasValue)
+            {
+                return;
+            }
+
+            if (_lastValue.HasValue)
+            {
+                if (value > _lastValue)
+                {
+                    _lastValue = value;
+                }
+            }
+            else
+            {
+                _lastValue = value;
+            }
+        }
+
+        public override void OnCompleted()
+        {
+            ForwardOnNext(_lastValue);
+            ForwardOnCompleted();
+        }
+    }
+
+    internal sealed class MaxInt64Nullable : Pipe<long?>
+    {
+        private long? _lastValue;
+
+        public MaxInt64Nullable(IObservable<long?> source) : base(source)
+        {
+        }
+
+        protected override Pipe<long?, long?> Clone() => new MaxInt64Nullable(_source);
+
+        public override void OnNext(long? value)
+        {
+            if (!value.HasValue)
+            {
+                return;
+            }
+
+            if (_lastValue.HasValue)
+            {
+                if (value > _lastValue)
+                {
+                    _lastValue = value;
+                }
+            }
+            else
+            {
+                _lastValue = value;
+            }
+        }
+
+        public override void OnCompleted()
+        {
+            ForwardOnNext(_lastValue);
+            ForwardOnCompleted();
         }
     }
 }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Skip.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Skip.cs
@@ -9,16 +9,19 @@ namespace System.Reactive.Linq.ObservableImpl
 {
     internal static class Skip<TSource>
     {
-        internal sealed class Count : Producer<TSource, Count._>
+        internal sealed class Count : Pipe<TSource>
         {
-            private readonly IObservable<TSource> _source;
             private readonly int _count;
 
-            public Count(IObservable<TSource> source, int count)
+            private int _remaining;
+
+            public Count(IObservable<TSource> source, int count) : base(source)
             {
-                _source = source;
                 _count = count;
+                _remaining = count;
             }
+
+            protected override Pipe<TSource, TSource> Clone() => new Count(_source, _count);
 
             public IObservable<TSource> Combine(int count)
             {
@@ -32,30 +35,15 @@ namespace System.Reactive.Linq.ObservableImpl
                 return new Count(_source, _count + count);
             }
 
-            protected override _ CreateSink(IObserver<TSource> observer) => new _(_count, observer);
-
-            protected override void Run(_ sink) => sink.Run(_source);
-
-            internal sealed class _ : IdentitySink<TSource>
+            public override void OnNext(TSource value)
             {
-                private int _remaining;
-
-                public _(int count, IObserver<TSource> observer)
-                    : base(observer)
+                if (_remaining <= 0)
                 {
-                    _remaining = count;
+                    ForwardOnNext(value);
                 }
-
-                public override void OnNext(TSource value)
+                else
                 {
-                    if (_remaining <= 0)
-                    {
-                        ForwardOnNext(value);
-                    }
-                    else
-                    {
-                        _remaining--;
-                    }
+                    _remaining--;
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Sum.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Sum.cs
@@ -4,408 +4,279 @@
 
 namespace System.Reactive.Linq.ObservableImpl
 {
-    internal sealed class SumDouble : Producer<double, SumDouble._>
+    internal sealed class SumDouble : Pipe<double>
     {
-        private readonly IObservable<double> _source;
+        private double _sum;
 
-        public SumDouble(IObservable<double> source)
+        public SumDouble(IObservable<double> source) : base(source)
         {
-            _source = source;
         }
 
-        protected override _ CreateSink(IObserver<double> observer) => new _(observer);
+        protected override Pipe<double, double> Clone() => new SumDouble(_source);
 
-        protected override void Run(_ sink) => sink.Run(_source);
-
-        internal sealed class _ : IdentitySink<double>
+        public override void OnNext(double value)
         {
-            private double _sum;
+            _sum += value;
+        }
 
-            public _(IObserver<double> observer)
-                : base(observer)
-            {
-            }
-
-            public override void OnNext(double value)
-            {
-                _sum += value;
-            }
-
-            public override void OnCompleted()
-            {
-                ForwardOnNext(_sum);
-                ForwardOnCompleted();
-            }
+        public override void OnCompleted()
+        {
+            ForwardOnNext(_sum);
+            ForwardOnCompleted();
         }
     }
 
-    internal sealed class SumSingle : Producer<float, SumSingle._>
+    internal sealed class SumSingle : Pipe<float>
     {
-        private readonly IObservable<float> _source;
+        private double _sum; // This is what LINQ to Objects does (accumulates into double that is)!
 
-        public SumSingle(IObservable<float> source)
+        public SumSingle(IObservable<float> source) : base(source)
         {
-            _source = source;
         }
 
-        protected override _ CreateSink(IObserver<float> observer) => new _(observer);
+        protected override Pipe<float, float> Clone() => new SumSingle(_source);
 
-        protected override void Run(_ sink) => sink.Run(_source);
-
-        internal sealed class _ : IdentitySink<float>
+        public override void OnNext(float value)
         {
-            private double _sum; // This is what LINQ to Objects does (accumulates into double that is)!
+            _sum += value; // This is what LINQ to Objects does!
+        }
 
-            public _(IObserver<float> observer)
-                : base(observer)
-            {
-            }
-
-            public override void OnNext(float value)
-            {
-                _sum += value; // This is what LINQ to Objects does!
-            }
-
-            public override void OnCompleted()
-            {
-                ForwardOnNext((float)_sum); // This is what LINQ to Objects does!
-                ForwardOnCompleted();
-            }
+        public override void OnCompleted()
+        {
+            ForwardOnNext((float)_sum); // This is what LINQ to Objects does!
+            ForwardOnCompleted();
         }
     }
 
-    internal sealed class SumDecimal : Producer<decimal, SumDecimal._>
+    internal sealed class SumDecimal : Pipe<decimal>
     {
-        private readonly IObservable<decimal> _source;
+        private decimal _sum;
 
-        public SumDecimal(IObservable<decimal> source)
+        public SumDecimal(IObservable<decimal> source) : base(source)
         {
-            _source = source;
         }
 
-        protected override _ CreateSink(IObserver<decimal> observer) => new _(observer);
+        protected override Pipe<decimal, decimal> Clone() => new SumDecimal(_source);
 
-        protected override void Run(_ sink) => sink.Run(_source);
-
-        internal sealed class _ : IdentitySink<decimal>
+        public override void OnNext(decimal value)
         {
-            private decimal _sum;
+            _sum += value;
+        }
 
-            public _(IObserver<decimal> observer)
-                : base(observer)
-            {
-            }
-
-            public override void OnNext(decimal value)
-            {
-                _sum += value;
-            }
-
-            public override void OnCompleted()
-            {
-                ForwardOnNext(_sum);
-                ForwardOnCompleted();
-            }
+        public override void OnCompleted()
+        {
+            ForwardOnNext(_sum);
+            ForwardOnCompleted();
         }
     }
 
-    internal sealed class SumInt32 : Producer<int, SumInt32._>
+    internal sealed class SumInt32 : Pipe<int>
     {
-        private readonly IObservable<int> _source;
+        private int _sum;
 
-        public SumInt32(IObservable<int> source)
+        public SumInt32(IObservable<int> source) : base(source)
         {
-            _source = source;
         }
 
-        protected override _ CreateSink(IObserver<int> observer) => new _(observer);
+        protected override Pipe<int, int> Clone() => new SumInt32(_source);
 
-        protected override void Run(_ sink) => sink.Run(_source);
-
-        internal sealed class _ : IdentitySink<int>
+        public override void OnNext(int value)
         {
-            private int _sum;
-
-            public _(IObserver<int> observer)
-                : base(observer)
+            try
             {
-            }
-
-            public override void OnNext(int value)
-            {
-                try
+                checked
                 {
-                    checked
+                    _sum += value;
+                }
+            }
+            catch (Exception exception)
+            {
+                ForwardOnError(exception);
+            }
+        }
+
+        public override void OnCompleted()
+        {
+            ForwardOnNext(_sum);
+            ForwardOnCompleted();
+        }
+    }
+
+    internal sealed class SumInt64 : Pipe<long>
+    {
+        private long _sum;
+
+        public SumInt64(IObservable<long> source) : base(source)
+        {
+        }
+
+        protected override Pipe<long, long> Clone() => new SumInt64(_source);
+
+        public override void OnNext(long value)
+        {
+            try
+            {
+                checked
+                {
+                    _sum += value;
+                }
+            }
+            catch (Exception exception)
+            {
+                ForwardOnError(exception);
+            }
+        }
+
+        public override void OnCompleted()
+        {
+            ForwardOnNext(_sum);
+            ForwardOnCompleted();
+        }
+    }
+
+    internal sealed class SumDoubleNullable : Pipe<double?>
+    {
+        private double _sum;
+
+        public SumDoubleNullable(IObservable<double?> source) : base(source)
+        {
+        }
+
+        protected override Pipe<double?, double?> Clone() => new SumDoubleNullable(_source);
+
+        public override void OnNext(double? value)
+        {
+            if (value != null)
+            {
+                _sum += value.Value;
+            }
+        }
+
+        public override void OnCompleted()
+        {
+            ForwardOnNext(_sum);
+            ForwardOnCompleted();
+        }
+        
+    }
+
+    internal sealed class SumSingleNullable : Pipe<float?>
+    {
+        private double _sum; // This is what LINQ to Objects does (accumulates into double that is)!
+
+        public SumSingleNullable(IObservable<float?> source) : base(source)
+        {
+        }
+
+        protected override Pipe<float?, float?> Clone() => new SumSingleNullable(_source);
+
+        public override void OnNext(float? value)
+        {
+            if (value != null)
+            {
+                _sum += value.Value; // This is what LINQ to Objects does!
+            }
+        }
+
+        public override void OnCompleted()
+        {
+            ForwardOnNext((float)_sum); // This is what LINQ to Objects does!
+            ForwardOnCompleted();
+        }
+    }
+
+    internal sealed class SumDecimalNullable : Pipe<decimal?>
+    {
+        private decimal _sum;
+
+        public SumDecimalNullable(IObservable<decimal?> source) : base(source)
+        {
+        }
+
+        protected override Pipe<decimal?, decimal?> Clone() => new SumDecimalNullable(_source);
+
+        public override void OnNext(decimal? value)
+        {
+            if (value != null)
+            {
+                _sum += value.Value;
+            }
+        }
+
+        public override void OnCompleted()
+        {
+            ForwardOnNext(_sum);
+            ForwardOnCompleted();
+        }
+    }
+
+    internal sealed class SumInt32Nullable : Pipe<int?>
+    {
+        private int _sum;
+
+        public SumInt32Nullable(IObservable<int?> source) : base(source)
+        {
+        }
+
+        protected override Pipe<int?, int?> Clone() => new SumInt32Nullable(_source);
+
+        public override void OnNext(int? value)
+        {
+            try
+            {
+                checked
+                {
+                    if (value != null)
                     {
-                        _sum += value;
+                        _sum += value.Value;
                     }
                 }
-                catch (Exception exception)
-                {
-                    ForwardOnError(exception);
-                }
             }
-
-            public override void OnCompleted()
+            catch (Exception exception)
             {
-                ForwardOnNext(_sum);
-                ForwardOnCompleted();
+                ForwardOnError(exception);
             }
+        }
+
+        public override void OnCompleted()
+        {
+            ForwardOnNext(_sum);
+            ForwardOnCompleted();
         }
     }
 
-    internal sealed class SumInt64 : Producer<long, SumInt64._>
+    internal sealed class SumInt64Nullable : Pipe<long?>
     {
-        private readonly IObservable<long> _source;
+        private long _sum;
 
-        public SumInt64(IObservable<long> source)
+        public SumInt64Nullable(IObservable<long?> source) : base(source)
         {
-            _source = source;
         }
 
-        protected override _ CreateSink(IObserver<long> observer) => new _(observer);
-
-        protected override void Run(_ sink) => sink.Run(_source);
-
-        internal sealed class _ : IdentitySink<long>
+        protected override Pipe<long?, long?> Clone() => new SumInt64Nullable(_source);
+        
+        public override void OnNext(long? value)
         {
-            private long _sum;
-
-            public _(IObserver<long> observer)
-                : base(observer)
+            try
             {
-            }
-
-            public override void OnNext(long value)
-            {
-                try
+                checked
                 {
-                    checked
+                    if (value != null)
                     {
-                        _sum += value;
+                        _sum += value.Value;
                     }
                 }
-                catch (Exception exception)
-                {
-                    ForwardOnError(exception);
-                }
             }
-
-            public override void OnCompleted()
+            catch (Exception exception)
             {
-                ForwardOnNext(_sum);
-                ForwardOnCompleted();
+                ForwardOnError(exception);
             }
         }
-    }
 
-    internal sealed class SumDoubleNullable : Producer<double?, SumDoubleNullable._>
-    {
-        private readonly IObservable<double?> _source;
-
-        public SumDoubleNullable(IObservable<double?> source)
+        public override void OnCompleted()
         {
-            _source = source;
-        }
-
-        protected override _ CreateSink(IObserver<double?> observer) => new _(observer);
-
-        protected override void Run(_ sink) => sink.Run(_source);
-
-        internal sealed class _ : IdentitySink<double?>
-        {
-            private double _sum;
-
-            public _(IObserver<double?> observer)
-                : base(observer)
-            {
-            }
-
-            public override void OnNext(double? value)
-            {
-                if (value != null)
-                {
-                    _sum += value.Value;
-                }
-            }
-
-            public override void OnCompleted()
-            {
-                ForwardOnNext(_sum);
-                ForwardOnCompleted();
-            }
-        }
-    }
-
-    internal sealed class SumSingleNullable : Producer<float?, SumSingleNullable._>
-    {
-        private readonly IObservable<float?> _source;
-
-        public SumSingleNullable(IObservable<float?> source)
-        {
-            _source = source;
-        }
-
-        protected override _ CreateSink(IObserver<float?> observer) => new _(observer);
-
-        protected override void Run(_ sink) => sink.Run(_source);
-
-        internal sealed class _ : IdentitySink<float?>
-        {
-            private double _sum; // This is what LINQ to Objects does (accumulates into double that is)!
-
-            public _(IObserver<float?> observer)
-                : base(observer)
-            {
-            }
-
-            public override void OnNext(float? value)
-            {
-                if (value != null)
-                {
-                    _sum += value.Value; // This is what LINQ to Objects does!
-                }
-            }
-
-            public override void OnCompleted()
-            {
-                ForwardOnNext((float)_sum); // This is what LINQ to Objects does!
-                ForwardOnCompleted();
-            }
-        }
-    }
-
-    internal sealed class SumDecimalNullable : Producer<decimal?, SumDecimalNullable._>
-    {
-        private readonly IObservable<decimal?> _source;
-
-        public SumDecimalNullable(IObservable<decimal?> source)
-        {
-            _source = source;
-        }
-
-        protected override _ CreateSink(IObserver<decimal?> observer) => new _(observer);
-
-        protected override void Run(_ sink) => sink.Run(_source);
-
-        internal sealed class _ : IdentitySink<decimal?>
-        {
-            private decimal _sum;
-
-            public _(IObserver<decimal?> observer)
-                : base(observer)
-            {
-            }
-
-            public override void OnNext(decimal? value)
-            {
-                if (value != null)
-                {
-                    _sum += value.Value;
-                }
-            }
-
-            public override void OnCompleted()
-            {
-                ForwardOnNext(_sum);
-                ForwardOnCompleted();
-            }
-        }
-    }
-
-    internal sealed class SumInt32Nullable : Producer<int?, SumInt32Nullable._>
-    {
-        private readonly IObservable<int?> _source;
-
-        public SumInt32Nullable(IObservable<int?> source)
-        {
-            _source = source;
-        }
-
-        protected override _ CreateSink(IObserver<int?> observer) => new _(observer);
-
-        protected override void Run(_ sink) => sink.Run(_source);
-
-        internal sealed class _ : IdentitySink<int?>
-        {
-            private int _sum;
-
-            public _(IObserver<int?> observer)
-                : base(observer)
-            {
-            }
-
-            public override void OnNext(int? value)
-            {
-                try
-                {
-                    checked
-                    {
-                        if (value != null)
-                        {
-                            _sum += value.Value;
-                        }
-                    }
-                }
-                catch (Exception exception)
-                {
-                    ForwardOnError(exception);
-                }
-            }
-
-            public override void OnCompleted()
-            {
-                ForwardOnNext(_sum);
-                ForwardOnCompleted();
-            }
-        }
-    }
-
-    internal sealed class SumInt64Nullable : Producer<long?, SumInt64Nullable._>
-    {
-        private readonly IObservable<long?> _source;
-
-        public SumInt64Nullable(IObservable<long?> source)
-        {
-            _source = source;
-        }
-
-        protected override _ CreateSink(IObserver<long?> observer) => new _(observer);
-
-        protected override void Run(_ sink) => sink.Run(_source);
-
-        internal sealed class _ : IdentitySink<long?>
-        {
-            private long _sum;
-
-            public _(IObserver<long?> observer)
-                : base(observer)
-            {
-            }
-
-            public override void OnNext(long? value)
-            {
-                try
-                {
-                    checked
-                    {
-                        if (value != null)
-                        {
-                            _sum += value.Value;
-                        }
-                    }
-                }
-                catch (Exception exception)
-                {
-                    ForwardOnError(exception);
-                }
-            }
-
-            public override void OnCompleted()
-            {
-                ForwardOnNext(_sum);
-                ForwardOnCompleted();
-            }
+            ForwardOnNext(_sum);
+            ForwardOnCompleted();
         }
     }
 }

--- a/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Aggregates.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Aggregates.cs
@@ -286,13 +286,23 @@ namespace System.Reactive.Linq
 
         public virtual IObservable<TSource> Max<TSource>(IObservable<TSource> source)
         {
-            // BREAKING CHANGE v2 > v1.x - Behavior for reference types
+            if (default(TSource) == null)
+            {
+                // BREAKING CHANGE v2 > v1.x - Behavior for reference types
+                return new MaxNullable<TSource>(source, Comparer<TSource>.Default);
+            }
+
             return new Max<TSource>(source, Comparer<TSource>.Default);
         }
 
         public virtual IObservable<TSource> Max<TSource>(IObservable<TSource> source, IComparer<TSource> comparer)
         {
-            // BREAKING CHANGE v2 > v1.x - Behavior for reference types
+            if (default(TSource) == null)
+            {
+                // BREAKING CHANGE v2 > v1.x - Behavior for reference types
+                return new MaxNullable<TSource>(source, comparer);
+            }
+
             return new Max<TSource>(source, comparer);
         }
 


### PR DESCRIPTION
While looking through the _AsyncIx_ code for C# 8, I stumbled across the [`AsyncIterator`](https://github.com/dotnet/reactive/blob/IxAsyncCSharp8/Ix.NET/Source/System.Linq.Async/System/Linq/AsyncIterator.cs) class. It is a hybrid of `IAsyncEnumerable` and `IAsyncEnumerator` and reduce the number of allocations by reusing the `IAsyncEnumerable` instance for the first enumerator. In this PR I do the same for `IObservable` and `IObserver`.

There are some downsides in doing that. It glues two things together that should be (at least mentally) kept separated. While the operators still only expose the `IObservable` interface, it'd be possible to access implementation details with a dynamic cast:

```csharp
    var query = obs.Where(x => x < 10);

    if (query is IDisposable disposable)
        disposable.Dispose();        // Oops
```

On the other hand it brings some reduction in allocations. What I like most is that it removes several lines of boiler plate code.

I used the name `Pipe` because it connects sources/producers and sinks. For the implementation I used the `Producer` class as base class and literally copy and pasted the code of the `Sink`, plus some minor additions, like the implemented `CreateSink` method. There are also some example usage for some random operators. If you like the idea I can transform more of them.

I marked the PR as discussion, because I'm not sure myself if it is a good idea. I definitely  don't like that operators would leak the `IDisposable` interface. That could lead to strange problems if one is using, for example, an auto disposing object store. I don't know, however, if such a thing exists and is in use. On the other hand the same would apply for the `AsyncIterator`. What I really like is the reduction of boiler plate code. The `Select` class only contains: the constructor, the clone method, and `OnNext` method.