### PR TITLE
Fix wrong usage of ISchedulerLongRunning in ObserveOn

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Concurrency/Synchronization.ObserveOn.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/Synchronization.ObserveOn.cs
@@ -28,6 +28,26 @@ namespace System.Reactive.Concurrency
             protected override void Run(ObserveOnObserverNew<TSource> sink) => sink.Run(_source);
         }
 
+        /// <summary>
+        /// The new ObserveOn operator run with an ISchedulerLongRunning in a mostly lock-free manner.
+        /// </summary>
+        internal sealed class SchedulerLongRunning : Producer<TSource, ObserveOnObserverLongRunning<TSource>>
+        {
+            private readonly IObservable<TSource> _source;
+            private readonly ISchedulerLongRunning _scheduler;
+
+            public SchedulerLongRunning(IObservable<TSource> source, ISchedulerLongRunning scheduler)
+            {
+                _source = source;
+                _scheduler = scheduler;
+            }
+
+            protected override ObserveOnObserverLongRunning<TSource> CreateSink(IObserver<TSource> observer) => new ObserveOnObserverLongRunning<TSource>(_scheduler, observer);
+
+            [Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "2", Justification = "Visibility restricted to friend assemblies. Those should be correct by inspection.")]
+            protected override void Run(ObserveOnObserverLongRunning<TSource> sink) => sink.Run(_source);
+        }
+
         internal sealed class Context : Producer<TSource, Context._>
         {
             private readonly IObservable<TSource> _source;

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/Synchronization.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/Synchronization.cs
@@ -181,6 +181,11 @@ namespace System.Reactive.Concurrency
                 throw new ArgumentNullException(nameof(scheduler));
             }
 
+            var longRunning = scheduler.AsLongRunning();
+            if (longRunning != null)
+            {
+                return new ObserveOn<TSource>.SchedulerLongRunning(source, longRunning);
+            }
             return new ObserveOn<TSource>.Scheduler(source, scheduler);
         }
 


### PR DESCRIPTION
The optimized `ObserveOn` was using the `ISchedulerLongRunning` scheduler incorrectly. This type of scheduler is meant to be kept alive by possibly blocking the backing thread as long as the sequence is still active.

Additional changes:
- Removed the `ISchedulerLongRunning` cases from the `ObserveOnObserverNew` implementation.
- The `ObserveOnObserverNew` no longer supports error delaying (Based on unit tests, it was expected only from `ISchedulerLongRunning` schedulers anyway). 
- Created a new `ObserveOnObserverLongRunning` dedicated to working with `ISchedulerLongRunning`.
- The choice of which implementation to use has been moved to assembly time inside the `ObserveOn` extension method.
- Added unit test to verify there is no thread hopping with the TaskPoolScheduler.
- Added unit test to verify applying DisableOptimizations to TaskPoolScheduler and calling `AsLongRunning()` no longer returns an `ISchedulerLongRunning` implementation.


Fixes #877