### PR TITLE
Fix Generate (timed) crash upon disposing a long sequence

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Generate.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Generate.cs
@@ -195,9 +195,19 @@ namespace System.Reactive.Linq.ObservableImpl
                 private bool _hasResult;
                 private TResult _result;
 
+                private IDisposable _timerDisposable;
+
                 public void Run(IScheduler outerScheduler, TState initialState)
                 {
-                    SetUpstream(outerScheduler.Schedule((@this: this, initialState), (scheduler, tuple) => tuple.@this.InvokeRec(scheduler, tuple.initialState)));
+                    var timer = new SingleAssignmentDisposable();
+                    Disposable.TrySetMultiple(ref _timerDisposable, timer);
+                    timer.Disposable = outerScheduler.Schedule((@this: this, initialState), (scheduler, tuple) => tuple.@this.InvokeRec(scheduler, tuple.initialState));
+                }
+
+                protected override void Dispose(bool disposing)
+                {
+                    Disposable.TryDispose(ref _timerDisposable);
+                    base.Dispose(disposing);
                 }
 
                 private IDisposable InvokeRec(IScheduler self, TState state)
@@ -240,7 +250,11 @@ namespace System.Reactive.Linq.ObservableImpl
                         return Disposable.Empty;
                     }
 
-                    return self.Schedule((@this: this, state), time, (scheduler, tuple) => tuple.@this.InvokeRec(scheduler, tuple.state));
+                    var timer = new SingleAssignmentDisposable();
+                    Disposable.TrySetMultiple(ref _timerDisposable, timer);
+                    timer.Disposable = self.Schedule((@this: this, state), time, (scheduler, tuple) => tuple.@this.InvokeRec(scheduler, tuple.state));
+
+                    return Disposable.Empty;
                 }
             }
         }
@@ -275,6 +289,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 private readonly Func<TState, TResult> _resultSelector;
                 private readonly Func<TState, TimeSpan> _timeSelector;
 
+
                 public _(Relative parent, IObserver<TResult> observer)
                     : base(observer)
                 {
@@ -290,9 +305,19 @@ namespace System.Reactive.Linq.ObservableImpl
                 private bool _hasResult;
                 private TResult _result;
 
+                private IDisposable _timerDisposable;
+
                 public void Run(IScheduler outerScheduler, TState initialState)
                 {
-                    SetUpstream(outerScheduler.Schedule((@this: this, initialState), (scheduler, tuple) => tuple.@this.InvokeRec(scheduler, tuple.initialState)));
+                    var timer = new SingleAssignmentDisposable();
+                    Disposable.TrySetMultiple(ref _timerDisposable, timer);
+                    timer.Disposable = outerScheduler.Schedule((@this: this, initialState), (scheduler, tuple) => tuple.@this.InvokeRec(scheduler, tuple.initialState));
+                }
+
+                protected override void Dispose(bool disposing)
+                {
+                    Disposable.TryDispose(ref _timerDisposable);
+                    base.Dispose(disposing);
                 }
 
                 private IDisposable InvokeRec(IScheduler self, TState state)
@@ -335,10 +360,13 @@ namespace System.Reactive.Linq.ObservableImpl
                         return Disposable.Empty;
                     }
 
-                    return self.Schedule((@this: this, state), time, (scheduler, tuple) => tuple.@this.InvokeRec(scheduler, tuple.state));
+                    var timer = new SingleAssignmentDisposable();
+                    Disposable.TrySetMultiple(ref _timerDisposable, timer);
+                    timer.Disposable = self.Schedule((@this: this, state), time, (scheduler, tuple) => tuple.@this.InvokeRec(scheduler, tuple.state));
+
+                    return Disposable.Empty;
                 }
             }
         }
     }
 }
-


### PR DESCRIPTION
Due to how recursive scheduling has to link up `IDisposable`s in the [`UserWorkItem`](https://github.com/dotnet/reactive/blob/master/Rx.NET/Source/src/System.Reactive/Concurrency/UserWorkItem.cs#L29) class, a long running timed `Generate` would produce a long chain of `UserWorkItem`s and crash with stack overflow if the whole sequence itself is disposed.

The fix is to have the recursive scheduling in `Generate` not return the next step's `IDisposable` from the function but keep replacing a main reference with the newer and newer `IDisposable`s, and thus no link chain is formed.

The use of the SAD indirection is necessary because when the `Schedule` returns with the `IDisposable`, the payload may have already run and we would overwrite a newer step's `IDisposable`.