### PR TITLE
Use some more C# 8.0 features for async Ix

### DIFF
--- a/Ix.NET/Source/System.Interactive.Async/System/Linq/Operators/DistinctUntilChanged.cs
+++ b/Ix.NET/Source/System.Interactive.Async/System/Linq/Operators/DistinctUntilChanged.cs
@@ -94,10 +94,7 @@ namespace System.Linq
         private static IAsyncEnumerable<TSource> DistinctUntilChangedCore<TSource>(IAsyncEnumerable<TSource> source, IEqualityComparer<TSource> comparer)
         {
 #if USE_ASYNC_ITERATOR
-            if (comparer == null)
-            {
-                comparer = EqualityComparer<TSource>.Default;
-            }
+            comparer ??= EqualityComparer<TSource>.Default;
 
             return AsyncEnumerable.Create(Core);
 
@@ -135,10 +132,7 @@ namespace System.Linq
         private static IAsyncEnumerable<TSource> DistinctUntilChangedCore<TSource, TKey>(IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
         {
 #if USE_ASYNC_ITERATOR
-            if (comparer == null)
-            {
-                comparer = EqualityComparer<TKey>.Default;
-            }
+            comparer ??= EqualityComparer<TKey>.Default;
 
             return AsyncEnumerable.Create(Core);
 
@@ -180,10 +174,7 @@ namespace System.Linq
         private static IAsyncEnumerable<TSource> DistinctUntilChangedCore<TSource, TKey>(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, IEqualityComparer<TKey> comparer)
         {
 #if USE_ASYNC_ITERATOR
-            if (comparer == null)
-            {
-                comparer = EqualityComparer<TKey>.Default;
-            }
+            comparer ??= EqualityComparer<TKey>.Default;
 
             return AsyncEnumerable.Create(Core);
 
@@ -226,10 +217,7 @@ namespace System.Linq
         private static IAsyncEnumerable<TSource> DistinctUntilChangedCore<TSource, TKey>(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<TKey>> keySelector, IEqualityComparer<TKey> comparer)
         {
 #if USE_ASYNC_ITERATOR
-            if (comparer == null)
-            {
-                comparer = EqualityComparer<TKey>.Default;
-            }
+            comparer ??= EqualityComparer<TKey>.Default;
 
             return AsyncEnumerable.Create(Core);
 

--- a/Ix.NET/Source/System.Interactive.Async/System/Linq/Operators/IsEmpty.cs
+++ b/Ix.NET/Source/System.Interactive.Async/System/Linq/Operators/IsEmpty.cs
@@ -17,9 +17,9 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<bool> Core(IAsyncEnumerable<TSource> _source, CancellationToken _cancellationToken)
+            static async ValueTask<bool> Core(IAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     return !await e.MoveNextAsync();
                 }

--- a/Ix.NET/Source/System.Interactive.Async/System/Linq/Operators/Max.cs
+++ b/Ix.NET/Source/System.Interactive.Async/System/Linq/Operators/Max.cs
@@ -19,10 +19,7 @@ namespace System.Linq
 
             static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, IComparer<TSource> comparer, CancellationToken cancellationToken)
             {
-                if (comparer == null)
-                {
-                    comparer = Comparer<TSource>.Default;
-                }
+                comparer ??= Comparer<TSource>.Default;
 
                 await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {

--- a/Ix.NET/Source/System.Interactive.Async/System/Linq/Operators/Max.cs
+++ b/Ix.NET/Source/System.Interactive.Async/System/Linq/Operators/Max.cs
@@ -17,14 +17,14 @@ namespace System.Linq
 
             return Core(source, comparer, cancellationToken);
 
-            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, IComparer<TSource> _comparer, CancellationToken _cancellationToken)
+            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, IComparer<TSource> comparer, CancellationToken cancellationToken)
             {
-                if (_comparer == null)
+                if (comparer == null)
                 {
-                    _comparer = Comparer<TSource>.Default;
+                    comparer = Comparer<TSource>.Default;
                 }
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                         throw Error.NoElements();
@@ -35,7 +35,7 @@ namespace System.Linq
                     {
                         var cur = e.Current;
 
-                        if (_comparer.Compare(cur, max) > 0)
+                        if (comparer.Compare(cur, max) > 0)
                         {
                             max = cur;
                         }

--- a/Ix.NET/Source/System.Interactive.Async/System/Linq/Operators/MaxBy.cs
+++ b/Ix.NET/Source/System.Interactive.Async/System/Linq/Operators/MaxBy.cs
@@ -76,20 +76,14 @@ namespace System.Linq
 
         private static ValueTask<IList<TSource>> MaxByCore<TSource, TKey>(IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey> comparer, CancellationToken cancellationToken)
         {
-            if (comparer == null)
-            {
-                comparer = Comparer<TKey>.Default;
-            }
+            comparer ??= Comparer<TKey>.Default;
 
             return ExtremaBy(source, keySelector, (key, minValue) => comparer.Compare(key, minValue), cancellationToken);
         }
 
         private static ValueTask<IList<TSource>> MaxByCore<TSource, TKey>(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, IComparer<TKey> comparer, CancellationToken cancellationToken)
         {
-            if (comparer == null)
-            {
-                comparer = Comparer<TKey>.Default;
-            }
+            comparer ??= Comparer<TKey>.Default;
 
             return ExtremaBy(source, keySelector, (key, minValue) => comparer.Compare(key, minValue), cancellationToken);
         }
@@ -97,10 +91,7 @@ namespace System.Linq
 #if !NO_DEEP_CANCELLATION
         private static ValueTask<IList<TSource>> MaxByCore<TSource, TKey>(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<TKey>> keySelector, IComparer<TKey> comparer, CancellationToken cancellationToken)
         {
-            if (comparer == null)
-            {
-                comparer = Comparer<TKey>.Default;
-            }
+            comparer ??= Comparer<TKey>.Default;
 
             return ExtremaBy(source, keySelector, (key, minValue) => comparer.Compare(key, minValue), cancellationToken);
         }

--- a/Ix.NET/Source/System.Interactive.Async/System/Linq/Operators/Min.cs
+++ b/Ix.NET/Source/System.Interactive.Async/System/Linq/Operators/Min.cs
@@ -19,10 +19,7 @@ namespace System.Linq
 
             static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, IComparer<TSource> comparer, CancellationToken cancellationToken)
             {
-                if (comparer == null)
-                {
-                    comparer = Comparer<TSource>.Default;
-                }
+                comparer ??= Comparer<TSource>.Default;
 
                 await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {

--- a/Ix.NET/Source/System.Interactive.Async/System/Linq/Operators/Min.cs
+++ b/Ix.NET/Source/System.Interactive.Async/System/Linq/Operators/Min.cs
@@ -17,14 +17,14 @@ namespace System.Linq
 
             return Core(source, comparer, cancellationToken);
 
-            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, IComparer<TSource> _comparer, CancellationToken _cancellationToken)
+            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, IComparer<TSource> comparer, CancellationToken cancellationToken)
             {
-                if (_comparer == null)
+                if (comparer == null)
                 {
-                    _comparer = Comparer<TSource>.Default;
+                    comparer = Comparer<TSource>.Default;
                 }
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                         throw Error.NoElements();
@@ -35,7 +35,7 @@ namespace System.Linq
                     {
                         var cur = e.Current;
 
-                        if (_comparer.Compare(cur, min) < 0)
+                        if (comparer.Compare(cur, min) < 0)
                         {
                             min = cur;
                         }

--- a/Ix.NET/Source/System.Interactive.Async/System/Linq/Operators/MinBy.cs
+++ b/Ix.NET/Source/System.Interactive.Async/System/Linq/Operators/MinBy.cs
@@ -76,20 +76,14 @@ namespace System.Linq
 
         private static ValueTask<IList<TSource>> MinByCore<TSource, TKey>(IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey> comparer, CancellationToken cancellationToken)
         {
-            if (comparer == null)
-            {
-                comparer = Comparer<TKey>.Default;
-            }
+            comparer ??= Comparer<TKey>.Default;
 
             return ExtremaBy(source, keySelector, (key, minValue) => -comparer.Compare(key, minValue), cancellationToken);
         }
 
         private static ValueTask<IList<TSource>> MinByCore<TSource, TKey>(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, IComparer<TKey> comparer, CancellationToken cancellationToken)
         {
-            if (comparer == null)
-            {
-                comparer = Comparer<TKey>.Default;
-            }
+            comparer ??= Comparer<TKey>.Default;
 
             return ExtremaBy(source, keySelector, (key, minValue) => -comparer.Compare(key, minValue), cancellationToken);
         }
@@ -97,10 +91,7 @@ namespace System.Linq
 #if !NO_DEEP_CANCELLATION
         private static ValueTask<IList<TSource>> MinByCore<TSource, TKey>(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<TKey>> keySelector, IComparer<TKey> comparer, CancellationToken cancellationToken)
         {
-            if (comparer == null)
-            {
-                comparer = Comparer<TKey>.Default;
-            }
+            comparer ??= Comparer<TKey>.Default;
 
             return ExtremaBy(source, keySelector, (key, minValue) => -comparer.Compare(key, minValue), cancellationToken);
         }

--- a/Ix.NET/Source/System.Linq.Async/System.Linq.Async.csproj
+++ b/Ix.NET/Source/System.Linq.Async/System.Linq.Async.csproj
@@ -87,4 +87,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
+
 </Project>

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/Aggregate.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/Aggregate.cs
@@ -19,9 +19,9 @@ namespace System.Linq
 
             return Core(source, accumulator, cancellationToken);
 
-            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, Func<TSource, TSource, TSource> _accumulator, CancellationToken _cancellationToken)
+            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, Func<TSource, TSource, TSource> accumulator, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
@@ -32,7 +32,7 @@ namespace System.Linq
 
                     while (await e.MoveNextAsync())
                     {
-                        acc = _accumulator(acc, e.Current);
+                        acc = accumulator(acc, e.Current);
                     }
 
                     return acc;
@@ -49,9 +49,9 @@ namespace System.Linq
 
             return Core(source, accumulator, cancellationToken);
 
-            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, Func<TSource, TSource, ValueTask<TSource>> _accumulator, CancellationToken _cancellationToken)
+            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, Func<TSource, TSource, ValueTask<TSource>> accumulator, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
@@ -62,7 +62,7 @@ namespace System.Linq
 
                     while (await e.MoveNextAsync())
                     {
-                        acc = await _accumulator(acc, e.Current).ConfigureAwait(false);
+                        acc = await accumulator(acc, e.Current).ConfigureAwait(false);
                     }
 
                     return acc;
@@ -80,9 +80,9 @@ namespace System.Linq
 
             return Core(source, accumulator, cancellationToken);
 
-            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, Func<TSource, TSource, CancellationToken, ValueTask<TSource>> _accumulator, CancellationToken _cancellationToken)
+            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, Func<TSource, TSource, CancellationToken, ValueTask<TSource>> accumulator, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
@@ -93,7 +93,7 @@ namespace System.Linq
 
                     while (await e.MoveNextAsync())
                     {
-                        acc = await _accumulator(acc, e.Current, _cancellationToken).ConfigureAwait(false);
+                        acc = await accumulator(acc, e.Current, cancellationToken).ConfigureAwait(false);
                     }
 
                     return acc;
@@ -111,13 +111,13 @@ namespace System.Linq
 
             return Core(source, seed, accumulator, cancellationToken);
 
-            static async ValueTask<TAccumulate> Core(IAsyncEnumerable<TSource> _source, TAccumulate _seed, Func<TAccumulate, TSource, TAccumulate> _accumulator, CancellationToken _cancellationToken)
+            static async ValueTask<TAccumulate> Core(IAsyncEnumerable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, TAccumulate> accumulator, CancellationToken cancellationToken)
             {
-                var acc = _seed;
+                var acc = seed;
 
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    acc = _accumulator(acc, item);
+                    acc = accumulator(acc, item);
                 }
 
                 return acc;
@@ -133,13 +133,13 @@ namespace System.Linq
 
             return Core(source, seed, accumulator, cancellationToken);
 
-            static async ValueTask<TAccumulate> Core(IAsyncEnumerable<TSource> _source, TAccumulate _seed, Func<TAccumulate, TSource, ValueTask<TAccumulate>> _accumulator, CancellationToken _cancellationToken)
+            static async ValueTask<TAccumulate> Core(IAsyncEnumerable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, ValueTask<TAccumulate>> accumulator, CancellationToken cancellationToken)
             {
-                var acc = _seed;
+                var acc = seed;
 
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    acc = await _accumulator(acc, item).ConfigureAwait(false);
+                    acc = await accumulator(acc, item).ConfigureAwait(false);
                 }
 
                 return acc;
@@ -156,13 +156,13 @@ namespace System.Linq
 
             return Core(source, seed, accumulator, cancellationToken);
 
-            static async ValueTask<TAccumulate> Core(IAsyncEnumerable<TSource> _source, TAccumulate _seed, Func<TAccumulate, TSource, CancellationToken, ValueTask<TAccumulate>> _accumulator, CancellationToken _cancellationToken)
+            static async ValueTask<TAccumulate> Core(IAsyncEnumerable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, CancellationToken, ValueTask<TAccumulate>> accumulator, CancellationToken cancellationToken)
             {
-                var acc = _seed;
+                var acc = seed;
 
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    acc = await _accumulator(acc, item, _cancellationToken).ConfigureAwait(false);
+                    acc = await accumulator(acc, item, cancellationToken).ConfigureAwait(false);
                 }
 
                 return acc;
@@ -181,16 +181,16 @@ namespace System.Linq
 
             return Core(source, seed, accumulator, resultSelector, cancellationToken);
 
-            static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> _source, TAccumulate _seed, Func<TAccumulate, TSource, TAccumulate> _accumulator, Func<TAccumulate, TResult> _resultSelector, CancellationToken _cancellationToken)
+            static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, TAccumulate> accumulator, Func<TAccumulate, TResult> resultSelector, CancellationToken cancellationToken)
             {
-                var acc = _seed;
+                var acc = seed;
 
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    acc = _accumulator(acc, item);
+                    acc = accumulator(acc, item);
                 }
 
-                return _resultSelector(acc);
+                return resultSelector(acc);
             }
         }
 
@@ -205,16 +205,16 @@ namespace System.Linq
 
             return Core(source, seed, accumulator, resultSelector, cancellationToken);
 
-            static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> _source, TAccumulate _seed, Func<TAccumulate, TSource, ValueTask<TAccumulate>> _accumulator, Func<TAccumulate, ValueTask<TResult>> _resultSelector, CancellationToken _cancellationToken)
+            static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, ValueTask<TAccumulate>> accumulator, Func<TAccumulate, ValueTask<TResult>> resultSelector, CancellationToken cancellationToken)
             {
-                var acc = _seed;
+                var acc = seed;
 
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    acc = await _accumulator(acc, item).ConfigureAwait(false);
+                    acc = await accumulator(acc, item).ConfigureAwait(false);
                 }
 
-                return await _resultSelector(acc).ConfigureAwait(false);
+                return await resultSelector(acc).ConfigureAwait(false);
             }
         }
 
@@ -230,16 +230,16 @@ namespace System.Linq
 
             return Core(source, seed, accumulator, resultSelector, cancellationToken);
 
-            static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> _source, TAccumulate _seed, Func<TAccumulate, TSource, CancellationToken, ValueTask<TAccumulate>> _accumulator, Func<TAccumulate, CancellationToken, ValueTask<TResult>> _resultSelector, CancellationToken _cancellationToken)
+            static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, CancellationToken, ValueTask<TAccumulate>> accumulator, Func<TAccumulate, CancellationToken, ValueTask<TResult>> resultSelector, CancellationToken cancellationToken)
             {
-                var acc = _seed;
+                var acc = seed;
 
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    acc = await _accumulator(acc, item, _cancellationToken).ConfigureAwait(false);
+                    acc = await accumulator(acc, item, cancellationToken).ConfigureAwait(false);
                 }
 
-                return await _resultSelector(acc, _cancellationToken).ConfigureAwait(false);
+                return await resultSelector(acc, cancellationToken).ConfigureAwait(false);
             }
         }
 #endif

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/All.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/All.cs
@@ -19,11 +19,11 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            static async ValueTask<bool> Core(IAsyncEnumerable<TSource> _source, Func<TSource, bool> _predicate, CancellationToken _cancellationToken)
+            static async ValueTask<bool> Core(IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate, CancellationToken cancellationToken)
             {
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    if (!_predicate(item))
+                    if (!predicate(item))
                     {
                         return false;
                     }
@@ -42,11 +42,11 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            static async ValueTask<bool> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<bool>> _predicate, CancellationToken _cancellationToken)
+            static async ValueTask<bool> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<bool>> predicate, CancellationToken cancellationToken)
             {
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    if (!await _predicate(item).ConfigureAwait(false))
+                    if (!await predicate(item).ConfigureAwait(false))
                     {
                         return false;
                     }
@@ -66,11 +66,11 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            static async ValueTask<bool> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<bool>> _predicate, CancellationToken _cancellationToken)
+            static async ValueTask<bool> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<bool>> predicate, CancellationToken cancellationToken)
             {
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    if (!await _predicate(item, _cancellationToken).ConfigureAwait(false))
+                    if (!await predicate(item, cancellationToken).ConfigureAwait(false))
                     {
                         return false;
                     }

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/Any.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/Any.cs
@@ -17,9 +17,9 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<bool> Core(IAsyncEnumerable<TSource> _source, CancellationToken _cancellationToken)
+            static async ValueTask<bool> Core(IAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     return await e.MoveNextAsync();
                 }
@@ -35,11 +35,11 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            static async ValueTask<bool> Core(IAsyncEnumerable<TSource> _source, Func<TSource, bool> _predicate, CancellationToken _cancellationToken)
+            static async ValueTask<bool> Core(IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate, CancellationToken cancellationToken)
             {
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    if (_predicate(item))
+                    if (predicate(item))
                     {
                         return true;
                     }
@@ -58,11 +58,11 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            static async ValueTask<bool> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<bool>> _predicate, CancellationToken _cancellationToken)
+            static async ValueTask<bool> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<bool>> predicate, CancellationToken cancellationToken)
             {
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    if (await _predicate(item).ConfigureAwait(false))
+                    if (await predicate(item).ConfigureAwait(false))
                     {
                         return true;
                     }
@@ -82,11 +82,11 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            static async ValueTask<bool> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<bool>> _predicate, CancellationToken _cancellationToken)
+            static async ValueTask<bool> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<bool>> predicate, CancellationToken cancellationToken)
             {
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    if (await _predicate(item, _cancellationToken).ConfigureAwait(false))
+                    if (await predicate(item, cancellationToken).ConfigureAwait(false))
                     {
                         return true;
                     }

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/Average.Generated.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/Average.Generated.cs
@@ -17,9 +17,9 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<double> Core(IAsyncEnumerable<int> _source, CancellationToken _cancellationToken)
+            static async ValueTask<double> Core(IAsyncEnumerable<int> source, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
@@ -51,22 +51,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double> Core(IAsyncEnumerable<TSource> _source, Func<TSource, int> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double> Core(IAsyncEnumerable<TSource> source, Func<TSource, int> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    long sum = _selector(e.Current);
+                    long sum = selector(e.Current);
                     long count = 1;
                     checked
                     {
                         while (await e.MoveNextAsync())
                         {
-                            sum += _selector(e.Current);
+                            sum += selector(e.Current);
                             ++count;
                         }
                     }
@@ -85,22 +85,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<int>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<int>> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    long sum = await _selector(e.Current).ConfigureAwait(false);
+                    long sum = await selector(e.Current).ConfigureAwait(false);
                     long count = 1;
                     checked
                     {
                         while (await e.MoveNextAsync())
                         {
-                            sum += await _selector(e.Current).ConfigureAwait(false);
+                            sum += await selector(e.Current).ConfigureAwait(false);
                             ++count;
                         }
                     }
@@ -120,22 +120,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<int>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<int>> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    long sum = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                    long sum = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                     long count = 1;
                     checked
                     {
                         while (await e.MoveNextAsync())
                         {
-                            sum += await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                            sum += await selector(e.Current, cancellationToken).ConfigureAwait(false);
                             ++count;
                         }
                     }
@@ -153,9 +153,9 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<double> Core(IAsyncEnumerable<long> _source, CancellationToken _cancellationToken)
+            static async ValueTask<double> Core(IAsyncEnumerable<long> source, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
@@ -187,22 +187,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double> Core(IAsyncEnumerable<TSource> _source, Func<TSource, long> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double> Core(IAsyncEnumerable<TSource> source, Func<TSource, long> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    long sum = _selector(e.Current);
+                    long sum = selector(e.Current);
                     long count = 1;
                     checked
                     {
                         while (await e.MoveNextAsync())
                         {
-                            sum += _selector(e.Current);
+                            sum += selector(e.Current);
                             ++count;
                         }
                     }
@@ -221,22 +221,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<long>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<long>> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    long sum = await _selector(e.Current).ConfigureAwait(false);
+                    long sum = await selector(e.Current).ConfigureAwait(false);
                     long count = 1;
                     checked
                     {
                         while (await e.MoveNextAsync())
                         {
-                            sum += await _selector(e.Current).ConfigureAwait(false);
+                            sum += await selector(e.Current).ConfigureAwait(false);
                             ++count;
                         }
                     }
@@ -256,22 +256,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<long>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<long>> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    long sum = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                    long sum = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                     long count = 1;
                     checked
                     {
                         while (await e.MoveNextAsync())
                         {
-                            sum += await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                            sum += await selector(e.Current, cancellationToken).ConfigureAwait(false);
                             ++count;
                         }
                     }
@@ -289,9 +289,9 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<float> Core(IAsyncEnumerable<float> _source, CancellationToken _cancellationToken)
+            static async ValueTask<float> Core(IAsyncEnumerable<float> source, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
@@ -323,22 +323,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<float> Core(IAsyncEnumerable<TSource> _source, Func<TSource, float> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<float> Core(IAsyncEnumerable<TSource> source, Func<TSource, float> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    double sum = _selector(e.Current);
+                    double sum = selector(e.Current);
                     long count = 1;
                     checked
                     {
                         while (await e.MoveNextAsync())
                         {
-                            sum += _selector(e.Current);
+                            sum += selector(e.Current);
                             ++count;
                         }
                     }
@@ -357,22 +357,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<float> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<float>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<float> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<float>> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    double sum = await _selector(e.Current).ConfigureAwait(false);
+                    double sum = await selector(e.Current).ConfigureAwait(false);
                     long count = 1;
                     checked
                     {
                         while (await e.MoveNextAsync())
                         {
-                            sum += await _selector(e.Current).ConfigureAwait(false);
+                            sum += await selector(e.Current).ConfigureAwait(false);
                             ++count;
                         }
                     }
@@ -392,22 +392,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<float> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<float>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<float> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<float>> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    double sum = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                    double sum = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                     long count = 1;
                     checked
                     {
                         while (await e.MoveNextAsync())
                         {
-                            sum += await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                            sum += await selector(e.Current, cancellationToken).ConfigureAwait(false);
                             ++count;
                         }
                     }
@@ -425,9 +425,9 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<double> Core(IAsyncEnumerable<double> _source, CancellationToken _cancellationToken)
+            static async ValueTask<double> Core(IAsyncEnumerable<double> source, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
@@ -459,22 +459,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double> Core(IAsyncEnumerable<TSource> _source, Func<TSource, double> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double> Core(IAsyncEnumerable<TSource> source, Func<TSource, double> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    double sum = _selector(e.Current);
+                    double sum = selector(e.Current);
                     long count = 1;
                     checked
                     {
                         while (await e.MoveNextAsync())
                         {
-                            sum += _selector(e.Current);
+                            sum += selector(e.Current);
                             ++count;
                         }
                     }
@@ -493,22 +493,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<double>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<double>> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    double sum = await _selector(e.Current).ConfigureAwait(false);
+                    double sum = await selector(e.Current).ConfigureAwait(false);
                     long count = 1;
                     checked
                     {
                         while (await e.MoveNextAsync())
                         {
-                            sum += await _selector(e.Current).ConfigureAwait(false);
+                            sum += await selector(e.Current).ConfigureAwait(false);
                             ++count;
                         }
                     }
@@ -528,22 +528,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<double>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<double>> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    double sum = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                    double sum = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                     long count = 1;
                     checked
                     {
                         while (await e.MoveNextAsync())
                         {
-                            sum += await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                            sum += await selector(e.Current, cancellationToken).ConfigureAwait(false);
                             ++count;
                         }
                     }
@@ -561,9 +561,9 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<decimal> Core(IAsyncEnumerable<decimal> _source, CancellationToken _cancellationToken)
+            static async ValueTask<decimal> Core(IAsyncEnumerable<decimal> source, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
@@ -595,22 +595,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<decimal> Core(IAsyncEnumerable<TSource> _source, Func<TSource, decimal> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<decimal> Core(IAsyncEnumerable<TSource> source, Func<TSource, decimal> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    decimal sum = _selector(e.Current);
+                    decimal sum = selector(e.Current);
                     long count = 1;
                     checked
                     {
                         while (await e.MoveNextAsync())
                         {
-                            sum += _selector(e.Current);
+                            sum += selector(e.Current);
                             ++count;
                         }
                     }
@@ -629,22 +629,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<decimal> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<decimal>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<decimal> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<decimal>> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    decimal sum = await _selector(e.Current).ConfigureAwait(false);
+                    decimal sum = await selector(e.Current).ConfigureAwait(false);
                     long count = 1;
                     checked
                     {
                         while (await e.MoveNextAsync())
                         {
-                            sum += await _selector(e.Current).ConfigureAwait(false);
+                            sum += await selector(e.Current).ConfigureAwait(false);
                             ++count;
                         }
                     }
@@ -664,22 +664,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<decimal> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<decimal>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<decimal> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<decimal>> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    decimal sum = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                    decimal sum = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                     long count = 1;
                     checked
                     {
                         while (await e.MoveNextAsync())
                         {
-                            sum += await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                            sum += await selector(e.Current, cancellationToken).ConfigureAwait(false);
                             ++count;
                         }
                     }
@@ -697,9 +697,9 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<double?> Core(IAsyncEnumerable<int?> _source, CancellationToken _cancellationToken)
+            static async ValueTask<double?> Core(IAsyncEnumerable<int?> source, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
@@ -739,13 +739,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, int?> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> source, Func<TSource, int?> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
-                        var v = _selector(e.Current);
+                        var v = selector(e.Current);
                         if (v.HasValue)
                         {
                             long sum = v.GetValueOrDefault();
@@ -754,7 +754,7 @@ namespace System.Linq
                             {
                                 while (await e.MoveNextAsync())
                                 {
-                                    v = _selector(e.Current);
+                                    v = selector(e.Current);
                                     if (v.HasValue)
                                     {
                                         sum += v.GetValueOrDefault();
@@ -781,13 +781,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<int?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<int?>> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
-                        var v = await _selector(e.Current).ConfigureAwait(false);
+                        var v = await selector(e.Current).ConfigureAwait(false);
                         if (v.HasValue)
                         {
                             long sum = v.GetValueOrDefault();
@@ -796,7 +796,7 @@ namespace System.Linq
                             {
                                 while (await e.MoveNextAsync())
                                 {
-                                    v = await _selector(e.Current).ConfigureAwait(false);
+                                    v = await selector(e.Current).ConfigureAwait(false);
                                     if (v.HasValue)
                                     {
                                         sum += v.GetValueOrDefault();
@@ -824,13 +824,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<int?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<int?>> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
-                        var v = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        var v = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                         if (v.HasValue)
                         {
                             long sum = v.GetValueOrDefault();
@@ -839,7 +839,7 @@ namespace System.Linq
                             {
                                 while (await e.MoveNextAsync())
                                 {
-                                    v = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                                    v = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                                     if (v.HasValue)
                                     {
                                         sum += v.GetValueOrDefault();
@@ -865,9 +865,9 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<double?> Core(IAsyncEnumerable<long?> _source, CancellationToken _cancellationToken)
+            static async ValueTask<double?> Core(IAsyncEnumerable<long?> source, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
@@ -907,13 +907,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, long?> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> source, Func<TSource, long?> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
-                        var v = _selector(e.Current);
+                        var v = selector(e.Current);
                         if (v.HasValue)
                         {
                             long sum = v.GetValueOrDefault();
@@ -922,7 +922,7 @@ namespace System.Linq
                             {
                                 while (await e.MoveNextAsync())
                                 {
-                                    v = _selector(e.Current);
+                                    v = selector(e.Current);
                                     if (v.HasValue)
                                     {
                                         sum += v.GetValueOrDefault();
@@ -949,13 +949,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<long?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<long?>> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
-                        var v = await _selector(e.Current).ConfigureAwait(false);
+                        var v = await selector(e.Current).ConfigureAwait(false);
                         if (v.HasValue)
                         {
                             long sum = v.GetValueOrDefault();
@@ -964,7 +964,7 @@ namespace System.Linq
                             {
                                 while (await e.MoveNextAsync())
                                 {
-                                    v = await _selector(e.Current).ConfigureAwait(false);
+                                    v = await selector(e.Current).ConfigureAwait(false);
                                     if (v.HasValue)
                                     {
                                         sum += v.GetValueOrDefault();
@@ -992,13 +992,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<long?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<long?>> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
-                        var v = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        var v = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                         if (v.HasValue)
                         {
                             long sum = v.GetValueOrDefault();
@@ -1007,7 +1007,7 @@ namespace System.Linq
                             {
                                 while (await e.MoveNextAsync())
                                 {
-                                    v = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                                    v = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                                     if (v.HasValue)
                                     {
                                         sum += v.GetValueOrDefault();
@@ -1033,9 +1033,9 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<float?> Core(IAsyncEnumerable<float?> _source, CancellationToken _cancellationToken)
+            static async ValueTask<float?> Core(IAsyncEnumerable<float?> source, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
@@ -1075,13 +1075,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<float?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, float?> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<float?> Core(IAsyncEnumerable<TSource> source, Func<TSource, float?> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
-                        var v = _selector(e.Current);
+                        var v = selector(e.Current);
                         if (v.HasValue)
                         {
                             double sum = v.GetValueOrDefault();
@@ -1090,7 +1090,7 @@ namespace System.Linq
                             {
                                 while (await e.MoveNextAsync())
                                 {
-                                    v = _selector(e.Current);
+                                    v = selector(e.Current);
                                     if (v.HasValue)
                                     {
                                         sum += v.GetValueOrDefault();
@@ -1117,13 +1117,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<float?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<float?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<float?> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<float?>> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
-                        var v = await _selector(e.Current).ConfigureAwait(false);
+                        var v = await selector(e.Current).ConfigureAwait(false);
                         if (v.HasValue)
                         {
                             double sum = v.GetValueOrDefault();
@@ -1132,7 +1132,7 @@ namespace System.Linq
                             {
                                 while (await e.MoveNextAsync())
                                 {
-                                    v = await _selector(e.Current).ConfigureAwait(false);
+                                    v = await selector(e.Current).ConfigureAwait(false);
                                     if (v.HasValue)
                                     {
                                         sum += v.GetValueOrDefault();
@@ -1160,13 +1160,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<float?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<float?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<float?> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<float?>> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
-                        var v = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        var v = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                         if (v.HasValue)
                         {
                             double sum = v.GetValueOrDefault();
@@ -1175,7 +1175,7 @@ namespace System.Linq
                             {
                                 while (await e.MoveNextAsync())
                                 {
-                                    v = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                                    v = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                                     if (v.HasValue)
                                     {
                                         sum += v.GetValueOrDefault();
@@ -1201,9 +1201,9 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<double?> Core(IAsyncEnumerable<double?> _source, CancellationToken _cancellationToken)
+            static async ValueTask<double?> Core(IAsyncEnumerable<double?> source, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
@@ -1243,13 +1243,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, double?> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> source, Func<TSource, double?> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
-                        var v = _selector(e.Current);
+                        var v = selector(e.Current);
                         if (v.HasValue)
                         {
                             double sum = v.GetValueOrDefault();
@@ -1258,7 +1258,7 @@ namespace System.Linq
                             {
                                 while (await e.MoveNextAsync())
                                 {
-                                    v = _selector(e.Current);
+                                    v = selector(e.Current);
                                     if (v.HasValue)
                                     {
                                         sum += v.GetValueOrDefault();
@@ -1285,13 +1285,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<double?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<double?>> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
-                        var v = await _selector(e.Current).ConfigureAwait(false);
+                        var v = await selector(e.Current).ConfigureAwait(false);
                         if (v.HasValue)
                         {
                             double sum = v.GetValueOrDefault();
@@ -1300,7 +1300,7 @@ namespace System.Linq
                             {
                                 while (await e.MoveNextAsync())
                                 {
-                                    v = await _selector(e.Current).ConfigureAwait(false);
+                                    v = await selector(e.Current).ConfigureAwait(false);
                                     if (v.HasValue)
                                     {
                                         sum += v.GetValueOrDefault();
@@ -1328,13 +1328,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<double?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<double?>> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
-                        var v = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        var v = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                         if (v.HasValue)
                         {
                             double sum = v.GetValueOrDefault();
@@ -1343,7 +1343,7 @@ namespace System.Linq
                             {
                                 while (await e.MoveNextAsync())
                                 {
-                                    v = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                                    v = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                                     if (v.HasValue)
                                     {
                                         sum += v.GetValueOrDefault();
@@ -1369,9 +1369,9 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<decimal?> Core(IAsyncEnumerable<decimal?> _source, CancellationToken _cancellationToken)
+            static async ValueTask<decimal?> Core(IAsyncEnumerable<decimal?> source, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
@@ -1411,13 +1411,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<decimal?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, decimal?> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<decimal?> Core(IAsyncEnumerable<TSource> source, Func<TSource, decimal?> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
-                        var v = _selector(e.Current);
+                        var v = selector(e.Current);
                         if (v.HasValue)
                         {
                             decimal sum = v.GetValueOrDefault();
@@ -1426,7 +1426,7 @@ namespace System.Linq
                             {
                                 while (await e.MoveNextAsync())
                                 {
-                                    v = _selector(e.Current);
+                                    v = selector(e.Current);
                                     if (v.HasValue)
                                     {
                                         sum += v.GetValueOrDefault();
@@ -1453,13 +1453,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<decimal?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<decimal?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<decimal?> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<decimal?>> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
-                        var v = await _selector(e.Current).ConfigureAwait(false);
+                        var v = await selector(e.Current).ConfigureAwait(false);
                         if (v.HasValue)
                         {
                             decimal sum = v.GetValueOrDefault();
@@ -1468,7 +1468,7 @@ namespace System.Linq
                             {
                                 while (await e.MoveNextAsync())
                                 {
-                                    v = await _selector(e.Current).ConfigureAwait(false);
+                                    v = await selector(e.Current).ConfigureAwait(false);
                                     if (v.HasValue)
                                     {
                                         sum += v.GetValueOrDefault();
@@ -1496,13 +1496,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<decimal?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<decimal?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<decimal?> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<decimal?>> selector, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
-                        var v = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        var v = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                         if (v.HasValue)
                         {
                             decimal sum = v.GetValueOrDefault();
@@ -1511,7 +1511,7 @@ namespace System.Linq
                             {
                                 while (await e.MoveNextAsync())
                                 {
-                                    v = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                                    v = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                                     if (v.HasValue)
                                     {
                                         sum += v.GetValueOrDefault();

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/Average.Generated.tt
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/Average.Generated.tt
@@ -52,13 +52,13 @@ foreach (var o in os)
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<<#=o.res#>> Core(IAsyncEnumerable<<#=o.type#>> _source, CancellationToken _cancellationToken)
+            static async ValueTask<<#=o.res#>> Core(IAsyncEnumerable<<#=o.type#>> source, CancellationToken cancellationToken)
             {
 <#
 if (isNullable)
 {
 #>
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
@@ -91,7 +91,7 @@ if (isNullable)
 else
 {
 #>
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
@@ -126,17 +126,17 @@ else
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<<#=o.res#>> Core(IAsyncEnumerable<TSource> _source, Func<TSource, <#=o.type#>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<<#=o.res#>> Core(IAsyncEnumerable<TSource> source, Func<TSource, <#=o.type#>> selector, CancellationToken cancellationToken)
             {
 <#
 if (isNullable)
 {
 #>
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
-                        var v = _selector(e.Current);
+                        var v = selector(e.Current);
                         if (v.HasValue)
                         {
                             <#=o.sum#> sum = v.GetValueOrDefault();
@@ -145,7 +145,7 @@ if (isNullable)
                             {
                                 while (await e.MoveNextAsync())
                                 {
-                                    v = _selector(e.Current);
+                                    v = selector(e.Current);
                                     if (v.HasValue)
                                     {
                                         sum += v.GetValueOrDefault();
@@ -165,20 +165,20 @@ if (isNullable)
 else
 {
 #>
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    <#=o.sum#> sum = _selector(e.Current);
+                    <#=o.sum#> sum = selector(e.Current);
                     long count = 1;
                     checked
                     {
                         while (await e.MoveNextAsync())
                         {
-                            sum += _selector(e.Current);
+                            sum += selector(e.Current);
                             ++count;
                         }
                     }
@@ -191,8 +191,7 @@ else
             }
         }
 
-        internal static ValueTask<<#=o.res#>> AverageAsyncCore<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<<#=o.type#>>> selector, CancellationToken cancellationToken = default)
-
+        internal static ValueTask<<#=o.res#>> AverageAwaitAsyncCore<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<<#=o.type#>>> selector, CancellationToken cancellationToken = default)
         {
             if (source == null)
                 throw Error.ArgumentNull(nameof(source));
@@ -201,17 +200,17 @@ else
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<<#=o.res#>> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<<#=o.type#>>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<<#=o.res#>> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<<#=o.type#>>> selector, CancellationToken cancellationToken)
             {
 <#
 if (isNullable)
 {
 #>
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
-                        var v = await _selector(e.Current).ConfigureAwait(false);
+                        var v = await selector(e.Current).ConfigureAwait(false);
                         if (v.HasValue)
                         {
                             <#=o.sum#> sum = v.GetValueOrDefault();
@@ -220,7 +219,7 @@ if (isNullable)
                             {
                                 while (await e.MoveNextAsync())
                                 {
-                                    v = await _selector(e.Current).ConfigureAwait(false);
+                                    v = await selector(e.Current).ConfigureAwait(false);
                                     if (v.HasValue)
                                     {
                                         sum += v.GetValueOrDefault();
@@ -240,20 +239,20 @@ if (isNullable)
 else
 {
 #>
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    <#=o.sum#> sum = await _selector(e.Current).ConfigureAwait(false);
+                    <#=o.sum#> sum = await selector(e.Current).ConfigureAwait(false);
                     long count = 1;
                     checked
                     {
                         while (await e.MoveNextAsync())
                         {
-                            sum += await _selector(e.Current).ConfigureAwait(false);
+                            sum += await selector(e.Current).ConfigureAwait(false);
                             ++count;
                         }
                     }
@@ -267,8 +266,7 @@ else
         }
 
 #if !NO_DEEP_CANCELLATION
-        internal static ValueTask<<#=o.res#>> AverageWithCancellationAsyncCore<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<<#=o.type#>>> selector, CancellationToken cancellationToken = default)
-
+        internal static ValueTask<<#=o.res#>> AverageAwaitWithCancellationAsyncCore<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<<#=o.type#>>> selector, CancellationToken cancellationToken = default)
         {
             if (source == null)
                 throw Error.ArgumentNull(nameof(source));
@@ -277,17 +275,17 @@ else
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<<#=o.res#>> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<<#=o.type#>>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<<#=o.res#>> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<<#=o.type#>>> selector, CancellationToken cancellationToken)
             {
 <#
 if (isNullable)
 {
 #>
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
-                        var v = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        var v = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                         if (v.HasValue)
                         {
                             <#=o.sum#> sum = v.GetValueOrDefault();
@@ -296,7 +294,7 @@ if (isNullable)
                             {
                                 while (await e.MoveNextAsync())
                                 {
-                                    v = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                                    v = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                                     if (v.HasValue)
                                     {
                                         sum += v.GetValueOrDefault();
@@ -316,20 +314,20 @@ if (isNullable)
 else
 {
 #>
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    <#=o.sum#> sum = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                    <#=o.sum#> sum = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                     long count = 1;
                     checked
                     {
                         while (await e.MoveNextAsync())
                         {
-                            sum += await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                            sum += await selector(e.Current, cancellationToken).ConfigureAwait(false);
                             ++count;
                         }
                     }

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/Contains.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/Contains.cs
@@ -26,11 +26,11 @@ namespace System.Linq
             {
                 return Core(source, value, cancellationToken);
 
-                static async ValueTask<bool> Core(IAsyncEnumerable<TSource> _source, TSource _value, CancellationToken _cancellationToken)
+                static async ValueTask<bool> Core(IAsyncEnumerable<TSource> source, TSource value, CancellationToken cancellationToken)
                 {
-                    await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                    await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                     {
-                        if (EqualityComparer<TSource>.Default.Equals(item, _value))
+                        if (EqualityComparer<TSource>.Default.Equals(item, value))
                         {
                             return true;
                         }
@@ -43,11 +43,11 @@ namespace System.Linq
             {
                 return Core(source, value, comparer, cancellationToken);
 
-                static async ValueTask<bool> Core(IAsyncEnumerable<TSource> _source, TSource _value, IEqualityComparer<TSource> _comparer, CancellationToken _cancellationToken)
+                static async ValueTask<bool> Core(IAsyncEnumerable<TSource> source, TSource value, IEqualityComparer<TSource> comparer, CancellationToken cancellationToken)
                 {
-                    await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                    await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                     {
-                        if (_comparer.Equals(item, _value))
+                        if (comparer.Equals(item, value))
                         {
                             return true;
                         }

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/Count.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/Count.cs
@@ -28,11 +28,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<int> Core(IAsyncEnumerable<TSource> _source, CancellationToken _cancellationToken)
+            static async ValueTask<int> Core(IAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
             {
                 var count = 0;
 
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
                     checked
                     {
@@ -53,13 +53,13 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            static async ValueTask<int> Core(IAsyncEnumerable<TSource> _source, Func<TSource, bool> _predicate, CancellationToken _cancellationToken)
+            static async ValueTask<int> Core(IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate, CancellationToken cancellationToken)
             {
                 var count = 0;
 
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    if (_predicate(item))
+                    if (predicate(item))
                     {
                         checked
                         {
@@ -81,13 +81,13 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            static async ValueTask<int> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<bool>> _predicate, CancellationToken _cancellationToken)
+            static async ValueTask<int> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<bool>> predicate, CancellationToken cancellationToken)
             {
                 var count = 0;
 
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    if (await _predicate(item).ConfigureAwait(false))
+                    if (await predicate(item).ConfigureAwait(false))
                     {
                         checked
                         {
@@ -110,13 +110,13 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            static async ValueTask<int> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<bool>> _predicate, CancellationToken _cancellationToken)
+            static async ValueTask<int> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<bool>> predicate, CancellationToken cancellationToken)
             {
                 var count = 0;
 
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    if (await _predicate(item, _cancellationToken).ConfigureAwait(false))
+                    if (await predicate(item, cancellationToken).ConfigureAwait(false))
                     {
                         checked
                         {

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/ElementAt.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/ElementAt.cs
@@ -17,11 +17,11 @@ namespace System.Linq
 
             return Core(source, index, cancellationToken);
 
-            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, int _index, CancellationToken _cancellationToken)
+            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, int index, CancellationToken cancellationToken)
             {
-                if (_source is IAsyncPartition<TSource> p)
+                if (source is IAsyncPartition<TSource> p)
                 {
-                    var first = await p.TryGetElementAtAsync(_index, _cancellationToken).ConfigureAwait(false);
+                    var first = await p.TryGetElementAtAsync(index, cancellationToken).ConfigureAwait(false);
 
                     if (first.HasValue)
                     {
@@ -30,21 +30,21 @@ namespace System.Linq
                 }
                 else
                 {
-                    if (_source is IList<TSource> list)
+                    if (source is IList<TSource> list)
                     {
-                        return list[_index];
+                        return list[index];
                     }
 
-                    if (_index >= 0)
+                    if (index >= 0)
                     {
-                        await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                        await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                         {
-                            if (_index == 0)
+                            if (index == 0)
                             {
                                 return item;
                             }
 
-                            _index--;
+                            index--;
                         }
                     }
                 }

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/ElementAtOrDefault.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/ElementAtOrDefault.cs
@@ -17,11 +17,11 @@ namespace System.Linq
 
             return Core(source, index, cancellationToken);
 
-            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, int _index, CancellationToken _cancellationToken)
+            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, int index, CancellationToken cancellationToken)
             {
-                if (_source is IAsyncPartition<TSource> p)
+                if (source is IAsyncPartition<TSource> p)
                 {
-                    var first = await p.TryGetElementAtAsync(_index, _cancellationToken).ConfigureAwait(false);
+                    var first = await p.TryGetElementAtAsync(index, cancellationToken).ConfigureAwait(false);
 
                     if (first.HasValue)
                     {
@@ -29,25 +29,25 @@ namespace System.Linq
                     }
                 }
 
-                if (_index >= 0)
+                if (index >= 0)
                 {
-                    if (_source is IList<TSource> list)
+                    if (source is IList<TSource> list)
                     {
-                        if (_index < list.Count)
+                        if (index < list.Count)
                         {
-                            return list[_index];
+                            return list[index];
                         }
                     }
                     else
                     {
-                        await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                        await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                         {
-                            if (_index == 0)
+                            if (index == 0)
                             {
                                 return item;
                             }
 
-                            _index--;
+                            index--;
                         }
                     }
                 }

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/First.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/First.cs
@@ -17,9 +17,9 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, CancellationToken _cancellationToken)
+            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
             {
-                var first = await TryGetFirst(_source, _cancellationToken).ConfigureAwait(false);
+                var first = await TryGetFirst(source, cancellationToken).ConfigureAwait(false);
 
                 return first.HasValue ? first.Value : throw Error.NoElements();
             }
@@ -34,9 +34,9 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, Func<TSource, bool> _predicate, CancellationToken _cancellationToken)
+            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate, CancellationToken cancellationToken)
             {
-                var first = await TryGetFirst(_source, _predicate, _cancellationToken).ConfigureAwait(false);
+                var first = await TryGetFirst(source, predicate, cancellationToken).ConfigureAwait(false);
 
                 return first.HasValue ? first.Value : throw Error.NoElements();
             }
@@ -51,9 +51,9 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<bool>> _predicate, CancellationToken _cancellationToken)
+            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<bool>> predicate, CancellationToken cancellationToken)
             {
-                var first = await TryGetFirst(_source, _predicate, _cancellationToken).ConfigureAwait(false);
+                var first = await TryGetFirst(source, predicate, cancellationToken).ConfigureAwait(false);
 
                 return first.HasValue ? first.Value : throw Error.NoElements();
             }
@@ -69,9 +69,9 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<bool>> _predicate, CancellationToken _cancellationToken)
+            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<bool>> predicate, CancellationToken cancellationToken)
             {
-                var first = await TryGetFirst(_source, _predicate, _cancellationToken).ConfigureAwait(false);
+                var first = await TryGetFirst(source, predicate, cancellationToken).ConfigureAwait(false);
 
                 return first.HasValue ? first.Value : throw Error.NoElements();
             }

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/FirstOrDefault.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/FirstOrDefault.cs
@@ -17,9 +17,9 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, CancellationToken _cancellationToken)
+            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
             {
-                var first = await TryGetFirst(_source, _cancellationToken).ConfigureAwait(false);
+                var first = await TryGetFirst(source, cancellationToken).ConfigureAwait(false);
 
                 return first.HasValue ? first.Value : default;
             }
@@ -34,9 +34,9 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, Func<TSource, bool> _predicate, CancellationToken _cancellationToken)
+            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate, CancellationToken cancellationToken)
             {
-                var first = await TryGetFirst(_source, _predicate, _cancellationToken).ConfigureAwait(false);
+                var first = await TryGetFirst(source, predicate, cancellationToken).ConfigureAwait(false);
 
                 return first.HasValue ? first.Value : default;
             }
@@ -51,9 +51,9 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<bool>> _predicate, CancellationToken _cancellationToken)
+            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<bool>> predicate, CancellationToken cancellationToken)
             {
-                var first = await TryGetFirst(_source, _predicate, _cancellationToken).ConfigureAwait(false);
+                var first = await TryGetFirst(source, predicate, cancellationToken).ConfigureAwait(false);
 
                 return first.HasValue ? first.Value : default;
             }
@@ -69,9 +69,9 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<bool>> _predicate, CancellationToken _cancellationToken)
+            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<bool>> predicate, CancellationToken cancellationToken)
             {
-                var first = await TryGetFirst(_source, _predicate, _cancellationToken).ConfigureAwait(false);
+                var first = await TryGetFirst(source, predicate, cancellationToken).ConfigureAwait(false);
 
                 return first.HasValue ? first.Value : default;
             }
@@ -95,9 +95,9 @@ namespace System.Linq
             {
                 return Core(source, cancellationToken);
 
-                static async ValueTask<Maybe<TSource>> Core(IAsyncEnumerable<TSource> _source, CancellationToken _cancellationToken)
+                static async ValueTask<Maybe<TSource>> Core(IAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
                 {
-                    await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                    await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                     {
                         if (await e.MoveNextAsync())
                         {

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/ForEach.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/ForEach.cs
@@ -26,11 +26,11 @@ namespace System.Linq
 
             return Core(source, action, cancellationToken);
 
-            static async Task Core(IAsyncEnumerable<TSource> _source, Action<TSource> _action, CancellationToken _cancellationToken)
+            static async Task Core(IAsyncEnumerable<TSource> source, Action<TSource> action, CancellationToken cancellationToken)
             {
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    _action(item);
+                    action(item);
                 }
             }
         }
@@ -44,13 +44,13 @@ namespace System.Linq
 
             return Core(source, action, cancellationToken);
 
-            static async Task Core(IAsyncEnumerable<TSource> _source, Action<TSource, int> _action, CancellationToken _cancellationToken)
+            static async Task Core(IAsyncEnumerable<TSource> source, Action<TSource, int> action, CancellationToken cancellationToken)
             {
                 var index = 0;
 
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    _action(item, checked(index++));
+                    action(item, checked(index++));
                 }
             }
         }
@@ -64,11 +64,11 @@ namespace System.Linq
 
             return Core(source, action, cancellationToken);
 
-            static async Task Core(IAsyncEnumerable<TSource> _source, Func<TSource, Task> _action, CancellationToken _cancellationToken)
+            static async Task Core(IAsyncEnumerable<TSource> source, Func<TSource, Task> action, CancellationToken cancellationToken)
             {
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    await _action(item).ConfigureAwait(false);
+                    await action(item).ConfigureAwait(false);
                 }
             }
         }
@@ -82,11 +82,11 @@ namespace System.Linq
 
             return Core(source, action, cancellationToken);
 
-            static async Task Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, Task> _action, CancellationToken _cancellationToken)
+            static async Task Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, Task> action, CancellationToken cancellationToken)
             {
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    await _action(item, _cancellationToken).ConfigureAwait(false);
+                    await action(item, cancellationToken).ConfigureAwait(false);
                 }
             }
         }
@@ -100,13 +100,13 @@ namespace System.Linq
 
             return Core(source, action, cancellationToken);
 
-            static async Task Core(IAsyncEnumerable<TSource> _source, Func<TSource, int, Task> _action, CancellationToken _cancellationToken)
+            static async Task Core(IAsyncEnumerable<TSource> source, Func<TSource, int, Task> action, CancellationToken cancellationToken)
             {
                 var index = 0;
 
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    await _action(item, checked(index++)).ConfigureAwait(false);
+                    await action(item, checked(index++)).ConfigureAwait(false);
                 }
             }
         }
@@ -120,13 +120,13 @@ namespace System.Linq
 
             return Core(source, action, cancellationToken);
 
-            static async Task Core(IAsyncEnumerable<TSource> _source, Func<TSource, int, CancellationToken, Task> _action, CancellationToken _cancellationToken)
+            static async Task Core(IAsyncEnumerable<TSource> source, Func<TSource, int, CancellationToken, Task> action, CancellationToken cancellationToken)
             {
                 var index = 0;
 
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    await _action(item, checked(index++), _cancellationToken).ConfigureAwait(false);
+                    await action(item, checked(index++), cancellationToken).ConfigureAwait(false);
                 }
             }
         }

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/Last.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/Last.cs
@@ -17,9 +17,9 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, CancellationToken _cancellationToken)
+            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
             {
-                var last = await TryGetLast(_source, _cancellationToken).ConfigureAwait(false);
+                var last = await TryGetLast(source, cancellationToken).ConfigureAwait(false);
 
                 return last.HasValue ? last.Value : throw Error.NoElements();
             }
@@ -34,9 +34,9 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, Func<TSource, bool> _predicate, CancellationToken _cancellationToken)
+            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate, CancellationToken cancellationToken)
             {
-                var last = await TryGetLast(_source, _predicate, _cancellationToken).ConfigureAwait(false);
+                var last = await TryGetLast(source, predicate, cancellationToken).ConfigureAwait(false);
 
                 return last.HasValue ? last.Value : throw Error.NoElements();
             }
@@ -51,9 +51,9 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<bool>> _predicate, CancellationToken _cancellationToken)
+            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<bool>> predicate, CancellationToken cancellationToken)
             {
-                var last = await TryGetLast(_source, _predicate, _cancellationToken).ConfigureAwait(false);
+                var last = await TryGetLast(source, predicate, cancellationToken).ConfigureAwait(false);
 
                 return last.HasValue ? last.Value : throw Error.NoElements();
             }
@@ -69,9 +69,9 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<bool>> _predicate, CancellationToken _cancellationToken)
+            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<bool>> predicate, CancellationToken cancellationToken)
             {
-                var last = await TryGetLast(_source, _predicate, _cancellationToken).ConfigureAwait(false);
+                var last = await TryGetLast(source, predicate, cancellationToken).ConfigureAwait(false);
 
                 return last.HasValue ? last.Value : throw Error.NoElements();
             }

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/LastOrDefault.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/LastOrDefault.cs
@@ -17,9 +17,9 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, CancellationToken _cancellationToken)
+            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
             {
-                var last = await TryGetLast(_source, _cancellationToken).ConfigureAwait(false);
+                var last = await TryGetLast(source, cancellationToken).ConfigureAwait(false);
 
                 return last.HasValue ? last.Value : default;
             }
@@ -34,9 +34,9 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, Func<TSource, bool> _predicate, CancellationToken _cancellationToken)
+            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate, CancellationToken cancellationToken)
             {
-                var last = await TryGetLast(_source, _predicate, _cancellationToken).ConfigureAwait(false);
+                var last = await TryGetLast(source, predicate, cancellationToken).ConfigureAwait(false);
 
                 return last.HasValue ? last.Value : default;
             }
@@ -51,9 +51,9 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<bool>> _predicate, CancellationToken _cancellationToken)
+            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<bool>> predicate, CancellationToken cancellationToken)
             {
-                var last = await TryGetLast(_source, _predicate, _cancellationToken).ConfigureAwait(false);
+                var last = await TryGetLast(source, predicate, cancellationToken).ConfigureAwait(false);
 
                 return last.HasValue ? last.Value : default;
             }
@@ -69,9 +69,9 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<bool>> _predicate, CancellationToken _cancellationToken)
+            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<bool>> predicate, CancellationToken cancellationToken)
             {
-                var last = await TryGetLast(_source, _predicate, _cancellationToken).ConfigureAwait(false);
+                var last = await TryGetLast(source, predicate, cancellationToken).ConfigureAwait(false);
 
                 return last.HasValue ? last.Value : default;
             }
@@ -96,12 +96,12 @@ namespace System.Linq
             {
                 return Core(source, cancellationToken);
 
-                static async ValueTask<Maybe<TSource>> Core(IAsyncEnumerable<TSource> _source, CancellationToken _cancellationToken)
+                static async ValueTask<Maybe<TSource>> Core(IAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
                 {
                     var last = default(TSource);
                     var hasLast = false;
 
-                    await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                    await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                     {
                         hasLast = true;
                         last = item;

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/LongCount.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/LongCount.cs
@@ -17,11 +17,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<long> Core(IAsyncEnumerable<TSource> _source, CancellationToken _cancellationToken)
+            static async ValueTask<long> Core(IAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
             {
                 var count = 0L;
 
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
                     checked
                     {
@@ -42,13 +42,13 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            static async ValueTask<long> Core(IAsyncEnumerable<TSource> _source, Func<TSource, bool> _predicate, CancellationToken _cancellationToken)
+            static async ValueTask<long> Core(IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate, CancellationToken cancellationToken)
             {
                 var count = 0L;
 
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    if (_predicate(item))
+                    if (predicate(item))
                     {
                         checked
                         {
@@ -70,13 +70,13 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            static async ValueTask<long> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<bool>> _predicate, CancellationToken _cancellationToken)
+            static async ValueTask<long> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<bool>> predicate, CancellationToken cancellationToken)
             {
                 var count = 0L;
 
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    if (await _predicate(item).ConfigureAwait(false))
+                    if (await predicate(item).ConfigureAwait(false))
                     {
                         checked
                         {
@@ -99,13 +99,13 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            static async ValueTask<long> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<bool>> _predicate, CancellationToken _cancellationToken)
+            static async ValueTask<long> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<bool>> predicate, CancellationToken cancellationToken)
             {
                 var count = 0L;
 
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    if (await _predicate(item, _cancellationToken).ConfigureAwait(false))
+                    if (await predicate(item, cancellationToken).ConfigureAwait(false))
                     {
                         checked
                         {

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/Max.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/Max.cs
@@ -19,13 +19,13 @@ namespace System.Linq
             {
                 return Core(source, cancellationToken);
 
-                static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, CancellationToken _cancellationToken)
+                static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
                 {
                     var comparer = Comparer<TSource>.Default;
 
                     var value = default(TSource);
 
-                    await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                    await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                     {
                         do
                         {
@@ -56,13 +56,13 @@ namespace System.Linq
             {
                 return Core(source, cancellationToken);
 
-                static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, CancellationToken _cancellationToken)
+                static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
                 {
                     var comparer = Comparer<TSource>.Default;
 
                     var value = default(TSource);
 
-                    await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                    await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                     {
                         if (!await e.MoveNextAsync())
                         {
@@ -97,13 +97,13 @@ namespace System.Linq
             {
                 return Core(source, selector, cancellationToken);
 
-                static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> _source, Func<TSource, TResult> _selector, CancellationToken _cancellationToken)
+                static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> source, Func<TSource, TResult> selector, CancellationToken cancellationToken)
                 {
                     var comparer = Comparer<TResult>.Default;
 
                     var value = default(TResult);
 
-                    await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                    await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                     {
                         do
                         {
@@ -112,13 +112,13 @@ namespace System.Linq
                                 return value;
                             }
 
-                            value = _selector(e.Current);
+                            value = selector(e.Current);
                         }
                         while (value == null);
 
                         while (await e.MoveNextAsync())
                         {
-                            var x = _selector(e.Current);
+                            var x = selector(e.Current);
 
                             if (x != null && comparer.Compare(x, value) > 0)
                             {
@@ -134,24 +134,24 @@ namespace System.Linq
             {
                 return Core(source, selector, cancellationToken);
 
-                static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> _source, Func<TSource, TResult> _selector, CancellationToken _cancellationToken)
+                static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> source, Func<TSource, TResult> selector, CancellationToken cancellationToken)
                 {
                     var comparer = Comparer<TResult>.Default;
 
                     var value = default(TResult);
 
-                    await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                    await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                     {
                         if (!await e.MoveNextAsync())
                         {
                             throw Error.NoElements();
                         }
 
-                        value = _selector(e.Current);
+                        value = selector(e.Current);
 
                         while (await e.MoveNextAsync())
                         {
-                            var x = _selector(e.Current);
+                            var x = selector(e.Current);
                             if (comparer.Compare(x, value) > 0)
                             {
                                 value = x;
@@ -175,13 +175,13 @@ namespace System.Linq
             {
                 return Core(source, selector, cancellationToken);
 
-                static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<TResult>> _selector, CancellationToken _cancellationToken)
+                static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<TResult>> selector, CancellationToken cancellationToken)
                 {
                     var comparer = Comparer<TResult>.Default;
 
                     var value = default(TResult);
 
-                    await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                    await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                     {
                         do
                         {
@@ -190,13 +190,13 @@ namespace System.Linq
                                 return value;
                             }
 
-                            value = await _selector(e.Current).ConfigureAwait(false);
+                            value = await selector(e.Current).ConfigureAwait(false);
                         }
                         while (value == null);
 
                         while (await e.MoveNextAsync())
                         {
-                            var x = await _selector(e.Current).ConfigureAwait(false);
+                            var x = await selector(e.Current).ConfigureAwait(false);
 
                             if (x != null && comparer.Compare(x, value) > 0)
                             {
@@ -212,24 +212,24 @@ namespace System.Linq
             {
                 return Core(source, selector, cancellationToken);
 
-                static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<TResult>> _selector, CancellationToken _cancellationToken)
+                static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<TResult>> selector, CancellationToken cancellationToken)
                 {
                     var comparer = Comparer<TResult>.Default;
 
                     var value = default(TResult);
 
-                    await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                    await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                     {
                         if (!await e.MoveNextAsync())
                         {
                             throw Error.NoElements();
                         }
 
-                        value = await _selector(e.Current).ConfigureAwait(false);
+                        value = await selector(e.Current).ConfigureAwait(false);
 
                         while (await e.MoveNextAsync())
                         {
-                            var x = await _selector(e.Current).ConfigureAwait(false);
+                            var x = await selector(e.Current).ConfigureAwait(false);
 
                             if (comparer.Compare(x, value) > 0)
                             {
@@ -255,13 +255,13 @@ namespace System.Linq
             {
                 return Core(source, selector, cancellationToken);
 
-                static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<TResult>> _selector, CancellationToken _cancellationToken)
+                static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<TResult>> selector, CancellationToken cancellationToken)
                 {
                     var comparer = Comparer<TResult>.Default;
 
                     var value = default(TResult);
 
-                    await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                    await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                     {
                         do
                         {
@@ -270,13 +270,13 @@ namespace System.Linq
                                 return value;
                             }
 
-                            value = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                            value = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                         }
                         while (value == null);
 
                         while (await e.MoveNextAsync())
                         {
-                            var x = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                            var x = await selector(e.Current, cancellationToken).ConfigureAwait(false);
 
                             if (x != null && comparer.Compare(x, value) > 0)
                             {
@@ -292,24 +292,24 @@ namespace System.Linq
             {
                 return Core(source, selector, cancellationToken);
 
-                static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<TResult>> _selector, CancellationToken _cancellationToken)
+                static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<TResult>> selector, CancellationToken cancellationToken)
                 {
                     var comparer = Comparer<TResult>.Default;
 
                     var value = default(TResult);
 
-                    await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                    await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                     {
                         if (!await e.MoveNextAsync())
                         {
                             throw Error.NoElements();
                         }
 
-                        value = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        value = await selector(e.Current, cancellationToken).ConfigureAwait(false);
 
                         while (await e.MoveNextAsync())
                         {
-                            var x = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                            var x = await selector(e.Current, cancellationToken).ConfigureAwait(false);
 
                             if (comparer.Compare(x, value) > 0)
                             {

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/Min.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/Min.cs
@@ -19,13 +19,13 @@ namespace System.Linq
             {
                 return Core(source, cancellationToken);
 
-                static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, CancellationToken _cancellationToken)
+                static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
                 {
                     var comparer = Comparer<TSource>.Default;
 
                     var value = default(TSource);
 
-                    await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                    await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                     {
                         do
                         {
@@ -56,13 +56,13 @@ namespace System.Linq
             {
                 return Core(source, cancellationToken);
 
-                static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, CancellationToken _cancellationToken)
+                static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
                 {
                     var comparer = Comparer<TSource>.Default;
 
                     var value = default(TSource);
 
-                    await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                    await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                     {
                         if (!await e.MoveNextAsync())
                         {
@@ -98,13 +98,13 @@ namespace System.Linq
             {
                 return Core(source, selector, cancellationToken);
 
-                static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> _source, Func<TSource, TResult> _selector, CancellationToken _cancellationToken)
+                static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> source, Func<TSource, TResult> selector, CancellationToken cancellationToken)
                 {
                     var comparer = Comparer<TResult>.Default;
 
                     var value = default(TResult);
 
-                    await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                    await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                     {
                         do
                         {
@@ -113,13 +113,13 @@ namespace System.Linq
                                 return value;
                             }
 
-                            value = _selector(e.Current);
+                            value = selector(e.Current);
                         }
                         while (value == null);
 
                         while (await e.MoveNextAsync())
                         {
-                            var x = _selector(e.Current);
+                            var x = selector(e.Current);
 
                             if (x != null && comparer.Compare(x, value) < 0)
                             {
@@ -135,24 +135,24 @@ namespace System.Linq
             {
                 return Core(source, selector, cancellationToken);
 
-                static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> _source, Func<TSource, TResult> _selector, CancellationToken _cancellationToken)
+                static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> source, Func<TSource, TResult> selector, CancellationToken cancellationToken)
                 {
                     var comparer = Comparer<TResult>.Default;
 
                     var value = default(TResult);
 
-                    await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                    await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                     {
                         if (!await e.MoveNextAsync())
                         {
                             throw Error.NoElements();
                         }
 
-                        value = _selector(e.Current);
+                        value = selector(e.Current);
 
                         while (await e.MoveNextAsync())
                         {
-                            var x = _selector(e.Current);
+                            var x = selector(e.Current);
 
                             if (comparer.Compare(x, value) < 0)
                             {
@@ -177,13 +177,13 @@ namespace System.Linq
             {
                 return Core(source, selector, cancellationToken);
 
-                static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<TResult>> _selector, CancellationToken _cancellationToken)
+                static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<TResult>> selector, CancellationToken cancellationToken)
                 {
                     var comparer = Comparer<TResult>.Default;
 
                     var value = default(TResult);
 
-                    await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                    await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                     {
                         do
                         {
@@ -192,13 +192,13 @@ namespace System.Linq
                                 return value;
                             }
 
-                            value = await _selector(e.Current).ConfigureAwait(false);
+                            value = await selector(e.Current).ConfigureAwait(false);
                         }
                         while (value == null);
 
                         while (await e.MoveNextAsync())
                         {
-                            var x = await _selector(e.Current).ConfigureAwait(false);
+                            var x = await selector(e.Current).ConfigureAwait(false);
 
                             if (x != null && comparer.Compare(x, value) < 0)
                             {
@@ -214,24 +214,24 @@ namespace System.Linq
             {
                 return Core(source, selector, cancellationToken);
 
-                static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<TResult>> _selector, CancellationToken _cancellationToken)
+                static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<TResult>> selector, CancellationToken cancellationToken)
                 {
                     var comparer = Comparer<TResult>.Default;
 
                     var value = default(TResult);
 
-                    await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                    await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                     {
                         if (!await e.MoveNextAsync())
                         {
                             throw Error.NoElements();
                         }
 
-                        value = await _selector(e.Current).ConfigureAwait(false);
+                        value = await selector(e.Current).ConfigureAwait(false);
 
                         while (await e.MoveNextAsync())
                         {
-                            var x = await _selector(e.Current).ConfigureAwait(false);
+                            var x = await selector(e.Current).ConfigureAwait(false);
 
                             if (comparer.Compare(x, value) < 0)
                             {
@@ -257,13 +257,13 @@ namespace System.Linq
             {
                 return Core(source, selector, cancellationToken);
 
-                static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<TResult>> _selector, CancellationToken _cancellationToken)
+                static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<TResult>> selector, CancellationToken cancellationToken)
                 {
                     var comparer = Comparer<TResult>.Default;
 
                     var value = default(TResult);
 
-                    await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                    await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                     {
                         do
                         {
@@ -272,13 +272,13 @@ namespace System.Linq
                                 return value;
                             }
 
-                            value = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                            value = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                         }
                         while (value == null);
 
                         while (await e.MoveNextAsync())
                         {
-                            var x = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                            var x = await selector(e.Current, cancellationToken).ConfigureAwait(false);
 
                             if (x != null && comparer.Compare(x, value) < 0)
                             {
@@ -294,23 +294,23 @@ namespace System.Linq
             {
                 return Core(source, selector, cancellationToken);
 
-                static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<TResult>> _selector, CancellationToken _cancellationToken)
+                static async ValueTask<TResult> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<TResult>> selector, CancellationToken cancellationToken)
                 {
                     var comparer = Comparer<TResult>.Default;
 
                     var value = default(TResult);
 
-                    await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                    await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                     {
                         if (!await e.MoveNextAsync())
                         {
                             throw Error.NoElements();
                         }
 
-                        value = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        value = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                         while (await e.MoveNextAsync())
                         {
-                            var x = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                            var x = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                             if (comparer.Compare(x, value) < 0)
                             {
                                 value = x;

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/MinMax.Generated.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/MinMax.Generated.cs
@@ -17,11 +17,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<int> Core(IAsyncEnumerable<int> _source, CancellationToken _cancellationToken)
+            static async ValueTask<int> Core(IAsyncEnumerable<int> source, CancellationToken cancellationToken)
             {
                 int value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
@@ -53,22 +53,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<int> Core(IAsyncEnumerable<TSource> _source, Func<TSource, int> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<int> Core(IAsyncEnumerable<TSource> source, Func<TSource, int> selector, CancellationToken cancellationToken)
             {
                 int value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = _selector(e.Current);
+                    value = selector(e.Current);
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = _selector(e.Current);
+                        var x = selector(e.Current);
                         if (x > value)
                         {
                             value = x;
@@ -89,22 +89,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<int> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<int>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<int> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<int>> selector, CancellationToken cancellationToken)
             {
                 int value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = await _selector(e.Current).ConfigureAwait(false);
+                    value = await selector(e.Current).ConfigureAwait(false);
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = await _selector(e.Current).ConfigureAwait(false);
+                        var x = await selector(e.Current).ConfigureAwait(false);
                         if (x > value)
                         {
                             value = x;
@@ -126,22 +126,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<int> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<int>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<int> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<int>> selector, CancellationToken cancellationToken)
             {
                 int value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                    value = await selector(e.Current, cancellationToken).ConfigureAwait(false);
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        var x = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                         if (x > value)
                         {
                             value = x;
@@ -161,11 +161,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<int?> Core(IAsyncEnumerable<int?> _source, CancellationToken _cancellationToken)
+            static async ValueTask<int?> Core(IAsyncEnumerable<int?> source, CancellationToken cancellationToken)
             {
                 int? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -236,11 +236,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<int?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, int?> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<int?> Core(IAsyncEnumerable<TSource> source, Func<TSource, int?> selector, CancellationToken cancellationToken)
             {
                 int? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -251,7 +251,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = _selector(e.Current);
+                        value = selector(e.Current);
                     }
                     while (!value.HasValue);
 
@@ -270,7 +270,7 @@ namespace System.Linq
 
                         while (await e.MoveNextAsync())
                         {
-                            var cur = _selector(e.Current);
+                            var cur = selector(e.Current);
                             var x = cur.GetValueOrDefault();
 
                             if (x > valueVal)
@@ -284,7 +284,7 @@ namespace System.Linq
                     {
                         while (await e.MoveNextAsync())
                         {
-                            var cur = _selector(e.Current);
+                            var cur = selector(e.Current);
                             var x = cur.GetValueOrDefault();
 
                             // Do not replace & with &&. The branch prediction cost outweighs the extra operation
@@ -311,11 +311,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<int?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<int?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<int?> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<int?>> selector, CancellationToken cancellationToken)
             {
                 int? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -326,7 +326,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = await _selector(e.Current).ConfigureAwait(false);
+                        value = await selector(e.Current).ConfigureAwait(false);
                     }
                     while (!value.HasValue);
 
@@ -345,7 +345,7 @@ namespace System.Linq
 
                         while (await e.MoveNextAsync())
                         {
-                            var cur = await _selector(e.Current).ConfigureAwait(false);
+                            var cur = await selector(e.Current).ConfigureAwait(false);
                             var x = cur.GetValueOrDefault();
 
                             if (x > valueVal)
@@ -359,7 +359,7 @@ namespace System.Linq
                     {
                         while (await e.MoveNextAsync())
                         {
-                            var cur = await _selector(e.Current).ConfigureAwait(false);
+                            var cur = await selector(e.Current).ConfigureAwait(false);
                             var x = cur.GetValueOrDefault();
 
                             // Do not replace & with &&. The branch prediction cost outweighs the extra operation
@@ -387,11 +387,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<int?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<int?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<int?> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<int?>> selector, CancellationToken cancellationToken)
             {
                 int? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -402,7 +402,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        value = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                     }
                     while (!value.HasValue);
 
@@ -421,7 +421,7 @@ namespace System.Linq
 
                         while (await e.MoveNextAsync())
                         {
-                            var cur = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                            var cur = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                             var x = cur.GetValueOrDefault();
 
                             if (x > valueVal)
@@ -435,7 +435,7 @@ namespace System.Linq
                     {
                         while (await e.MoveNextAsync())
                         {
-                            var cur = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                            var cur = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                             var x = cur.GetValueOrDefault();
 
                             // Do not replace & with &&. The branch prediction cost outweighs the extra operation
@@ -461,11 +461,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<long> Core(IAsyncEnumerable<long> _source, CancellationToken _cancellationToken)
+            static async ValueTask<long> Core(IAsyncEnumerable<long> source, CancellationToken cancellationToken)
             {
                 long value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
@@ -497,22 +497,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<long> Core(IAsyncEnumerable<TSource> _source, Func<TSource, long> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<long> Core(IAsyncEnumerable<TSource> source, Func<TSource, long> selector, CancellationToken cancellationToken)
             {
                 long value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = _selector(e.Current);
+                    value = selector(e.Current);
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = _selector(e.Current);
+                        var x = selector(e.Current);
                         if (x > value)
                         {
                             value = x;
@@ -533,22 +533,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<long> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<long>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<long> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<long>> selector, CancellationToken cancellationToken)
             {
                 long value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = await _selector(e.Current).ConfigureAwait(false);
+                    value = await selector(e.Current).ConfigureAwait(false);
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = await _selector(e.Current).ConfigureAwait(false);
+                        var x = await selector(e.Current).ConfigureAwait(false);
                         if (x > value)
                         {
                             value = x;
@@ -570,22 +570,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<long> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<long>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<long> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<long>> selector, CancellationToken cancellationToken)
             {
                 long value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                    value = await selector(e.Current, cancellationToken).ConfigureAwait(false);
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        var x = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                         if (x > value)
                         {
                             value = x;
@@ -605,11 +605,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<long?> Core(IAsyncEnumerable<long?> _source, CancellationToken _cancellationToken)
+            static async ValueTask<long?> Core(IAsyncEnumerable<long?> source, CancellationToken cancellationToken)
             {
                 long? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -680,11 +680,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<long?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, long?> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<long?> Core(IAsyncEnumerable<TSource> source, Func<TSource, long?> selector, CancellationToken cancellationToken)
             {
                 long? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -695,7 +695,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = _selector(e.Current);
+                        value = selector(e.Current);
                     }
                     while (!value.HasValue);
 
@@ -714,7 +714,7 @@ namespace System.Linq
 
                         while (await e.MoveNextAsync())
                         {
-                            var cur = _selector(e.Current);
+                            var cur = selector(e.Current);
                             var x = cur.GetValueOrDefault();
 
                             if (x > valueVal)
@@ -728,7 +728,7 @@ namespace System.Linq
                     {
                         while (await e.MoveNextAsync())
                         {
-                            var cur = _selector(e.Current);
+                            var cur = selector(e.Current);
                             var x = cur.GetValueOrDefault();
 
                             // Do not replace & with &&. The branch prediction cost outweighs the extra operation
@@ -755,11 +755,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<long?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<long?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<long?> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<long?>> selector, CancellationToken cancellationToken)
             {
                 long? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -770,7 +770,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = await _selector(e.Current).ConfigureAwait(false);
+                        value = await selector(e.Current).ConfigureAwait(false);
                     }
                     while (!value.HasValue);
 
@@ -789,7 +789,7 @@ namespace System.Linq
 
                         while (await e.MoveNextAsync())
                         {
-                            var cur = await _selector(e.Current).ConfigureAwait(false);
+                            var cur = await selector(e.Current).ConfigureAwait(false);
                             var x = cur.GetValueOrDefault();
 
                             if (x > valueVal)
@@ -803,7 +803,7 @@ namespace System.Linq
                     {
                         while (await e.MoveNextAsync())
                         {
-                            var cur = await _selector(e.Current).ConfigureAwait(false);
+                            var cur = await selector(e.Current).ConfigureAwait(false);
                             var x = cur.GetValueOrDefault();
 
                             // Do not replace & with &&. The branch prediction cost outweighs the extra operation
@@ -831,11 +831,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<long?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<long?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<long?> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<long?>> selector, CancellationToken cancellationToken)
             {
                 long? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -846,7 +846,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        value = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                     }
                     while (!value.HasValue);
 
@@ -865,7 +865,7 @@ namespace System.Linq
 
                         while (await e.MoveNextAsync())
                         {
-                            var cur = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                            var cur = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                             var x = cur.GetValueOrDefault();
 
                             if (x > valueVal)
@@ -879,7 +879,7 @@ namespace System.Linq
                     {
                         while (await e.MoveNextAsync())
                         {
-                            var cur = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                            var cur = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                             var x = cur.GetValueOrDefault();
 
                             // Do not replace & with &&. The branch prediction cost outweighs the extra operation
@@ -905,11 +905,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<float> Core(IAsyncEnumerable<float> _source, CancellationToken _cancellationToken)
+            static async ValueTask<float> Core(IAsyncEnumerable<float> source, CancellationToken cancellationToken)
             {
                 float value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
@@ -956,18 +956,18 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<float> Core(IAsyncEnumerable<TSource> _source, Func<TSource, float> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<float> Core(IAsyncEnumerable<TSource> source, Func<TSource, float> selector, CancellationToken cancellationToken)
             {
                 float value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = _selector(e.Current);
+                    value = selector(e.Current);
 
                     // NaN is ordered less than all other values. We need to do explicit checks
                     // to ensure this, but once we've found a value that is not NaN we need no
@@ -981,12 +981,12 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = _selector(e.Current);
+                        value = selector(e.Current);
                     }
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = _selector(e.Current);
+                        var x = selector(e.Current);
                         if (x > value)
                         {
                             value = x;
@@ -1007,18 +1007,18 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<float> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<float>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<float> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<float>> selector, CancellationToken cancellationToken)
             {
                 float value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = await _selector(e.Current).ConfigureAwait(false);
+                    value = await selector(e.Current).ConfigureAwait(false);
 
                     // NaN is ordered less than all other values. We need to do explicit checks
                     // to ensure this, but once we've found a value that is not NaN we need no
@@ -1032,12 +1032,12 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = await _selector(e.Current).ConfigureAwait(false);
+                        value = await selector(e.Current).ConfigureAwait(false);
                     }
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = await _selector(e.Current).ConfigureAwait(false);
+                        var x = await selector(e.Current).ConfigureAwait(false);
                         if (x > value)
                         {
                             value = x;
@@ -1059,18 +1059,18 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<float> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<float>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<float> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<float>> selector, CancellationToken cancellationToken)
             {
                 float value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                    value = await selector(e.Current, cancellationToken).ConfigureAwait(false);
 
                     // NaN is ordered less than all other values. We need to do explicit checks
                     // to ensure this, but once we've found a value that is not NaN we need no
@@ -1084,12 +1084,12 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        value = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                     }
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        var x = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                         if (x > value)
                         {
                             value = x;
@@ -1109,11 +1109,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<float?> Core(IAsyncEnumerable<float?> _source, CancellationToken _cancellationToken)
+            static async ValueTask<float?> Core(IAsyncEnumerable<float?> source, CancellationToken cancellationToken)
             {
                 float? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -1180,11 +1180,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<float?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, float?> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<float?> Core(IAsyncEnumerable<TSource> source, Func<TSource, float?> selector, CancellationToken cancellationToken)
             {
                 float? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -1195,7 +1195,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = _selector(e.Current);
+                        value = selector(e.Current);
                     }
                     while (!value.HasValue);
 
@@ -1215,7 +1215,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        var cur = _selector(e.Current);
+                        var cur = selector(e.Current);
 
                         if (cur.HasValue)
                         {
@@ -1225,7 +1225,7 @@ namespace System.Linq
 
                     while (await e.MoveNextAsync())
                     {
-                        var cur = _selector(e.Current);
+                        var cur = selector(e.Current);
                         var x = cur.GetValueOrDefault();
 
                         // Do not replace & with &&. The branch prediction cost outweighs the extra operation
@@ -1251,11 +1251,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<float?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<float?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<float?> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<float?>> selector, CancellationToken cancellationToken)
             {
                 float? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -1266,7 +1266,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = await _selector(e.Current).ConfigureAwait(false);
+                        value = await selector(e.Current).ConfigureAwait(false);
                     }
                     while (!value.HasValue);
 
@@ -1286,7 +1286,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        var cur = await _selector(e.Current).ConfigureAwait(false);
+                        var cur = await selector(e.Current).ConfigureAwait(false);
 
                         if (cur.HasValue)
                         {
@@ -1296,7 +1296,7 @@ namespace System.Linq
 
                     while (await e.MoveNextAsync())
                     {
-                        var cur = await _selector(e.Current).ConfigureAwait(false);
+                        var cur = await selector(e.Current).ConfigureAwait(false);
                         var x = cur.GetValueOrDefault();
 
                         // Do not replace & with &&. The branch prediction cost outweighs the extra operation
@@ -1323,11 +1323,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<float?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<float?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<float?> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<float?>> selector, CancellationToken cancellationToken)
             {
                 float? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -1338,7 +1338,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        value = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                     }
                     while (!value.HasValue);
 
@@ -1358,7 +1358,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        var cur = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        var cur = await selector(e.Current, cancellationToken).ConfigureAwait(false);
 
                         if (cur.HasValue)
                         {
@@ -1368,7 +1368,7 @@ namespace System.Linq
 
                     while (await e.MoveNextAsync())
                     {
-                        var cur = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        var cur = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                         var x = cur.GetValueOrDefault();
 
                         // Do not replace & with &&. The branch prediction cost outweighs the extra operation
@@ -1393,11 +1393,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<double> Core(IAsyncEnumerable<double> _source, CancellationToken _cancellationToken)
+            static async ValueTask<double> Core(IAsyncEnumerable<double> source, CancellationToken cancellationToken)
             {
                 double value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
@@ -1444,18 +1444,18 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double> Core(IAsyncEnumerable<TSource> _source, Func<TSource, double> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double> Core(IAsyncEnumerable<TSource> source, Func<TSource, double> selector, CancellationToken cancellationToken)
             {
                 double value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = _selector(e.Current);
+                    value = selector(e.Current);
 
                     // NaN is ordered less than all other values. We need to do explicit checks
                     // to ensure this, but once we've found a value that is not NaN we need no
@@ -1469,12 +1469,12 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = _selector(e.Current);
+                        value = selector(e.Current);
                     }
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = _selector(e.Current);
+                        var x = selector(e.Current);
                         if (x > value)
                         {
                             value = x;
@@ -1495,18 +1495,18 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<double>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<double>> selector, CancellationToken cancellationToken)
             {
                 double value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = await _selector(e.Current).ConfigureAwait(false);
+                    value = await selector(e.Current).ConfigureAwait(false);
 
                     // NaN is ordered less than all other values. We need to do explicit checks
                     // to ensure this, but once we've found a value that is not NaN we need no
@@ -1520,12 +1520,12 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = await _selector(e.Current).ConfigureAwait(false);
+                        value = await selector(e.Current).ConfigureAwait(false);
                     }
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = await _selector(e.Current).ConfigureAwait(false);
+                        var x = await selector(e.Current).ConfigureAwait(false);
                         if (x > value)
                         {
                             value = x;
@@ -1547,18 +1547,18 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<double>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<double>> selector, CancellationToken cancellationToken)
             {
                 double value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                    value = await selector(e.Current, cancellationToken).ConfigureAwait(false);
 
                     // NaN is ordered less than all other values. We need to do explicit checks
                     // to ensure this, but once we've found a value that is not NaN we need no
@@ -1572,12 +1572,12 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        value = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                     }
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        var x = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                         if (x > value)
                         {
                             value = x;
@@ -1597,11 +1597,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<double?> Core(IAsyncEnumerable<double?> _source, CancellationToken _cancellationToken)
+            static async ValueTask<double?> Core(IAsyncEnumerable<double?> source, CancellationToken cancellationToken)
             {
                 double? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -1668,11 +1668,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, double?> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> source, Func<TSource, double?> selector, CancellationToken cancellationToken)
             {
                 double? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -1683,7 +1683,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = _selector(e.Current);
+                        value = selector(e.Current);
                     }
                     while (!value.HasValue);
 
@@ -1703,7 +1703,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        var cur = _selector(e.Current);
+                        var cur = selector(e.Current);
 
                         if (cur.HasValue)
                         {
@@ -1713,7 +1713,7 @@ namespace System.Linq
 
                     while (await e.MoveNextAsync())
                     {
-                        var cur = _selector(e.Current);
+                        var cur = selector(e.Current);
                         var x = cur.GetValueOrDefault();
 
                         // Do not replace & with &&. The branch prediction cost outweighs the extra operation
@@ -1739,11 +1739,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<double?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<double?>> selector, CancellationToken cancellationToken)
             {
                 double? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -1754,7 +1754,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = await _selector(e.Current).ConfigureAwait(false);
+                        value = await selector(e.Current).ConfigureAwait(false);
                     }
                     while (!value.HasValue);
 
@@ -1774,7 +1774,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        var cur = await _selector(e.Current).ConfigureAwait(false);
+                        var cur = await selector(e.Current).ConfigureAwait(false);
 
                         if (cur.HasValue)
                         {
@@ -1784,7 +1784,7 @@ namespace System.Linq
 
                     while (await e.MoveNextAsync())
                     {
-                        var cur = await _selector(e.Current).ConfigureAwait(false);
+                        var cur = await selector(e.Current).ConfigureAwait(false);
                         var x = cur.GetValueOrDefault();
 
                         // Do not replace & with &&. The branch prediction cost outweighs the extra operation
@@ -1811,11 +1811,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<double?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<double?>> selector, CancellationToken cancellationToken)
             {
                 double? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -1826,7 +1826,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        value = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                     }
                     while (!value.HasValue);
 
@@ -1846,7 +1846,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        var cur = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        var cur = await selector(e.Current, cancellationToken).ConfigureAwait(false);
 
                         if (cur.HasValue)
                         {
@@ -1856,7 +1856,7 @@ namespace System.Linq
 
                     while (await e.MoveNextAsync())
                     {
-                        var cur = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        var cur = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                         var x = cur.GetValueOrDefault();
 
                         // Do not replace & with &&. The branch prediction cost outweighs the extra operation
@@ -1881,11 +1881,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<decimal> Core(IAsyncEnumerable<decimal> _source, CancellationToken _cancellationToken)
+            static async ValueTask<decimal> Core(IAsyncEnumerable<decimal> source, CancellationToken cancellationToken)
             {
                 decimal value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
@@ -1917,22 +1917,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<decimal> Core(IAsyncEnumerable<TSource> _source, Func<TSource, decimal> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<decimal> Core(IAsyncEnumerable<TSource> source, Func<TSource, decimal> selector, CancellationToken cancellationToken)
             {
                 decimal value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = _selector(e.Current);
+                    value = selector(e.Current);
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = _selector(e.Current);
+                        var x = selector(e.Current);
                         if (x > value)
                         {
                             value = x;
@@ -1953,22 +1953,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<decimal> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<decimal>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<decimal> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<decimal>> selector, CancellationToken cancellationToken)
             {
                 decimal value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = await _selector(e.Current).ConfigureAwait(false);
+                    value = await selector(e.Current).ConfigureAwait(false);
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = await _selector(e.Current).ConfigureAwait(false);
+                        var x = await selector(e.Current).ConfigureAwait(false);
                         if (x > value)
                         {
                             value = x;
@@ -1990,22 +1990,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<decimal> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<decimal>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<decimal> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<decimal>> selector, CancellationToken cancellationToken)
             {
                 decimal value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                    value = await selector(e.Current, cancellationToken).ConfigureAwait(false);
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        var x = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                         if (x > value)
                         {
                             value = x;
@@ -2025,11 +2025,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<decimal?> Core(IAsyncEnumerable<decimal?> _source, CancellationToken _cancellationToken)
+            static async ValueTask<decimal?> Core(IAsyncEnumerable<decimal?> source, CancellationToken cancellationToken)
             {
                 decimal? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -2074,11 +2074,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<decimal?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, decimal?> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<decimal?> Core(IAsyncEnumerable<TSource> source, Func<TSource, decimal?> selector, CancellationToken cancellationToken)
             {
                 decimal? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -2089,7 +2089,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = _selector(e.Current);
+                        value = selector(e.Current);
                     }
                     while (!value.HasValue);
 
@@ -2099,7 +2099,7 @@ namespace System.Linq
 
                     while (await e.MoveNextAsync())
                     {
-                        var cur = _selector(e.Current);
+                        var cur = selector(e.Current);
                         var x = cur.GetValueOrDefault();
 
                         if (cur.HasValue && x > valueVal)
@@ -2123,11 +2123,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<decimal?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<decimal?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<decimal?> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<decimal?>> selector, CancellationToken cancellationToken)
             {
                 decimal? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -2138,7 +2138,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = await _selector(e.Current).ConfigureAwait(false);
+                        value = await selector(e.Current).ConfigureAwait(false);
                     }
                     while (!value.HasValue);
 
@@ -2148,7 +2148,7 @@ namespace System.Linq
 
                     while (await e.MoveNextAsync())
                     {
-                        var cur = await _selector(e.Current).ConfigureAwait(false);
+                        var cur = await selector(e.Current).ConfigureAwait(false);
                         var x = cur.GetValueOrDefault();
 
                         if (cur.HasValue && x > valueVal)
@@ -2173,11 +2173,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<decimal?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<decimal?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<decimal?> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<decimal?>> selector, CancellationToken cancellationToken)
             {
                 decimal? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -2188,7 +2188,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        value = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                     }
                     while (!value.HasValue);
 
@@ -2198,7 +2198,7 @@ namespace System.Linq
 
                     while (await e.MoveNextAsync())
                     {
-                        var cur = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        var cur = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                         var x = cur.GetValueOrDefault();
 
                         if (cur.HasValue && x > valueVal)
@@ -2221,11 +2221,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<int> Core(IAsyncEnumerable<int> _source, CancellationToken _cancellationToken)
+            static async ValueTask<int> Core(IAsyncEnumerable<int> source, CancellationToken cancellationToken)
             {
                 int value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
@@ -2257,22 +2257,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<int> Core(IAsyncEnumerable<TSource> _source, Func<TSource, int> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<int> Core(IAsyncEnumerable<TSource> source, Func<TSource, int> selector, CancellationToken cancellationToken)
             {
                 int value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = _selector(e.Current);
+                    value = selector(e.Current);
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = _selector(e.Current);
+                        var x = selector(e.Current);
                         if (x < value)
                         {
                             value = x;
@@ -2293,22 +2293,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<int> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<int>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<int> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<int>> selector, CancellationToken cancellationToken)
             {
                 int value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = await _selector(e.Current).ConfigureAwait(false);
+                    value = await selector(e.Current).ConfigureAwait(false);
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = await _selector(e.Current).ConfigureAwait(false);
+                        var x = await selector(e.Current).ConfigureAwait(false);
                         if (x < value)
                         {
                             value = x;
@@ -2330,22 +2330,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<int> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<int>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<int> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<int>> selector, CancellationToken cancellationToken)
             {
                 int value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                    value = await selector(e.Current, cancellationToken).ConfigureAwait(false);
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        var x = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                         if (x < value)
                         {
                             value = x;
@@ -2365,11 +2365,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<int?> Core(IAsyncEnumerable<int?> _source, CancellationToken _cancellationToken)
+            static async ValueTask<int?> Core(IAsyncEnumerable<int?> source, CancellationToken cancellationToken)
             {
                 int? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -2416,11 +2416,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<int?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, int?> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<int?> Core(IAsyncEnumerable<TSource> source, Func<TSource, int?> selector, CancellationToken cancellationToken)
             {
                 int? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -2431,7 +2431,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = _selector(e.Current);
+                        value = selector(e.Current);
                     }
                     while (!value.HasValue);
 
@@ -2441,7 +2441,7 @@ namespace System.Linq
 
                     while (await e.MoveNextAsync())
                     {
-                        var cur = _selector(e.Current);
+                        var cur = selector(e.Current);
                         var x = cur.GetValueOrDefault();
 
                         // Do not replace & with &&. The branch prediction cost outweighs the extra operation
@@ -2467,11 +2467,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<int?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<int?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<int?> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<int?>> selector, CancellationToken cancellationToken)
             {
                 int? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -2482,7 +2482,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = await _selector(e.Current).ConfigureAwait(false);
+                        value = await selector(e.Current).ConfigureAwait(false);
                     }
                     while (!value.HasValue);
 
@@ -2492,7 +2492,7 @@ namespace System.Linq
 
                     while (await e.MoveNextAsync())
                     {
-                        var cur = await _selector(e.Current).ConfigureAwait(false);
+                        var cur = await selector(e.Current).ConfigureAwait(false);
                         var x = cur.GetValueOrDefault();
 
                         // Do not replace & with &&. The branch prediction cost outweighs the extra operation
@@ -2519,11 +2519,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<int?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<int?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<int?> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<int?>> selector, CancellationToken cancellationToken)
             {
                 int? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -2534,7 +2534,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        value = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                     }
                     while (!value.HasValue);
 
@@ -2544,7 +2544,7 @@ namespace System.Linq
 
                     while (await e.MoveNextAsync())
                     {
-                        var cur = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        var cur = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                         var x = cur.GetValueOrDefault();
 
                         // Do not replace & with &&. The branch prediction cost outweighs the extra operation
@@ -2569,11 +2569,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<long> Core(IAsyncEnumerable<long> _source, CancellationToken _cancellationToken)
+            static async ValueTask<long> Core(IAsyncEnumerable<long> source, CancellationToken cancellationToken)
             {
                 long value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
@@ -2605,22 +2605,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<long> Core(IAsyncEnumerable<TSource> _source, Func<TSource, long> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<long> Core(IAsyncEnumerable<TSource> source, Func<TSource, long> selector, CancellationToken cancellationToken)
             {
                 long value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = _selector(e.Current);
+                    value = selector(e.Current);
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = _selector(e.Current);
+                        var x = selector(e.Current);
                         if (x < value)
                         {
                             value = x;
@@ -2641,22 +2641,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<long> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<long>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<long> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<long>> selector, CancellationToken cancellationToken)
             {
                 long value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = await _selector(e.Current).ConfigureAwait(false);
+                    value = await selector(e.Current).ConfigureAwait(false);
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = await _selector(e.Current).ConfigureAwait(false);
+                        var x = await selector(e.Current).ConfigureAwait(false);
                         if (x < value)
                         {
                             value = x;
@@ -2678,22 +2678,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<long> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<long>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<long> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<long>> selector, CancellationToken cancellationToken)
             {
                 long value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                    value = await selector(e.Current, cancellationToken).ConfigureAwait(false);
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        var x = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                         if (x < value)
                         {
                             value = x;
@@ -2713,11 +2713,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<long?> Core(IAsyncEnumerable<long?> _source, CancellationToken _cancellationToken)
+            static async ValueTask<long?> Core(IAsyncEnumerable<long?> source, CancellationToken cancellationToken)
             {
                 long? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -2764,11 +2764,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<long?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, long?> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<long?> Core(IAsyncEnumerable<TSource> source, Func<TSource, long?> selector, CancellationToken cancellationToken)
             {
                 long? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -2779,7 +2779,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = _selector(e.Current);
+                        value = selector(e.Current);
                     }
                     while (!value.HasValue);
 
@@ -2789,7 +2789,7 @@ namespace System.Linq
 
                     while (await e.MoveNextAsync())
                     {
-                        var cur = _selector(e.Current);
+                        var cur = selector(e.Current);
                         var x = cur.GetValueOrDefault();
 
                         // Do not replace & with &&. The branch prediction cost outweighs the extra operation
@@ -2815,11 +2815,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<long?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<long?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<long?> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<long?>> selector, CancellationToken cancellationToken)
             {
                 long? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -2830,7 +2830,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = await _selector(e.Current).ConfigureAwait(false);
+                        value = await selector(e.Current).ConfigureAwait(false);
                     }
                     while (!value.HasValue);
 
@@ -2840,7 +2840,7 @@ namespace System.Linq
 
                     while (await e.MoveNextAsync())
                     {
-                        var cur = await _selector(e.Current).ConfigureAwait(false);
+                        var cur = await selector(e.Current).ConfigureAwait(false);
                         var x = cur.GetValueOrDefault();
 
                         // Do not replace & with &&. The branch prediction cost outweighs the extra operation
@@ -2867,11 +2867,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<long?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<long?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<long?> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<long?>> selector, CancellationToken cancellationToken)
             {
                 long? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -2882,7 +2882,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        value = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                     }
                     while (!value.HasValue);
 
@@ -2892,7 +2892,7 @@ namespace System.Linq
 
                     while (await e.MoveNextAsync())
                     {
-                        var cur = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        var cur = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                         var x = cur.GetValueOrDefault();
 
                         // Do not replace & with &&. The branch prediction cost outweighs the extra operation
@@ -2917,11 +2917,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<float> Core(IAsyncEnumerable<float> _source, CancellationToken _cancellationToken)
+            static async ValueTask<float> Core(IAsyncEnumerable<float> source, CancellationToken cancellationToken)
             {
                 float value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
@@ -2969,22 +2969,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<float> Core(IAsyncEnumerable<TSource> _source, Func<TSource, float> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<float> Core(IAsyncEnumerable<TSource> source, Func<TSource, float> selector, CancellationToken cancellationToken)
             {
                 float value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = _selector(e.Current);
+                    value = selector(e.Current);
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = _selector(e.Current);
+                        var x = selector(e.Current);
                         if (x < value)
                         {
                             value = x;
@@ -3021,22 +3021,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<float> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<float>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<float> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<float>> selector, CancellationToken cancellationToken)
             {
                 float value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = await _selector(e.Current).ConfigureAwait(false);
+                    value = await selector(e.Current).ConfigureAwait(false);
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = await _selector(e.Current).ConfigureAwait(false);
+                        var x = await selector(e.Current).ConfigureAwait(false);
                         if (x < value)
                         {
                             value = x;
@@ -3074,22 +3074,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<float> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<float>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<float> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<float>> selector, CancellationToken cancellationToken)
             {
                 float value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                    value = await selector(e.Current, cancellationToken).ConfigureAwait(false);
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        var x = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                         if (x < value)
                         {
                             value = x;
@@ -3125,11 +3125,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<float?> Core(IAsyncEnumerable<float?> _source, CancellationToken _cancellationToken)
+            static async ValueTask<float?> Core(IAsyncEnumerable<float?> source, CancellationToken cancellationToken)
             {
                 float? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -3192,11 +3192,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<float?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, float?> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<float?> Core(IAsyncEnumerable<TSource> source, Func<TSource, float?> selector, CancellationToken cancellationToken)
             {
                 float? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -3207,7 +3207,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = _selector(e.Current);
+                        value = selector(e.Current);
                     }
                     while (!value.HasValue);
 
@@ -3217,7 +3217,7 @@ namespace System.Linq
 
                     while (await e.MoveNextAsync())
                     {
-                        var cur = _selector(e.Current);
+                        var cur = selector(e.Current);
                         if (cur.HasValue)
                         {
                             var x = cur.GetValueOrDefault();
@@ -3259,11 +3259,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<float?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<float?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<float?> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<float?>> selector, CancellationToken cancellationToken)
             {
                 float? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -3274,7 +3274,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = await _selector(e.Current).ConfigureAwait(false);
+                        value = await selector(e.Current).ConfigureAwait(false);
                     }
                     while (!value.HasValue);
 
@@ -3284,7 +3284,7 @@ namespace System.Linq
 
                     while (await e.MoveNextAsync())
                     {
-                        var cur = await _selector(e.Current).ConfigureAwait(false);
+                        var cur = await selector(e.Current).ConfigureAwait(false);
                         if (cur.HasValue)
                         {
                             var x = cur.GetValueOrDefault();
@@ -3327,11 +3327,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<float?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<float?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<float?> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<float?>> selector, CancellationToken cancellationToken)
             {
                 float? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -3342,7 +3342,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        value = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                     }
                     while (!value.HasValue);
 
@@ -3352,7 +3352,7 @@ namespace System.Linq
 
                     while (await e.MoveNextAsync())
                     {
-                        var cur = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        var cur = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                         if (cur.HasValue)
                         {
                             var x = cur.GetValueOrDefault();
@@ -3393,11 +3393,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<double> Core(IAsyncEnumerable<double> _source, CancellationToken _cancellationToken)
+            static async ValueTask<double> Core(IAsyncEnumerable<double> source, CancellationToken cancellationToken)
             {
                 double value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
@@ -3445,22 +3445,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double> Core(IAsyncEnumerable<TSource> _source, Func<TSource, double> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double> Core(IAsyncEnumerable<TSource> source, Func<TSource, double> selector, CancellationToken cancellationToken)
             {
                 double value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = _selector(e.Current);
+                    value = selector(e.Current);
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = _selector(e.Current);
+                        var x = selector(e.Current);
                         if (x < value)
                         {
                             value = x;
@@ -3497,22 +3497,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<double>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<double>> selector, CancellationToken cancellationToken)
             {
                 double value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = await _selector(e.Current).ConfigureAwait(false);
+                    value = await selector(e.Current).ConfigureAwait(false);
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = await _selector(e.Current).ConfigureAwait(false);
+                        var x = await selector(e.Current).ConfigureAwait(false);
                         if (x < value)
                         {
                             value = x;
@@ -3550,22 +3550,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<double>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<double>> selector, CancellationToken cancellationToken)
             {
                 double value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                    value = await selector(e.Current, cancellationToken).ConfigureAwait(false);
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        var x = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                         if (x < value)
                         {
                             value = x;
@@ -3601,11 +3601,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<double?> Core(IAsyncEnumerable<double?> _source, CancellationToken _cancellationToken)
+            static async ValueTask<double?> Core(IAsyncEnumerable<double?> source, CancellationToken cancellationToken)
             {
                 double? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -3668,11 +3668,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, double?> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> source, Func<TSource, double?> selector, CancellationToken cancellationToken)
             {
                 double? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -3683,7 +3683,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = _selector(e.Current);
+                        value = selector(e.Current);
                     }
                     while (!value.HasValue);
 
@@ -3693,7 +3693,7 @@ namespace System.Linq
 
                     while (await e.MoveNextAsync())
                     {
-                        var cur = _selector(e.Current);
+                        var cur = selector(e.Current);
                         if (cur.HasValue)
                         {
                             var x = cur.GetValueOrDefault();
@@ -3735,11 +3735,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<double?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<double?>> selector, CancellationToken cancellationToken)
             {
                 double? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -3750,7 +3750,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = await _selector(e.Current).ConfigureAwait(false);
+                        value = await selector(e.Current).ConfigureAwait(false);
                     }
                     while (!value.HasValue);
 
@@ -3760,7 +3760,7 @@ namespace System.Linq
 
                     while (await e.MoveNextAsync())
                     {
-                        var cur = await _selector(e.Current).ConfigureAwait(false);
+                        var cur = await selector(e.Current).ConfigureAwait(false);
                         if (cur.HasValue)
                         {
                             var x = cur.GetValueOrDefault();
@@ -3803,11 +3803,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<double?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<double?>> selector, CancellationToken cancellationToken)
             {
                 double? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -3818,7 +3818,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        value = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                     }
                     while (!value.HasValue);
 
@@ -3828,7 +3828,7 @@ namespace System.Linq
 
                     while (await e.MoveNextAsync())
                     {
-                        var cur = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        var cur = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                         if (cur.HasValue)
                         {
                             var x = cur.GetValueOrDefault();
@@ -3869,11 +3869,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<decimal> Core(IAsyncEnumerable<decimal> _source, CancellationToken _cancellationToken)
+            static async ValueTask<decimal> Core(IAsyncEnumerable<decimal> source, CancellationToken cancellationToken)
             {
                 decimal value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
@@ -3905,22 +3905,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<decimal> Core(IAsyncEnumerable<TSource> _source, Func<TSource, decimal> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<decimal> Core(IAsyncEnumerable<TSource> source, Func<TSource, decimal> selector, CancellationToken cancellationToken)
             {
                 decimal value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = _selector(e.Current);
+                    value = selector(e.Current);
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = _selector(e.Current);
+                        var x = selector(e.Current);
                         if (x < value)
                         {
                             value = x;
@@ -3941,22 +3941,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<decimal> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<decimal>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<decimal> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<decimal>> selector, CancellationToken cancellationToken)
             {
                 decimal value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = await _selector(e.Current).ConfigureAwait(false);
+                    value = await selector(e.Current).ConfigureAwait(false);
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = await _selector(e.Current).ConfigureAwait(false);
+                        var x = await selector(e.Current).ConfigureAwait(false);
                         if (x < value)
                         {
                             value = x;
@@ -3978,22 +3978,22 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<decimal> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<decimal>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<decimal> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<decimal>> selector, CancellationToken cancellationToken)
             {
                 decimal value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
                         throw Error.NoElements();
                     }
 
-                    value = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                    value = await selector(e.Current, cancellationToken).ConfigureAwait(false);
 
                     while (await e.MoveNextAsync())
                     {
-                        var x = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        var x = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                         if (x < value)
                         {
                             value = x;
@@ -4013,11 +4013,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<decimal?> Core(IAsyncEnumerable<decimal?> _source, CancellationToken _cancellationToken)
+            static async ValueTask<decimal?> Core(IAsyncEnumerable<decimal?> source, CancellationToken cancellationToken)
             {
                 decimal? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -4062,11 +4062,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<decimal?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, decimal?> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<decimal?> Core(IAsyncEnumerable<TSource> source, Func<TSource, decimal?> selector, CancellationToken cancellationToken)
             {
                 decimal? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -4077,7 +4077,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = _selector(e.Current);
+                        value = selector(e.Current);
                     }
                     while (!value.HasValue);
 
@@ -4087,7 +4087,7 @@ namespace System.Linq
 
                     while (await e.MoveNextAsync())
                     {
-                        var cur = _selector(e.Current);
+                        var cur = selector(e.Current);
                         var x = cur.GetValueOrDefault();
 
                         if (cur.HasValue && x < valueVal)
@@ -4111,11 +4111,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<decimal?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<decimal?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<decimal?> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<decimal?>> selector, CancellationToken cancellationToken)
             {
                 decimal? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -4126,7 +4126,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = await _selector(e.Current).ConfigureAwait(false);
+                        value = await selector(e.Current).ConfigureAwait(false);
                     }
                     while (!value.HasValue);
 
@@ -4136,7 +4136,7 @@ namespace System.Linq
 
                     while (await e.MoveNextAsync())
                     {
-                        var cur = await _selector(e.Current).ConfigureAwait(false);
+                        var cur = await selector(e.Current).ConfigureAwait(false);
                         var x = cur.GetValueOrDefault();
 
                         if (cur.HasValue && x < valueVal)
@@ -4161,11 +4161,11 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<decimal?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<decimal?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<decimal?> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<decimal?>> selector, CancellationToken cancellationToken)
             {
                 decimal? value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -4176,7 +4176,7 @@ namespace System.Linq
                             return value;
                         }
 
-                        value = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        value = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                     }
                     while (!value.HasValue);
 
@@ -4186,7 +4186,7 @@ namespace System.Linq
 
                     while (await e.MoveNextAsync())
                     {
-                        var cur = await _selector(e.Current, _cancellationToken).ConfigureAwait(false);
+                        var cur = await selector(e.Current, cancellationToken).ConfigureAwait(false);
                         var x = cur.GetValueOrDefault();
 
                         if (cur.HasValue && x < valueVal)

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/MinMax.Generated.tt
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/MinMax.Generated.tt
@@ -35,7 +35,7 @@ foreach (var m in new[] { "Max", "Min" })
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<<#=t#>> Core(IAsyncEnumerable<<#=t#>> _source, CancellationToken _cancellationToken)
+            static async ValueTask<<#=t#>> Core(IAsyncEnumerable<<#=t#>> source, CancellationToken cancellationToken)
             {
 <#
         if (!isNullable)
@@ -43,7 +43,7 @@ foreach (var m in new[] { "Max", "Min" })
 #>
                 <#=t#> value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
@@ -115,7 +115,7 @@ foreach (var m in new[] { "Max", "Min" })
 #>
                 <#=t#> value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.
@@ -279,9 +279,9 @@ foreach (var m in new[] { "Max", "Min" })
 
 <#
 foreach (var overload in new[] {
-    new { selector = "Func<TSource, " + t + ">", invoke = "_selector(e.Current)" },
-    new { selector = "Func<TSource, ValueTask<" + t + ">>", invoke = "await _selector(e.Current).ConfigureAwait(false)" },
-    new { selector = "Func<TSource, CancellationToken, ValueTask<" + t + ">>", invoke = "await _selector(e.Current, _cancellationToken).ConfigureAwait(false)" },
+    new { selector = "Func<TSource, " + t + ">", invoke = "selector(e.Current)" },
+    new { selector = "Func<TSource, ValueTask<" + t + ">>", invoke = "await selector(e.Current).ConfigureAwait(false)" },
+    new { selector = "Func<TSource, CancellationToken, ValueTask<" + t + ">>", invoke = "await selector(e.Current, cancellationToken).ConfigureAwait(false)" },
 })
 {
     var isAsync = overload.invoke.StartsWith("await");
@@ -307,7 +307,7 @@ foreach (var overload in new[] {
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<<#=t#>> Core(IAsyncEnumerable<TSource> _source, <#=overload.selector#> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<<#=t#>> Core(IAsyncEnumerable<TSource> source, <#=overload.selector#> selector, CancellationToken cancellationToken)
             {
 <#
         if (!isNullable)
@@ -315,7 +315,7 @@ foreach (var overload in new[] {
 #>
                 <#=t#> value;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
@@ -387,7 +387,7 @@ foreach (var overload in new[] {
 #>
                 <#=t#> value = null;
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     // Start off knowing that we've a non-null value (or exit here, knowing we don't)
                     // so we don't have to keep testing for nullity.

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/SequenceEqual.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/SequenceEqual.cs
@@ -50,15 +50,15 @@ namespace System.Linq
 
             return Core(first, second, comparer, cancellationToken);
 
-            static async ValueTask<bool> Core(IAsyncEnumerable<TSource> _first, IAsyncEnumerable<TSource> _second, IEqualityComparer<TSource> _comparer, CancellationToken _cancellationToken)
+            static async ValueTask<bool> Core(IAsyncEnumerable<TSource> first, IAsyncEnumerable<TSource> second, IEqualityComparer<TSource> comparer, CancellationToken cancellationToken)
             {
-                await using (var e1 = _first.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e1 = first.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
-                    await using (var e2 = _second.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                    await using (var e2 = second.GetConfiguredAsyncEnumerator(cancellationToken, false))
                     {
                         while (await e1.MoveNextAsync())
                         {
-                            if (!(await e2.MoveNextAsync() && _comparer.Equals(e1.Current, e2.Current)))
+                            if (!(await e2.MoveNextAsync() && comparer.Equals(e1.Current, e2.Current)))
                             {
                                 return false;
                             }

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/Single.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/Single.cs
@@ -17,9 +17,9 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, CancellationToken _cancellationToken)
+            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
             {
-                if (_source is IList<TSource> list)
+                if (source is IList<TSource> list)
                 {
                     switch (list.Count)
                     {
@@ -30,7 +30,7 @@ namespace System.Linq
                     throw Error.MoreThanOneElement();
                 }
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
@@ -58,19 +58,19 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, Func<TSource, bool> _predicate, CancellationToken _cancellationToken)
+            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
                         var result = e.Current;
 
-                        if (_predicate(result))
+                        if (predicate(result))
                         {
                             while (await e.MoveNextAsync())
                             {
-                                if (_predicate(e.Current))
+                                if (predicate(e.Current))
                                 {
                                     throw Error.MoreThanOneElement();
                                 }
@@ -94,19 +94,19 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<bool>> _predicate, CancellationToken _cancellationToken)
+            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<bool>> predicate, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
                         var result = e.Current;
 
-                        if (await _predicate(result).ConfigureAwait(false))
+                        if (await predicate(result).ConfigureAwait(false))
                         {
                             while (await e.MoveNextAsync())
                             {
-                                if (await _predicate(e.Current).ConfigureAwait(false))
+                                if (await predicate(e.Current).ConfigureAwait(false))
                                 {
                                     throw Error.MoreThanOneElement();
                                 }
@@ -131,19 +131,19 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<bool>> _predicate, CancellationToken _cancellationToken)
+            static async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<bool>> predicate, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
                         var result = e.Current;
 
-                        if (await _predicate(result, _cancellationToken).ConfigureAwait(false))
+                        if (await predicate(result, cancellationToken).ConfigureAwait(false))
                         {
                             while (await e.MoveNextAsync())
                             {
-                                if (await _predicate(e.Current, _cancellationToken).ConfigureAwait(false))
+                                if (await predicate(e.Current, cancellationToken).ConfigureAwait(false))
                                 {
                                     throw Error.MoreThanOneElement();
                                 }

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/SingleOrDefault.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/SingleOrDefault.cs
@@ -17,9 +17,9 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, CancellationToken _cancellationToken)
+            async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
             {
-                if (_source is IList<TSource> list)
+                if (source is IList<TSource> list)
                 {
                     switch (list.Count)
                     {
@@ -30,7 +30,7 @@ namespace System.Linq
                     throw Error.MoreThanOneElement();
                 }
 
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     if (!await e.MoveNextAsync())
                     {
@@ -58,19 +58,19 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, Func<TSource, bool> _predicate, CancellationToken _cancellationToken)
+            async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
                         var result = e.Current;
 
-                        if (_predicate(result))
+                        if (predicate(result))
                         {
                             while (await e.MoveNextAsync())
                             {
-                                if (_predicate(e.Current))
+                                if (predicate(e.Current))
                                 {
                                     throw Error.MoreThanOneElement();
                                 }
@@ -94,19 +94,19 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<bool>> _predicate, CancellationToken _cancellationToken)
+            async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<bool>> predicate, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
                         var result = e.Current;
 
-                        if (await _predicate(result).ConfigureAwait(false))
+                        if (await predicate(result).ConfigureAwait(false))
                         {
                             while (await e.MoveNextAsync())
                             {
-                                if (await _predicate(e.Current).ConfigureAwait(false))
+                                if (await predicate(e.Current).ConfigureAwait(false))
                                 {
                                     throw Error.MoreThanOneElement();
                                 }
@@ -131,19 +131,19 @@ namespace System.Linq
 
             return Core(source, predicate, cancellationToken);
 
-            async ValueTask<TSource> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<bool>> _predicate, CancellationToken _cancellationToken)
+            async ValueTask<TSource> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<bool>> predicate, CancellationToken cancellationToken)
             {
-                await using (var e = _source.GetConfiguredAsyncEnumerator(_cancellationToken, false))
+                await using (var e = source.GetConfiguredAsyncEnumerator(cancellationToken, false))
                 {
                     while (await e.MoveNextAsync())
                     {
                         var result = e.Current;
 
-                        if (await _predicate(result, _cancellationToken).ConfigureAwait(false))
+                        if (await predicate(result, cancellationToken).ConfigureAwait(false))
                         {
                             while (await e.MoveNextAsync())
                             {
-                                if (await _predicate(e.Current, _cancellationToken).ConfigureAwait(false))
+                                if (await predicate(e.Current, cancellationToken).ConfigureAwait(false))
                                 {
                                     throw Error.MoreThanOneElement();
                                 }

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/Sum.Generated.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/Sum.Generated.cs
@@ -17,11 +17,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<int> Core(IAsyncEnumerable<int> _source, CancellationToken _cancellationToken)
+            static async ValueTask<int> Core(IAsyncEnumerable<int> source, CancellationToken cancellationToken)
             {
                 var sum = 0;
 
-                await foreach (int value in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (int value in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
                     checked
                     {
@@ -42,13 +42,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<int> Core(IAsyncEnumerable<TSource> _source, Func<TSource, int> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<int> Core(IAsyncEnumerable<TSource> source, Func<TSource, int> selector, CancellationToken cancellationToken)
             {
                 var sum = 0;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = _selector(item);
+                    var value = selector(item);
 
                     checked
                     {
@@ -69,13 +69,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<int> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<int>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<int> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<int>> selector, CancellationToken cancellationToken)
             {
                 var sum = 0;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = await _selector(item).ConfigureAwait(false);
+                    var value = await selector(item).ConfigureAwait(false);
 
                     checked
                     {
@@ -97,13 +97,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<int> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<int>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<int> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<int>> selector, CancellationToken cancellationToken)
             {
                 var sum = 0;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = await _selector(item, _cancellationToken).ConfigureAwait(false);
+                    var value = await selector(item, cancellationToken).ConfigureAwait(false);
 
                     checked
                     {
@@ -123,11 +123,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<long> Core(IAsyncEnumerable<long> _source, CancellationToken _cancellationToken)
+            static async ValueTask<long> Core(IAsyncEnumerable<long> source, CancellationToken cancellationToken)
             {
                 var sum = 0L;
 
-                await foreach (long value in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (long value in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
                     checked
                     {
@@ -148,13 +148,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<long> Core(IAsyncEnumerable<TSource> _source, Func<TSource, long> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<long> Core(IAsyncEnumerable<TSource> source, Func<TSource, long> selector, CancellationToken cancellationToken)
             {
                 var sum = 0L;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = _selector(item);
+                    var value = selector(item);
 
                     checked
                     {
@@ -175,13 +175,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<long> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<long>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<long> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<long>> selector, CancellationToken cancellationToken)
             {
                 var sum = 0L;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = await _selector(item).ConfigureAwait(false);
+                    var value = await selector(item).ConfigureAwait(false);
 
                     checked
                     {
@@ -203,13 +203,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<long> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<long>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<long> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<long>> selector, CancellationToken cancellationToken)
             {
                 var sum = 0L;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = await _selector(item, _cancellationToken).ConfigureAwait(false);
+                    var value = await selector(item, cancellationToken).ConfigureAwait(false);
 
                     checked
                     {
@@ -229,11 +229,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<float> Core(IAsyncEnumerable<float> _source, CancellationToken _cancellationToken)
+            static async ValueTask<float> Core(IAsyncEnumerable<float> source, CancellationToken cancellationToken)
             {
                 var sum = 0.0f;
 
-                await foreach (float value in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (float value in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
                     sum += value;
                 }
@@ -251,13 +251,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<float> Core(IAsyncEnumerable<TSource> _source, Func<TSource, float> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<float> Core(IAsyncEnumerable<TSource> source, Func<TSource, float> selector, CancellationToken cancellationToken)
             {
                 var sum = 0.0f;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = _selector(item);
+                    var value = selector(item);
 
                     sum += value;
                 }
@@ -275,13 +275,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<float> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<float>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<float> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<float>> selector, CancellationToken cancellationToken)
             {
                 var sum = 0.0f;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = await _selector(item).ConfigureAwait(false);
+                    var value = await selector(item).ConfigureAwait(false);
 
                     sum += value;
                 }
@@ -300,13 +300,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<float> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<float>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<float> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<float>> selector, CancellationToken cancellationToken)
             {
                 var sum = 0.0f;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = await _selector(item, _cancellationToken).ConfigureAwait(false);
+                    var value = await selector(item, cancellationToken).ConfigureAwait(false);
 
                     sum += value;
                 }
@@ -323,11 +323,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<double> Core(IAsyncEnumerable<double> _source, CancellationToken _cancellationToken)
+            static async ValueTask<double> Core(IAsyncEnumerable<double> source, CancellationToken cancellationToken)
             {
                 var sum = 0.0;
 
-                await foreach (double value in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (double value in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
                     sum += value;
                 }
@@ -345,13 +345,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double> Core(IAsyncEnumerable<TSource> _source, Func<TSource, double> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double> Core(IAsyncEnumerable<TSource> source, Func<TSource, double> selector, CancellationToken cancellationToken)
             {
                 var sum = 0.0;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = _selector(item);
+                    var value = selector(item);
 
                     sum += value;
                 }
@@ -369,13 +369,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<double>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<double>> selector, CancellationToken cancellationToken)
             {
                 var sum = 0.0;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = await _selector(item).ConfigureAwait(false);
+                    var value = await selector(item).ConfigureAwait(false);
 
                     sum += value;
                 }
@@ -394,13 +394,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<double>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<double>> selector, CancellationToken cancellationToken)
             {
                 var sum = 0.0;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = await _selector(item, _cancellationToken).ConfigureAwait(false);
+                    var value = await selector(item, cancellationToken).ConfigureAwait(false);
 
                     sum += value;
                 }
@@ -417,11 +417,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<decimal> Core(IAsyncEnumerable<decimal> _source, CancellationToken _cancellationToken)
+            static async ValueTask<decimal> Core(IAsyncEnumerable<decimal> source, CancellationToken cancellationToken)
             {
                 var sum = 0m;
 
-                await foreach (decimal value in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (decimal value in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
                     sum += value;
                 }
@@ -439,13 +439,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<decimal> Core(IAsyncEnumerable<TSource> _source, Func<TSource, decimal> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<decimal> Core(IAsyncEnumerable<TSource> source, Func<TSource, decimal> selector, CancellationToken cancellationToken)
             {
                 var sum = 0m;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = _selector(item);
+                    var value = selector(item);
 
                     sum += value;
                 }
@@ -463,13 +463,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<decimal> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<decimal>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<decimal> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<decimal>> selector, CancellationToken cancellationToken)
             {
                 var sum = 0m;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = await _selector(item).ConfigureAwait(false);
+                    var value = await selector(item).ConfigureAwait(false);
 
                     sum += value;
                 }
@@ -488,13 +488,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<decimal> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<decimal>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<decimal> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<decimal>> selector, CancellationToken cancellationToken)
             {
                 var sum = 0m;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = await _selector(item, _cancellationToken).ConfigureAwait(false);
+                    var value = await selector(item, cancellationToken).ConfigureAwait(false);
 
                     sum += value;
                 }
@@ -511,11 +511,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<int?> Core(IAsyncEnumerable<int?> _source, CancellationToken _cancellationToken)
+            static async ValueTask<int?> Core(IAsyncEnumerable<int?> source, CancellationToken cancellationToken)
             {
                 var sum = 0;
 
-                await foreach (int? value in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (int? value in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
                     checked
                     {
@@ -536,13 +536,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<int?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, int?> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<int?> Core(IAsyncEnumerable<TSource> source, Func<TSource, int?> selector, CancellationToken cancellationToken)
             {
                 var sum = 0;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = _selector(item);
+                    var value = selector(item);
 
                     checked
                     {
@@ -563,13 +563,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<int?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<int?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<int?> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<int?>> selector, CancellationToken cancellationToken)
             {
                 var sum = 0;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = await _selector(item).ConfigureAwait(false);
+                    var value = await selector(item).ConfigureAwait(false);
 
                     checked
                     {
@@ -591,13 +591,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<int?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<int?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<int?> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<int?>> selector, CancellationToken cancellationToken)
             {
                 var sum = 0;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = await _selector(item, _cancellationToken).ConfigureAwait(false);
+                    var value = await selector(item, cancellationToken).ConfigureAwait(false);
 
                     checked
                     {
@@ -617,11 +617,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<long?> Core(IAsyncEnumerable<long?> _source, CancellationToken _cancellationToken)
+            static async ValueTask<long?> Core(IAsyncEnumerable<long?> source, CancellationToken cancellationToken)
             {
                 var sum = 0L;
 
-                await foreach (long? value in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (long? value in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
                     checked
                     {
@@ -642,13 +642,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<long?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, long?> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<long?> Core(IAsyncEnumerable<TSource> source, Func<TSource, long?> selector, CancellationToken cancellationToken)
             {
                 var sum = 0L;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = _selector(item);
+                    var value = selector(item);
 
                     checked
                     {
@@ -669,13 +669,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<long?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<long?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<long?> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<long?>> selector, CancellationToken cancellationToken)
             {
                 var sum = 0L;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = await _selector(item).ConfigureAwait(false);
+                    var value = await selector(item).ConfigureAwait(false);
 
                     checked
                     {
@@ -697,13 +697,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<long?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<long?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<long?> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<long?>> selector, CancellationToken cancellationToken)
             {
                 var sum = 0L;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = await _selector(item, _cancellationToken).ConfigureAwait(false);
+                    var value = await selector(item, cancellationToken).ConfigureAwait(false);
 
                     checked
                     {
@@ -723,11 +723,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<float?> Core(IAsyncEnumerable<float?> _source, CancellationToken _cancellationToken)
+            static async ValueTask<float?> Core(IAsyncEnumerable<float?> source, CancellationToken cancellationToken)
             {
                 var sum = 0.0f;
 
-                await foreach (float? value in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (float? value in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
                     sum += value.GetValueOrDefault();
                 }
@@ -745,13 +745,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<float?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, float?> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<float?> Core(IAsyncEnumerable<TSource> source, Func<TSource, float?> selector, CancellationToken cancellationToken)
             {
                 var sum = 0.0f;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = _selector(item);
+                    var value = selector(item);
 
                     sum += value.GetValueOrDefault();
                 }
@@ -769,13 +769,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<float?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<float?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<float?> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<float?>> selector, CancellationToken cancellationToken)
             {
                 var sum = 0.0f;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = await _selector(item).ConfigureAwait(false);
+                    var value = await selector(item).ConfigureAwait(false);
 
                     sum += value.GetValueOrDefault();
                 }
@@ -794,13 +794,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<float?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<float?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<float?> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<float?>> selector, CancellationToken cancellationToken)
             {
                 var sum = 0.0f;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = await _selector(item, _cancellationToken).ConfigureAwait(false);
+                    var value = await selector(item, cancellationToken).ConfigureAwait(false);
 
                     sum += value.GetValueOrDefault();
                 }
@@ -817,11 +817,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<double?> Core(IAsyncEnumerable<double?> _source, CancellationToken _cancellationToken)
+            static async ValueTask<double?> Core(IAsyncEnumerable<double?> source, CancellationToken cancellationToken)
             {
                 var sum = 0.0;
 
-                await foreach (double? value in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (double? value in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
                     sum += value.GetValueOrDefault();
                 }
@@ -839,13 +839,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, double?> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> source, Func<TSource, double?> selector, CancellationToken cancellationToken)
             {
                 var sum = 0.0;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = _selector(item);
+                    var value = selector(item);
 
                     sum += value.GetValueOrDefault();
                 }
@@ -863,13 +863,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<double?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<double?>> selector, CancellationToken cancellationToken)
             {
                 var sum = 0.0;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = await _selector(item).ConfigureAwait(false);
+                    var value = await selector(item).ConfigureAwait(false);
 
                     sum += value.GetValueOrDefault();
                 }
@@ -888,13 +888,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<double?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<double?> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<double?>> selector, CancellationToken cancellationToken)
             {
                 var sum = 0.0;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = await _selector(item, _cancellationToken).ConfigureAwait(false);
+                    var value = await selector(item, cancellationToken).ConfigureAwait(false);
 
                     sum += value.GetValueOrDefault();
                 }
@@ -911,11 +911,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<decimal?> Core(IAsyncEnumerable<decimal?> _source, CancellationToken _cancellationToken)
+            static async ValueTask<decimal?> Core(IAsyncEnumerable<decimal?> source, CancellationToken cancellationToken)
             {
                 var sum = 0m;
 
-                await foreach (decimal? value in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (decimal? value in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
                     sum += value.GetValueOrDefault();
                 }
@@ -933,13 +933,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<decimal?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, decimal?> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<decimal?> Core(IAsyncEnumerable<TSource> source, Func<TSource, decimal?> selector, CancellationToken cancellationToken)
             {
                 var sum = 0m;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = _selector(item);
+                    var value = selector(item);
 
                     sum += value.GetValueOrDefault();
                 }
@@ -957,13 +957,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<decimal?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<decimal?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<decimal?> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<decimal?>> selector, CancellationToken cancellationToken)
             {
                 var sum = 0m;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = await _selector(item).ConfigureAwait(false);
+                    var value = await selector(item).ConfigureAwait(false);
 
                     sum += value.GetValueOrDefault();
                 }
@@ -982,13 +982,13 @@ namespace System.Linq
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<decimal?> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<decimal?>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<decimal?> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<decimal?>> selector, CancellationToken cancellationToken)
             {
                 var sum = 0m;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = await _selector(item, _cancellationToken).ConfigureAwait(false);
+                    var value = await selector(item, cancellationToken).ConfigureAwait(false);
 
                     sum += value.GetValueOrDefault();
                 }

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/Sum.Generated.tt
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/Sum.Generated.tt
@@ -42,11 +42,11 @@ foreach (var o in os)
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<<#=o.type#>> Core(IAsyncEnumerable<<#=o.type#>> _source, CancellationToken _cancellationToken)
+            static async ValueTask<<#=o.type#>> Core(IAsyncEnumerable<<#=o.type#>> source, CancellationToken cancellationToken)
             {
                 var sum = <#=o.zero#>;
 
-                await foreach (<#=o.type#> value in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (<#=o.type#> value in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
 <#
 if (o.@checked)
@@ -80,13 +80,13 @@ else
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<<#=o.type#>> Core(IAsyncEnumerable<TSource> _source, Func<TSource, <#=o.type#>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<<#=o.type#>> Core(IAsyncEnumerable<TSource> source, Func<TSource, <#=o.type#>> selector, CancellationToken cancellationToken)
             {
                 var sum = <#=o.zero#>;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = _selector(item);
+                    var value = selector(item);
 
 <#
 if (o.@checked)
@@ -111,8 +111,7 @@ else
             }
         }
 
-        internal static ValueTask<<#=o.type#>> SumAsyncCore<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<<#=o.type#>>> selector, CancellationToken cancellationToken = default)
-
+        internal static ValueTask<<#=o.type#>> SumAwaitAsyncCore<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<<#=o.type#>>> selector, CancellationToken cancellationToken = default)
         {
             if (source == null)
                 throw Error.ArgumentNull(nameof(source));
@@ -121,13 +120,13 @@ else
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<<#=o.type#>> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<<#=o.type#>>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<<#=o.type#>> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<<#=o.type#>>> selector, CancellationToken cancellationToken)
             {
                 var sum = <#=o.zero#>;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = await _selector(item).ConfigureAwait(false);
+                    var value = await selector(item).ConfigureAwait(false);
 
 <#
 if (o.@checked)
@@ -153,8 +152,7 @@ else
         }
 
 #if !NO_DEEP_CANCELLATION
-        internal static ValueTask<<#=o.type#>> SumWithCancellationAsyncCore<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<<#=o.type#>>> selector, CancellationToken cancellationToken = default)
-
+        internal static ValueTask<<#=o.type#>> SumAwaitWithCancellationAsyncCore<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<<#=o.type#>>> selector, CancellationToken cancellationToken = default)
         {
             if (source == null)
                 throw Error.ArgumentNull(nameof(source));
@@ -163,13 +161,13 @@ else
 
             return Core(source, selector, cancellationToken);
 
-            static async ValueTask<<#=o.type#>> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<<#=o.type#>>> _selector, CancellationToken _cancellationToken)
+            static async ValueTask<<#=o.type#>> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<<#=o.type#>>> selector, CancellationToken cancellationToken)
             {
                 var sum = <#=o.zero#>;
 
-                await foreach (TSource item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var value = await _selector(item, _cancellationToken).ConfigureAwait(false);
+                    var value = await selector(item, cancellationToken).ConfigureAwait(false);
 
 <#
 if (o.@checked)

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/ToDictionary.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/ToDictionary.cs
@@ -22,13 +22,13 @@ namespace System.Linq
 
             return Core(source, keySelector, comparer, cancellationToken);
 
-            static async ValueTask<Dictionary<TKey, TSource>> Core(IAsyncEnumerable<TSource> _source, Func<TSource, TKey> _keySelector, IEqualityComparer<TKey> _comparer, CancellationToken _cancellationToken)
+            static async ValueTask<Dictionary<TKey, TSource>> Core(IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
             {
-                var d = new Dictionary<TKey, TSource>(_comparer);
+                var d = new Dictionary<TKey, TSource>(comparer);
 
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var key = _keySelector(item);
+                    var key = keySelector(item);
 
                     d.Add(key, item);
                 }
@@ -49,13 +49,13 @@ namespace System.Linq
 
             return Core(source, keySelector, comparer, cancellationToken);
 
-            static async ValueTask<Dictionary<TKey, TSource>> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<TKey>> _keySelector, IEqualityComparer<TKey> _comparer, CancellationToken _cancellationToken)
+            static async ValueTask<Dictionary<TKey, TSource>> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
             {
-                var d = new Dictionary<TKey, TSource>(_comparer);
+                var d = new Dictionary<TKey, TSource>(comparer);
 
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var key = await _keySelector(item).ConfigureAwait(false);
+                    var key = await keySelector(item).ConfigureAwait(false);
 
                     d.Add(key, item);
                 }
@@ -77,13 +77,13 @@ namespace System.Linq
 
             return Core(source, keySelector, comparer, cancellationToken);
 
-            static async ValueTask<Dictionary<TKey, TSource>> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<TKey>> _keySelector, IEqualityComparer<TKey> _comparer, CancellationToken _cancellationToken)
+            static async ValueTask<Dictionary<TKey, TSource>> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<TKey>> keySelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
             {
-                var d = new Dictionary<TKey, TSource>(_comparer);
+                var d = new Dictionary<TKey, TSource>(comparer);
 
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var key = await _keySelector(item, _cancellationToken).ConfigureAwait(false);
+                    var key = await keySelector(item, cancellationToken).ConfigureAwait(false);
 
                     d.Add(key, item);
                 }
@@ -107,14 +107,14 @@ namespace System.Linq
 
             return Core(source, keySelector, elementSelector, comparer, cancellationToken);
 
-            static async ValueTask<Dictionary<TKey, TElement>> Core(IAsyncEnumerable<TSource> _source, Func<TSource, TKey> _keySelector, Func<TSource, TElement> _elementSelector, IEqualityComparer<TKey> _comparer, CancellationToken _cancellationToken)
+            static async ValueTask<Dictionary<TKey, TElement>> Core(IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
             {
-                var d = new Dictionary<TKey, TElement>(_comparer);
+                var d = new Dictionary<TKey, TElement>(comparer);
 
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var key = _keySelector(item);
-                    var value = _elementSelector(item);
+                    var key = keySelector(item);
+                    var value = elementSelector(item);
 
                     d.Add(key, value);
                 }
@@ -137,14 +137,14 @@ namespace System.Linq
 
             return Core(source, keySelector, elementSelector, comparer, cancellationToken);
 
-            static async ValueTask<Dictionary<TKey, TElement>> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<TKey>> _keySelector, Func<TSource, ValueTask<TElement>> _elementSelector, IEqualityComparer<TKey> _comparer, CancellationToken _cancellationToken)
+            static async ValueTask<Dictionary<TKey, TElement>> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
             {
-                var d = new Dictionary<TKey, TElement>(_comparer);
+                var d = new Dictionary<TKey, TElement>(comparer);
 
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var key = await _keySelector(item).ConfigureAwait(false);
-                    var value = await _elementSelector(item).ConfigureAwait(false);
+                    var key = await keySelector(item).ConfigureAwait(false);
+                    var value = await elementSelector(item).ConfigureAwait(false);
 
                     d.Add(key, value);
                 }
@@ -168,14 +168,14 @@ namespace System.Linq
 
             return Core(source, keySelector, elementSelector, comparer, cancellationToken);
 
-            static async ValueTask<Dictionary<TKey, TElement>> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<TKey>> _keySelector, Func<TSource, CancellationToken, ValueTask<TElement>> _elementSelector, IEqualityComparer<TKey> _comparer, CancellationToken _cancellationToken)
+            static async ValueTask<Dictionary<TKey, TElement>> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<TKey>> keySelector, Func<TSource, CancellationToken, ValueTask<TElement>> elementSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
             {
-                var d = new Dictionary<TKey, TElement>(_comparer);
+                var d = new Dictionary<TKey, TElement>(comparer);
 
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
-                    var key = await _keySelector(item, _cancellationToken).ConfigureAwait(false);
-                    var value = await _elementSelector(item, _cancellationToken).ConfigureAwait(false);
+                    var key = await keySelector(item, cancellationToken).ConfigureAwait(false);
+                    var value = await elementSelector(item, cancellationToken).ConfigureAwait(false);
 
                     d.Add(key, value);
                 }

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/ToHashSet.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/ToHashSet.cs
@@ -20,11 +20,11 @@ namespace System.Linq
 
             return Core(source, comparer, cancellationToken);
 
-            static async ValueTask<HashSet<TSource>> Core(IAsyncEnumerable<TSource> _source, IEqualityComparer<TSource> _comparer, CancellationToken _cancellationToken)
+            static async ValueTask<HashSet<TSource>> Core(IAsyncEnumerable<TSource> source, IEqualityComparer<TSource> comparer, CancellationToken cancellationToken)
             {
-                var set = new HashSet<TSource>(_comparer);
+                var set = new HashSet<TSource>(comparer);
 
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
                     set.Add(item);
                 }

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/ToList.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/ToList.cs
@@ -20,11 +20,11 @@ namespace System.Linq
 
             return Core(source, cancellationToken);
 
-            static async ValueTask<List<TSource>> Core(IAsyncEnumerable<TSource> _source, CancellationToken _cancellationToken)
+            static async ValueTask<List<TSource>> Core(IAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
             {
                 var list = new List<TSource>();
 
-                await foreach (var item in _source.WithCancellation(_cancellationToken).ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
                     list.Add(item);
                 }

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/ToLookup.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/ToLookup.cs
@@ -22,9 +22,9 @@ namespace System.Linq
 
             return Core(source, keySelector, comparer, cancellationToken);
 
-            static async ValueTask<ILookup<TKey, TSource>> Core(IAsyncEnumerable<TSource> _source, Func<TSource, TKey> _keySelector, IEqualityComparer<TKey> _comparer, CancellationToken _cancellationToken)
+            static async ValueTask<ILookup<TKey, TSource>> Core(IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
             {
-                return await Internal.Lookup<TKey, TSource>.CreateAsync(_source, _keySelector, _comparer, _cancellationToken).ConfigureAwait(false);
+                return await Internal.Lookup<TKey, TSource>.CreateAsync(source, keySelector, comparer, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -40,9 +40,9 @@ namespace System.Linq
 
             return Core(source, keySelector, comparer, cancellationToken);
 
-            async ValueTask<ILookup<TKey, TSource>> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<TKey>> _keySelector, IEqualityComparer<TKey> _comparer, CancellationToken _cancellationToken)
+            async ValueTask<ILookup<TKey, TSource>> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
             {
-                return await Internal.LookupWithTask<TKey, TSource>.CreateAsync(_source, _keySelector, _comparer, _cancellationToken).ConfigureAwait(false);
+                return await Internal.LookupWithTask<TKey, TSource>.CreateAsync(source, keySelector, comparer, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -59,9 +59,9 @@ namespace System.Linq
 
             return Core(source, keySelector, comparer, cancellationToken);
 
-            static async ValueTask<ILookup<TKey, TSource>> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<TKey>> _keySelector, IEqualityComparer<TKey> _comparer, CancellationToken _cancellationToken)
+            static async ValueTask<ILookup<TKey, TSource>> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<TKey>> keySelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
             {
-                return await Internal.LookupWithTask<TKey, TSource>.CreateAsync(_source, _keySelector, _comparer, _cancellationToken).ConfigureAwait(false);
+                return await Internal.LookupWithTask<TKey, TSource>.CreateAsync(source, keySelector, comparer, cancellationToken).ConfigureAwait(false);
             }
         }
 #endif
@@ -80,9 +80,9 @@ namespace System.Linq
 
             return Core(source, keySelector, elementSelector, comparer, cancellationToken);
 
-            static async ValueTask<ILookup<TKey, TElement>> Core(IAsyncEnumerable<TSource> _source, Func<TSource, TKey> _keySelector, Func<TSource, TElement> _elementSelector, IEqualityComparer<TKey> _comparer, CancellationToken _cancellationToken)
+            static async ValueTask<ILookup<TKey, TElement>> Core(IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
             {
-                return await Internal.Lookup<TKey, TElement>.CreateAsync(_source, _keySelector, _elementSelector, _comparer, _cancellationToken).ConfigureAwait(false);
+                return await Internal.Lookup<TKey, TElement>.CreateAsync(source, keySelector, elementSelector, comparer, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -100,9 +100,9 @@ namespace System.Linq
 
             return Core(source, keySelector, elementSelector, comparer, cancellationToken);
 
-            static async ValueTask<ILookup<TKey, TElement>> Core(IAsyncEnumerable<TSource> _source, Func<TSource, ValueTask<TKey>> _keySelector, Func<TSource, ValueTask<TElement>> _elementSelector, IEqualityComparer<TKey> _comparer, CancellationToken _cancellationToken)
+            static async ValueTask<ILookup<TKey, TElement>> Core(IAsyncEnumerable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
             {
-                return await Internal.LookupWithTask<TKey, TElement>.CreateAsync(_source, _keySelector, _elementSelector, _comparer, _cancellationToken).ConfigureAwait(false);
+                return await Internal.LookupWithTask<TKey, TElement>.CreateAsync(source, keySelector, elementSelector, comparer, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -121,9 +121,9 @@ namespace System.Linq
 
             return Core(source, keySelector, elementSelector, comparer, cancellationToken);
 
-            static async ValueTask<ILookup<TKey, TElement>> Core(IAsyncEnumerable<TSource> _source, Func<TSource, CancellationToken, ValueTask<TKey>> _keySelector, Func<TSource, CancellationToken, ValueTask<TElement>> _elementSelector, IEqualityComparer<TKey> _comparer, CancellationToken _cancellationToken)
+            static async ValueTask<ILookup<TKey, TElement>> Core(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<TKey>> keySelector, Func<TSource, CancellationToken, ValueTask<TElement>> elementSelector, IEqualityComparer<TKey> comparer, CancellationToken cancellationToken)
             {
-                return await Internal.LookupWithTask<TKey, TElement>.CreateAsync(_source, _keySelector, _elementSelector, _comparer, _cancellationToken).ConfigureAwait(false);
+                return await Internal.LookupWithTask<TKey, TElement>.CreateAsync(source, keySelector, elementSelector, comparer, cancellationToken).ConfigureAwait(false);
             }
         }
 #endif


### PR DESCRIPTION
* Null-coalescing assignment.
* Shadowing of parameter names is now allowed on local functions.

We can't yet put `[EnumeratorCancellation]` on `CancellationToken` parameters in local functions, because those don't support attributes (see https://github.com/dotnet/csharplang/issues/794). We can figure out which direction to go for those; either motivate getting custom attributes on local functions (because async iterators implementations as local functions seems a common case), or move these back to top-level methods just to support using the attribute (and do away with the `Create(Core)` dance in the `IAsyncEnumerator<T>` space).