### PR TITLE
Update Behavior/ReplaySubject to more eagerly handle disposed observers

### DIFF
--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Subjects/AsyncSubjectTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Subjects/AsyncSubjectTest.cs
@@ -547,5 +547,26 @@ namespace ReactiveTests.Tests
             s.OnError(new Exception());
             Assert.False(s.HasObservers);
         }
+
+        [Fact]
+        public void UnsubscribeAnotherObserverFromOnNext()
+        {
+            var subject = new AsyncSubject<int>();
+
+            var calls = 0;
+            IDisposable otherDisposable = null;
+
+            subject.Subscribe(_ =>
+            {
+                otherDisposable?.Dispose();
+            });
+
+            otherDisposable = subject.Subscribe(_ => calls++);
+
+            subject.OnNext(0);
+            subject.OnCompleted();
+
+            Assert.Equal(0, calls);
+        }
     }
 }

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Subjects/BehaviorSubjectTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Subjects/BehaviorSubjectTest.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Reactive.Concurrency;
 using System.Reactive.Subjects;
-using System.Threading;
 using Microsoft.Reactive.Testing;
 using Xunit;
 

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Subjects/BehaviorSubjectTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Subjects/BehaviorSubjectTest.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Reactive.Concurrency;
 using System.Reactive.Subjects;
+using System.Threading;
 using Microsoft.Reactive.Testing;
 using Xunit;
 
@@ -559,6 +560,27 @@ namespace ReactiveTests.Tests
             });
 
             Assert.False(s.TryGetValue(out var x));
+        }
+
+        [Fact]
+        public void UnsubscribeAnotherObserverFromOnNext()
+        {
+            var subject = new BehaviorSubject<int>(0);
+
+            var calls = 0;
+            IDisposable otherDisposable = null;
+
+            subject.Subscribe(_ =>
+            {
+                otherDisposable?.Dispose();
+            });
+
+            otherDisposable = subject.Subscribe(_ => calls++);
+
+            subject.OnNext(0);
+            subject.OnCompleted();
+
+            Assert.Equal(1, calls);
         }
     }
 }

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Subjects/ReplaySubjectTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Subjects/ReplaySubjectTest.cs
@@ -1845,6 +1845,73 @@ namespace ReactiveTests.Tests
             }));
         }
 
+        [Fact]
+        public void UnsubscribeAnotherObserverFromOnNext_Unbounded()
+        {
+            var subject = new ReplaySubject<int>();
+
+            var calls = 0;
+            IDisposable otherDisposable = null;
+
+            subject.Subscribe(_ =>
+            {
+                otherDisposable?.Dispose();
+            });
+
+            otherDisposable = subject.Subscribe(_ => calls++);
+
+            subject.OnNext(0);
+            subject.OnCompleted();
+
+            Assert.Equal(0, calls);
+        }
+
+        [Fact]
+        public void UnsubscribeAnotherObserverFromOnNext_SizeBound()
+        {
+            var subject = new ReplaySubject<int>(10);
+
+            var calls = 0;
+            IDisposable otherDisposable = null;
+
+            subject.Subscribe(_ =>
+            {
+                otherDisposable?.Dispose();
+            });
+
+            otherDisposable = subject.Subscribe(_ => calls++);
+
+            subject.OnNext(0);
+            subject.OnCompleted();
+
+            Assert.Equal(0, calls);
+        }
+
+        [Fact]
+        public void UnsubscribeAnotherObserverFromOnNext_TimeBound()
+        {
+            var subject = new ReplaySubject<int>(TimeSpan.FromHours(1));
+
+            var calls = 0;
+            IDisposable otherDisposable = null;
+
+            subject.Subscribe(_ =>
+            {
+                otherDisposable?.Dispose();
+            });
+
+            otherDisposable = subject.Subscribe(_ =>
+            {
+                calls++;
+            });
+
+            subject.OnNext(0);
+            subject.OnCompleted();
+
+            Assert.Equal(0, calls);
+        }
+
+
 #if !NO_INTERNALSTEST
         [Fact]
         public void FastImmediateObserver_Simple1()

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Subjects/SubjectTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Subjects/SubjectTest.cs
@@ -609,5 +609,26 @@ namespace ReactiveTests.Tests
             s.OnError(new Exception());
             Assert.False(s.HasObservers);
         }
+
+        [Fact]
+        public void UnsubscribeAnotherObserverFromOnNext()
+        {
+            var subject = new Subject<int>();
+
+            var calls = 0;
+            IDisposable otherDisposable = null;
+
+            subject.Subscribe(_ =>
+            {
+                otherDisposable?.Dispose();
+            });
+
+            otherDisposable = subject.Subscribe(_ => calls++);
+
+            subject.OnNext(0);
+            subject.OnCompleted();
+
+            Assert.Equal(0, calls);
+        }
     }
 }


### PR DESCRIPTION
This PR updates the `BehaviorSubject` and `ReplaySubject` to eagerly check for disposed observers while multiple observers are being notified. This handles the case when one observer disposes another one that would come next. The PR makes all 4 subject types consistent in this regard and adds the relevant unit tests.

Resolves #875.