### PR TITLE
Fix Delay(selector) NPE on immediate emissions

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Delay.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Delay.cs
@@ -657,7 +657,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     lock (_gate)
                     {
                         _atEnd = true;
-                        _subscription.Dispose();
+                        Disposable.TryDispose(ref _subscription);
 
                         CheckDone();
                     }

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/DelayTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/DelayTest.cs
@@ -1813,6 +1813,17 @@ namespace ReactiveTests.Tests
             e.WaitOne();
         }
 
+        [Fact]
+        public void Delay_Selector_Immediate()
+        {
+            var result = 0;
+            var source = Observable.Return(1);
+            var delayed = source.Delay(_ => Observable.Return(2));
+            delayed.Subscribe(v => result = v);
+
+            Assert.Equal(1, result);
+        }
+
         private class MyLongRunning2 : LocalScheduler, ISchedulerLongRunning
         {
             private ManualResetEvent _start;


### PR DESCRIPTION
The `_subscription` may be null if the participating Observables emit immediately and should have been disposed via the atomics utility method anyway.

Fixes #1048