### PR TITLE
Synchronize MostRecent when appropriate

### DIFF
--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/MostRecentTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/MostRecentTest.cs
@@ -24,7 +24,7 @@ namespace ReactiveTests.Tests
         }
 
         [Fact]
-        public void MostRecent1()
+        public void MostRecentAtomic1()
         {
             var evt = new AutoResetEvent(false);
             var nxt = new AutoResetEvent(false);
@@ -69,7 +69,7 @@ namespace ReactiveTests.Tests
         }
 
         [Fact]
-        public void MostRecent2()
+        public void MostRecentAtomic2()
         {
             var scheduler = new TestScheduler();
 
@@ -144,6 +144,140 @@ namespace ReactiveTests.Tests
             {
                 Assert.True(e2.MoveNext());
                 o2.Add((int)e2.Current);
+            });
+
+            scheduler.Start();
+
+            xs.Subscriptions.AssertEqual(
+                Subscribe(200, 285),
+                Subscribe(255, 300)
+            );
+
+            o1.AssertEqual(0, 3, 3, 6);
+            o2.AssertEqual(0, 6, 6, 7);
+        }
+
+        [Fact]
+        public void MostRecentNonAtomic1()
+        {
+            var evt = new AutoResetEvent(false);
+            var nxt = new AutoResetEvent(false);
+            var src = Observable.Create<decimal>(obs =>
+            {
+                Task.Run(() =>
+                {
+                    evt.WaitOne();
+                    obs.OnNext(1);
+                    nxt.Set();
+                    evt.WaitOne();
+                    obs.OnNext(2);
+                    nxt.Set();
+                    evt.WaitOne();
+                    obs.OnCompleted();
+                    nxt.Set();
+                });
+
+                return () => { };
+            });
+
+            var res = src.MostRecent(42).GetEnumerator();
+
+            Assert.True(res.MoveNext());
+            Assert.Equal(42, res.Current);
+            Assert.True(res.MoveNext());
+            Assert.Equal(42, res.Current);
+
+            for (var i = 1; i <= 2; i++)
+            {
+                evt.Set();
+                nxt.WaitOne();
+                Assert.True(res.MoveNext());
+                Assert.Equal(i, res.Current);
+                Assert.True(res.MoveNext());
+                Assert.Equal(i, res.Current);
+            }
+
+            evt.Set();
+            nxt.WaitOne();
+            Assert.False(res.MoveNext());
+        }
+
+        [Fact]
+        public void MostRecentNonAtomic2()
+        {
+            var scheduler = new TestScheduler();
+
+            var xs = scheduler.CreateHotObservable(
+                OnNext(210, 1m),
+                OnNext(220, 2m),
+                OnNext(230, 3m),
+                OnNext(240, 4m),
+                OnNext(250, 5m),
+                OnNext(260, 6m),
+                OnNext(270, 7m),
+                OnNext(280, 8m),
+                OnNext(290, 9m),
+                OnCompleted<decimal>(300)
+            );
+
+            var res = xs.MostRecent(0);
+
+            var e1 = default(IEnumerator<decimal>);
+            scheduler.ScheduleAbsolute(200, () =>
+            {
+                e1 = res.GetEnumerator();
+            });
+
+            var o1 = new List<decimal>();
+            scheduler.ScheduleAbsolute(205, () =>
+            {
+                Assert.True(e1.MoveNext());
+                o1.Add(e1.Current);
+            });
+            scheduler.ScheduleAbsolute(232, () =>
+            {
+                Assert.True(e1.MoveNext());
+                o1.Add(e1.Current);
+            });
+            scheduler.ScheduleAbsolute(234, () =>
+            {
+                Assert.True(e1.MoveNext());
+                o1.Add(e1.Current);
+            });
+            scheduler.ScheduleAbsolute(265, () =>
+            {
+                Assert.True(e1.MoveNext());
+                o1.Add(e1.Current);
+            });
+
+            scheduler.ScheduleAbsolute(285, () => e1.Dispose());
+
+            var e2 = default(IEnumerator);
+            scheduler.ScheduleAbsolute(255, () =>
+            {
+                e2 = ((IEnumerable)res).GetEnumerator();
+            });
+
+            var o2 = new List<decimal>();
+            scheduler.ScheduleAbsolute(258, () =>
+            {
+                Assert.True(e2.MoveNext());
+                o2.Add((decimal)e2.Current);
+            });
+            scheduler.ScheduleAbsolute(262, () =>
+            {
+                Assert.True(e2.MoveNext());
+                o2.Add((decimal)e2.Current);
+            });
+            scheduler.ScheduleAbsolute(264, () =>
+            {
+                Assert.True(e2.MoveNext());
+                o2.Add((decimal)e2.Current);
+            });
+            scheduler.ScheduleAbsolute(275, () =>
+            {
+                Assert.True(e2.MoveNext());
+                o2.Add((decimal)e2.Current);
             });
 
             scheduler.Start();


### PR DESCRIPTION
I added a check to MostRecent<>.Run which will return a different sink to synchronize reads & writes on _value when the size of TSource exceeds the native word size (checked using `System.Runtime.CompilerServices.Unsafe.SizeOf<T>()`) to prevent potentially reading an intermediate value in the middle of a write operation.