### PR TITLE
Fix a few more nullability warnings

### DIFF
--- a/Ix.NET/Source/Benchmarks.System.Interactive/BufferCountBenchmark.cs
+++ b/Ix.NET/Source/Benchmarks.System.Interactive/BufferCountBenchmark.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -15,7 +14,7 @@ namespace Benchmarks.System.Interactive
     {
         [Params(1, 10, 100, 1000, 10000, 100000, 1000000)]
         public int N;
-        private IList<int> _store;
+        private IList<int>? _store;
 
         [Benchmark]
         public void Exact()

--- a/Ix.NET/Source/Benchmarks.System.Interactive/IgnoreElementsBenchmark.cs
+++ b/Ix.NET/Source/Benchmarks.System.Interactive/IgnoreElementsBenchmark.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -18,8 +17,8 @@ namespace Benchmarks.System.Interactive
 
         private int _store;
 
-        private int[] _array;
-        private List<int> _list;
+        private int[]? _array;
+        private List<int>? _list;
 
         [Benchmark]
         public void Ignore()
@@ -32,7 +31,7 @@ namespace Benchmarks.System.Interactive
         [Benchmark]
         public void IgnoreList()
         {
-            _list
+            _list!
                 .IgnoreElements()
                 .Subscribe(v => Volatile.Write(ref _store, v));
         }
@@ -40,7 +39,7 @@ namespace Benchmarks.System.Interactive
         [Benchmark]
         public void IgnoreArray()
         {
-            _array
+            _array!
                 .IgnoreElements()
                 .Subscribe(v => Volatile.Write(ref _store, v));
         }

--- a/Ix.NET/Source/Benchmarks.System.Interactive/MinMaxBenchmark.cs
+++ b/Ix.NET/Source/Benchmarks.System.Interactive/MinMaxBenchmark.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -16,7 +15,7 @@ namespace Benchmarks.System.Interactive
         [Params(1, 10, 100, 1000, 10000, 100000, 1000000)]
         public int N;
         private int _store;
-        private IList<int> _listStore;
+        private IList<int>? _listStore;
 
         private readonly IComparer<int> _comparer = Comparer<int>.Default;
 

--- a/Ix.NET/Source/System.Interactive.Providers/System/Linq/QueryableEx.cs
+++ b/Ix.NET/Source/System.Interactive.Providers/System/Linq/QueryableEx.cs
@@ -100,7 +100,7 @@ namespace System.Linq
                 return type.GetMethods(BindingFlags.Static | BindingFlags.Public).ToLookup(m => m.Name);
             }
 
-            private static bool ArgsMatch(MethodInfo method, IList<Expression> arguments, Type[] typeArgs)
+            private static bool ArgsMatch(MethodInfo method, IList<Expression> arguments, Type[]? typeArgs)
             {
                 //
                 // Number of parameters should match. Notice we've sanitized IQueryProvider "this"

--- a/Ix.NET/Source/System.Interactive/System/Linq/Operators/DistinctUntilChanged.cs
+++ b/Ix.NET/Source/System.Interactive/System/Linq/Operators/DistinctUntilChanged.cs
@@ -80,7 +80,7 @@ namespace System.Linq
 
         private static IEnumerable<TSource> DistinctUntilChangedCore<TSource, TKey>(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
         {
-            var currentKey = default(TKey);
+            var currentKey = default(TKey)!;
             var hasCurrentKey = false;
 
             foreach (var item in source)

--- a/Ix.NET/Source/System.Interactive/System/Linq/Operators/Memoize.cs
+++ b/Ix.NET/Source/System.Interactive/System/Linq/Operators/Memoize.cs
@@ -113,10 +113,12 @@ namespace System.Linq
 
         private sealed class MemoizedBuffer<T> : IBuffer<T>
         {
-            private IRefCountList<T> _buffer;
+            private readonly object _gate = new object();
+            private readonly IRefCountList<T> _buffer;
+            private readonly IEnumerator<T> _source;
+
             private bool _disposed;
             private Exception? _error;
-            private IEnumerator<T> _source;
             private bool _stopped;
 
             public MemoizedBuffer(IEnumerator<T> source)
@@ -153,15 +155,12 @@ namespace System.Linq
 
             public void Dispose()
             {
-                lock (_source)
+                lock (_gate)
                 {
                     if (!_disposed)
                     {
                         _source.Dispose();
-                        _source = null;
-
                         _buffer.Clear();
-                        _buffer = null;
                     }
 
                     _disposed = true;
@@ -180,9 +179,9 @@ namespace System.Linq
                             throw new ObjectDisposedException("");
 
                         var hasValue = default(bool);
-                        var current = default(T);
+                        var current = default(T)!;
 
-                        lock (_source)
+                        lock (_gate)
                         {
                             if (i >= _buffer.Count)
                             {

--- a/Ix.NET/Source/System.Interactive/System/Linq/Operators/OnErrorResumeNext.cs
+++ b/Ix.NET/Source/System.Interactive/System/Linq/Operators/OnErrorResumeNext.cs
@@ -63,7 +63,7 @@ namespace System.Linq
 
                 while (true)
                 {
-                    var value = default(TSource);
+                    TSource value;
                     try
                     {
                         if (!innerEnumerator.MoveNext())

--- a/Ix.NET/Source/System.Interactive/System/Linq/Operators/Publish.cs
+++ b/Ix.NET/Source/System.Interactive/System/Linq/Operators/Publish.cs
@@ -62,11 +62,11 @@ namespace System.Linq
         private sealed class PublishedBuffer<T> : IBuffer<T>
         {
             private readonly object _gate = new object();
+            private readonly RefCountList<T> _buffer;
+            private readonly IEnumerator<T> _source;
 
-            private RefCountList<T> _buffer;
             private bool _disposed;
             private Exception? _error;
-            private IEnumerator<T> _source;
             private bool _stopped;
 
             public PublishedBuffer(IEnumerator<T> source)
@@ -109,10 +109,7 @@ namespace System.Linq
                     if (!_disposed)
                     {
                         _source.Dispose();
-                        _source = null;
-
                         _buffer.Clear();
-                        _buffer = null;
                     }
 
                     _disposed = true;
@@ -131,7 +128,7 @@ namespace System.Linq
                         }
 
                         var hasValue = default(bool);
-                        var current = default(T);
+                        var current = default(T)!;
 
                         lock (_gate)
                         {

--- a/Ix.NET/Source/System.Interactive/System/Linq/Operators/Scan.cs
+++ b/Ix.NET/Source/System.Interactive/System/Linq/Operators/Scan.cs
@@ -65,7 +65,7 @@ namespace System.Linq
         private static IEnumerable<TSource> ScanCore<TSource>(IEnumerable<TSource> source, Func<TSource, TSource, TSource> accumulator)
         {
             var hasSeed = false;
-            var acc = default(TSource);
+            var acc = default(TSource)!;
 
             foreach (var item in source)
             {

--- a/Ix.NET/Source/System.Interactive/System/Linq/Operators/Share.cs
+++ b/Ix.NET/Source/System.Interactive/System/Linq/Operators/Share.cs
@@ -58,8 +58,8 @@ namespace System.Linq
 
         private class SharedBuffer<T> : IBuffer<T>
         {
+            private readonly IEnumerator<T> _source;
             private bool _disposed;
-            private IEnumerator<T> _source;
 
             public SharedBuffer(IEnumerator<T> source)
             {
@@ -89,7 +89,6 @@ namespace System.Linq
                     if (!_disposed)
                     {
                         _source.Dispose();
-                        _source = null;
                     }
 
                     _disposed = true;
@@ -104,11 +103,15 @@ namespace System.Linq
 
                 private bool _disposed;
 
-                public ShareEnumerator(SharedBuffer<T> parent) => _parent = parent;
+                public ShareEnumerator(SharedBuffer<T> parent)
+                {
+                    _parent = parent;
+                    Current = default!;
+                }
 
                 public T Current { get; private set; }
 
-                object IEnumerator.Current => Current;
+                object? IEnumerator.Current => Current;
 
                 public void Dispose() => _disposed = true;
 
@@ -138,7 +141,7 @@ namespace System.Linq
                         return true;
                     }
                     _disposed = true;
-                    Current = default;
+                    Current = default!;
                     return false;
                 }
 

--- a/Ix.NET/Source/System.Interactive/System/Linq/RefCountList.cs
+++ b/Ix.NET/Source/System.Interactive/System/Linq/RefCountList.cs
@@ -45,7 +45,7 @@ namespace System.Linq
 
         public void Add(T item)
         {
-            _list[Count] = new RefCount { Value = item, Count = ReaderCount };
+            _list[Count] = new RefCount(item, ReaderCount);
 
             Count++;
         }
@@ -62,8 +62,14 @@ namespace System.Linq
 
         private sealed class RefCount
         {
-            public int Count;
-            public T Value;
+            public RefCount(T value, int count)
+            {
+                Value = value;
+                Count = count;
+            }
+
+            public int Count { get; set; }
+            public T Value { get; }
         }
     }
 }

--- a/Ix.NET/Source/System.Interactive/System/Linq/Yielder.cs
+++ b/Ix.NET/Source/System.Interactive/System/Linq/Yielder.cs
@@ -14,7 +14,11 @@ namespace System.Linq
         private bool _running;
         private bool _stopped;
 
-        public Yielder(Action<Yielder<T>> create) => _create = create;
+        public Yielder(Action<Yielder<T>> create)
+        {
+            _create = create;
+            Current = default!;
+        }
 
         public T Current { get; private set; }
 

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/AsyncEnumerableNamingTests.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/AsyncEnumerableNamingTests.cs
@@ -68,9 +68,9 @@ namespace Tests
             static bool IsTaskLike(Type t) => IsTask(t) || IsValueTask(t);
 
             static bool IsDelegate(Type t) => typeof(Delegate).IsAssignableFrom(t);
-            static bool TryGetInvoke(Type t, out MethodInfo m) => (m = t.GetMethod("Invoke")) != null;
-            static bool IsAsyncDelegate(Type t) => IsDelegate(t) && TryGetInvoke(t, out var i) && IsTaskLike(i.ReturnType);
-            static bool IsCancelableDelegate(Type t) => IsDelegate(t) && TryGetInvoke(t, out var i) && i.GetParameters().LastOrDefault()?.ParameterType == typeof(CancellationToken);
+            static bool TryGetInvoke(Type t, out MethodInfo? m) => (m = t.GetMethod("Invoke")) != null;
+            static bool IsAsyncDelegate(Type t) => IsDelegate(t) && TryGetInvoke(t, out var i) && IsTaskLike(i!.ReturnType);
+            static bool IsCancelableDelegate(Type t) => IsDelegate(t) && TryGetInvoke(t, out var i) && i!.GetParameters().LastOrDefault()?.ParameterType == typeof(CancellationToken);
             static DelegateKind GetDelegateKind(Type t) => IsAsyncDelegate(t) ? (IsCancelableDelegate(t) ? DelegateKind.AsyncCancel : DelegateKind.Async) : DelegateKind.Sync;
         }
 

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/SingleLinkedNode.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/SingleLinkedNode.cs
@@ -86,14 +86,14 @@ namespace System.Linq
         {
             Debug.Assert(index >= 0 && index < GetCount());
 
-            SingleLinkedNode<TSource>? node = this;
+            SingleLinkedNode<TSource> node = this;
             for (; index > 0; index--)
             {
-                node = node!.Linked;
+                node = node.Linked!;
+                Debug.Assert(node != null);
             }
 
-            Debug.Assert(node != null);
-            return node;
+            return node!;
         }
 
         /// <summary>


### PR DESCRIPTION
Deal with a few more cases. There still some warning behavior around `Debug.Assert` for down-level platforms (e.g. .NET 4.6.1) due to the lack of `[DoesNotReturnIf(false)]` on the `condition` parameter. My preference would be to suppress for down-level platforms that miss annotations.