### PR TITLE
Remove more redundant assignments

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Concurrency/CurrentThreadScheduler.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/CurrentThreadScheduler.cs
@@ -82,7 +82,7 @@ namespace System.Reactive.Concurrency
                 throw new ArgumentNullException(nameof(action));
             }
 
-            var queue = default(SchedulerQueue<TimeSpan>);
+            SchedulerQueue<TimeSpan> queue;
 
             // There is no timed task and no task is currently running
             if (!_running)

--- a/Rx.NET/Source/src/System.Reactive/EventSource.cs
+++ b/Rx.NET/Source/src/System.Reactive/EventSource.cs
@@ -71,8 +71,7 @@ namespace System.Reactive
         {
             lock (_subscriptions)
             {
-                var l = new Stack<IDisposable>();
-                if (!_subscriptions.TryGetValue(handler, out l))
+                if (!_subscriptions.TryGetValue(handler, out var l))
                 {
                     _subscriptions[handler] = l = new Stack<IDisposable>();
                 }

--- a/Rx.NET/Source/src/System.Reactive/Internal/ExceptionHelper.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/ExceptionHelper.cs
@@ -69,14 +69,13 @@ namespace System.Reactive
                     return false;
                 }
 
-                var b = default(Exception);
+                Exception b;
 
                 if (current == null)
                 {
                     b = ex;
                 }
-                else
-                if (current is AggregateException a)
+                else if (current is AggregateException a)
                 {
                     var list = new List<Exception>(a.InnerExceptions)
                     {
@@ -88,6 +87,7 @@ namespace System.Reactive
                 {
                     b = new AggregateException(current, ex);
                 }
+
                 if (Interlocked.CompareExchange(ref field, b, current) == current)
                 {
                     return true;
@@ -102,7 +102,6 @@ namespace System.Reactive
         {
             internal TerminatedException() : base("No further exceptions")
             {
-
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Internal/Helpers.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/Helpers.cs
@@ -25,7 +25,7 @@ namespace System.Reactive
 
         public static IObservable<T> Unpack<T>(IObservable<T> source)
         {
-            var hasOpt = default(bool);
+            bool hasOpt;
 
             do
             {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/AmbMany.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/AmbMany.cs
@@ -36,8 +36,8 @@ namespace System.Reactive.Linq.ObservableImpl
         protected override IDisposable Run(IObserver<T> observer)
         {
             var sourcesEnumerable = _sources;
-            var sources = default(IObservable<T>[]);
 
+            IObservable<T>[] sources;
             try
             {
                 sources = sourcesEnumerable.ToArray();

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/AppendPrepend.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/AppendPrepend.cs
@@ -35,8 +35,9 @@ namespace System.Reactive.Linq.ObservableImpl
             public IAppendPrepend Append(TSource value)
             {
                 var prev = new Node<TSource>(_value);
-                var appendNode = default(Node<TSource>);
-                var prependNode = default(Node<TSource>);
+
+                Node<TSource> appendNode;
+                Node<TSource> prependNode = null;
 
                 if (_append)
                 {
@@ -54,8 +55,9 @@ namespace System.Reactive.Linq.ObservableImpl
             public IAppendPrepend Prepend(TSource value)
             {
                 var prev = new Node<TSource>(_value);
-                var appendNode = default(Node<TSource>);
-                var prependNode = default(Node<TSource>);
+
+                Node<TSource> appendNode = null;
+                Node<TSource> prependNode;
 
                 if (_append)
                 {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Case.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Case.cs
@@ -42,7 +42,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public void Run(Case<TValue, TResult> parent)
             {
-                var result = default(IObservable<TResult>);
+                IObservable<TResult> result;
                 try
                 {
                     result = parent.Eval();

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Contains.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Contains.cs
@@ -37,7 +37,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public override void OnNext(TSource value)
             {
-                var res = false;
+                bool res;
                 try
                 {
                     res = _comparer.Equals(value, _value);

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/FromEvent.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/FromEvent.cs
@@ -327,7 +327,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             private void AddHandler(TDelegate onNext)
             {
-                var removeHandler = default(IDisposable);
+                IDisposable removeHandler;
                 try
                 {
                     removeHandler = _parent.AddHandler(onNext);

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/GroupBy.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/GroupBy.cs
@@ -77,7 +77,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
 
                 var fireNewMapEntry = false;
-                var writer = default(Subject<TElement>);
+                Subject<TElement> writer;
                 try
                 {
                     //

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/GroupByUntil.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/GroupByUntil.cs
@@ -319,7 +319,7 @@ namespace System.Reactive.Linq.ObservableImpl
         {
             added = false;
 
-            var value = default(TValue);
+            TValue value;
             var newValue = default(TValue);
             var hasNewValue = false;
             while (true)

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/If.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/If.cs
@@ -36,7 +36,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public void Run()
             {
-                var result = default(IObservable<TResult>);
+                IObservable<TResult> result;
                 try
                 {
                     result = _parent.Eval();

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Max.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Max.cs
@@ -46,8 +46,7 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (_hasValue)
                 {
-                    var comparison = 0;
-
+                    int comparison;
                     try
                     {
                         comparison = _comparer.Compare(value, _lastValue);
@@ -103,8 +102,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     else
                     {
-                        var comparison = 0;
-
+                        int comparison;
                         try
                         {
                             comparison = _comparer.Compare(value, _lastValue);

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Min.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Min.cs
@@ -46,8 +46,7 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (_hasValue)
                 {
-                    var comparison = 0;
-
+                    int comparison;
                     try
                     {
                         comparison = _comparer.Compare(value, _lastValue);
@@ -108,8 +107,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     else
                     {
-                        var comparison = 0;
-
+                        int comparison;
                         try
                         {
                             comparison = _comparer.Compare(value, _lastValue);

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/SelectMany.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/SelectMany.cs
@@ -381,7 +381,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         return;
                     }
 
-                    var e = default(IEnumerator<TCollection>);
+                    IEnumerator<TCollection> e;
                     try
                     {
                         e = xs.GetEnumerator();
@@ -470,7 +470,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         return;
                     }
 
-                    var e = default(IEnumerator<TCollection>);
+                    IEnumerator<TCollection> e;
                     try
                     {
                         e = xs.GetEnumerator();
@@ -1333,7 +1333,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         return;
                     }
 
-                    var e = default(IEnumerator<TResult>);
+                    IEnumerator<TResult> e;
                     try
                     {
                         e = xs.GetEnumerator();
@@ -1416,7 +1416,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         return;
                     }
 
-                    var e = default(IEnumerator<TResult>);
+                    IEnumerator<TResult> e;
                     try
                     {
                         e = xs.GetEnumerator();

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/SequenceEqual.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/SequenceEqual.cs
@@ -314,8 +314,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public override void OnCompleted()
                 {
-                    var hasNext = false;
-
+                    bool hasNext;
                     try
                     {
                         hasNext = _enumerator.MoveNext();

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Zip.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Zip.cs
@@ -322,7 +322,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public override void OnNext(TFirst value)
                 {
-                    var hasNext = false;
+                    bool hasNext;
                     try
                     {
                         hasNext = _rightEnumerator.MoveNext();

--- a/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Async.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Async.cs
@@ -670,7 +670,7 @@ namespace System.Reactive.Linq
 
         private IObservable<TSource> StartAsyncImpl<TSource>(Func<Task<TSource>> functionAsync, IScheduler scheduler)
         {
-            var task = default(Task<TSource>);
+            Task<TSource> task;
             try
             {
                 task = functionAsync();
@@ -702,7 +702,7 @@ namespace System.Reactive.Linq
         {
             var cancellable = new CancellationDisposable();
 
-            var task = default(Task<TSource>);
+            Task<TSource> task;
             try
             {
                 task = functionAsync(cancellable.Token);
@@ -712,7 +712,7 @@ namespace System.Reactive.Linq
                 return Throw<TSource>(exception);
             }
 
-            var result = default(IObservable<TSource>);
+            IObservable<TSource> result;
 
             if (scheduler != null)
             {
@@ -773,7 +773,7 @@ namespace System.Reactive.Linq
 
         private IObservable<Unit> StartAsyncImpl(Func<Task> actionAsync, IScheduler scheduler)
         {
-            var task = default(Task);
+            Task task;
             try
             {
                 task = actionAsync();
@@ -805,7 +805,7 @@ namespace System.Reactive.Linq
         {
             var cancellable = new CancellationDisposable();
 
-            var task = default(Task);
+            Task task;
             try
             {
                 task = actionAsync(cancellable.Token);
@@ -815,7 +815,7 @@ namespace System.Reactive.Linq
                 return Throw<Unit>(exception);
             }
 
-            var result = default(IObservable<Unit>);
+            IObservable<Unit> result;
 
             if (scheduler != null)
             {

--- a/Rx.NET/Source/src/System.Reactive/Subjects/AsyncSubject.cs
+++ b/Rx.NET/Source/src/System.Reactive/Subjects/AsyncSubject.cs
@@ -274,7 +274,7 @@ namespace System.Reactive.Subjects
                     break;
                 }
 
-                var b = default(AsyncSubjectDisposable[]);
+                AsyncSubjectDisposable[] b;
                 if (n == 1)
                 {
                     b = Array.Empty<AsyncSubjectDisposable>();

--- a/Rx.NET/Source/src/System.Reactive/Subjects/Subject.cs
+++ b/Rx.NET/Source/src/System.Reactive/Subjects/Subject.cs
@@ -225,7 +225,7 @@ namespace System.Reactive.Subjects
                     break;
                 }
 
-                var b = default(SubjectDisposable[]);
+                SubjectDisposable[] b;
                 if (n == 1)
                 {
                     b = Array.Empty<SubjectDisposable>();


### PR DESCRIPTION
Removing more cases where `default(T)` was used in conjunction with `var` to guide type inference, but it results in redundant assignments that can be removed.