### PR TITLE
4.x: Fix InvalidOp when enumerating the SystemClockChanged hashset

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Concurrency/LocalScheduler.TimerQueue.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/LocalScheduler.TimerQueue.cs
@@ -370,7 +370,7 @@ namespace System.Reactive.Concurrency
         /// </summary>
         /// <param name="args">Currently not used.</param>
         /// <param name="sender">Currently not used.</param>
-        internal void SystemClockChanged(object sender, SystemClockChangedEventArgs args)
+        internal virtual void SystemClockChanged(object sender, SystemClockChangedEventArgs args)
         {
             lock (StaticGate)
             {

--- a/Rx.NET/Source/src/System.Reactive/Internal/SystemClock.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/SystemClock.cs
@@ -59,7 +59,9 @@ namespace System.Reactive.PlatformServices
         {
             lock (SystemClockChanged)
             {
-                foreach (var entry in SystemClockChanged)
+                // create a defensive copy as the callbacks may change the hashset
+                var copySystemClockChanged = new List<WeakReference<LocalScheduler>>(SystemClockChanged);
+                foreach (var entry in copySystemClockChanged)
                 {
                     if (entry.TryGetTarget(out var scheduler))
                     {

--- a/Rx.NET/Source/src/System.Reactive/Internal/SystemClock.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/SystemClock.cs
@@ -21,7 +21,7 @@ namespace System.Reactive.PlatformServices
     {
         private static readonly Lazy<ISystemClock> ServiceSystemClock = new Lazy<ISystemClock>(InitializeSystemClock);
         private static readonly Lazy<INotifySystemClockChanged> ServiceSystemClockChanged = new Lazy<INotifySystemClockChanged>(InitializeSystemClockChanged);
-        private static readonly HashSet<WeakReference<LocalScheduler>> SystemClockChanged = new HashSet<WeakReference<LocalScheduler>>();
+        internal static readonly HashSet<WeakReference<LocalScheduler>> SystemClockChanged = new HashSet<WeakReference<LocalScheduler>>();
         private static IDisposable _systemClockChangedHandlerCollector;
 
         private static int _refCount;
@@ -55,7 +55,7 @@ namespace System.Reactive.PlatformServices
             }
         }
 
-        private static void OnSystemClockChanged(object sender, SystemClockChangedEventArgs e)
+        internal static void OnSystemClockChanged(object sender, SystemClockChangedEventArgs e)
         {
             lock (SystemClockChanged)
             {


### PR DESCRIPTION
When the clock change is notified, any modification to the SystemClockChanged hashset from the callbacks results in an InvalidOperationException. The fix is to create a copy of the hashset contents and enumerate that.

Resolves #879 