### PR TITLE
Serialize the dispose of Zip(IEnumerable) with MoveNext/Current

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Zip.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Zip.cs
@@ -274,6 +274,8 @@ namespace System.Reactive.Linq.ObservableImpl
                     _resultSelector = resultSelector;
                 }
 
+                int _enumerationInProgress;
+
                 private IEnumerator<TSecond> _rightEnumerator;
 
                 private static readonly IEnumerator<TSecond> DisposedEnumerator = MakeDisposedEnumerator();
@@ -315,17 +317,47 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (disposing)
                     {
-                        Interlocked.Exchange(ref _rightEnumerator, DisposedEnumerator)?.Dispose();
+                        if (Interlocked.Increment(ref _enumerationInProgress) == 1)
+                        {
+                            Interlocked.Exchange(ref _rightEnumerator, DisposedEnumerator)?.Dispose();
+                        }
                     }
                     base.Dispose(disposing);
                 }
 
                 public override void OnNext(TFirst value)
                 {
+                    var currentEnumerator = Volatile.Read(ref _rightEnumerator);
+                    if (currentEnumerator == DisposedEnumerator)
+                    {
+                        return;
+                    }
+                    if (Interlocked.Increment(ref _enumerationInProgress) != 1)
+                    {
+                        currentEnumerator.Dispose();
+                        return;
+                    }
                     bool hasNext;
+                    TSecond right = default;
+                    var wasDisposed = false;
                     try
                     {
-                        hasNext = _rightEnumerator.MoveNext();
+                        try
+                        {
+                            hasNext = currentEnumerator.MoveNext();
+                            if (hasNext)
+                            {
+                                right = currentEnumerator.Current;
+                            }
+                        }
+                        finally
+                        {
+                            if (Interlocked.Decrement(ref _enumerationInProgress) != 0)
+                            {
+                                currentEnumerator.Dispose();
+                                wasDisposed = true;
+                            }
+                        }
                     }
                     catch (Exception ex)
                     {
@@ -333,19 +365,13 @@ namespace System.Reactive.Linq.ObservableImpl
                         return;
                     }
 
+                    if (wasDisposed)
+                    {
+                        return;
+                    }
+
                     if (hasNext)
                     {
-                        TSecond right;
-                        try
-                        {
-                            right = _rightEnumerator.Current;
-                        }
-                        catch (Exception ex)
-                        {
-                            ForwardOnError(ex);
-                            return;
-                        }
-
                         TResult result;
                         try
                         {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Zip.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Zip.cs
@@ -353,7 +353,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         {
                             if (Interlocked.Decrement(ref _enumerationInProgress) != 0)
                             {
-                                currentEnumerator.Dispose();
+                                Interlocked.Exchange(ref _rightEnumerator, DisposedEnumerator)?.Dispose();
                                 wasDisposed = true;
                             }
                         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Zip.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Zip.cs
@@ -334,7 +334,6 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     if (Interlocked.Increment(ref _enumerationInProgress) != 1)
                     {
-                        currentEnumerator.Dispose();
                         return;
                     }
                     bool hasNext;

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ZipTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ZipTest.cs
@@ -3,10 +3,13 @@
 // See the LICENSE file in the project root for more information. 
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using System.Threading;
 using Microsoft.Reactive.Testing;
 using ReactiveTests.Dummies;
@@ -4052,6 +4055,113 @@ namespace ReactiveTests.Tests
             o2.Subscriptions.AssertEqual(
                 Subscribe(200, 225)
             );
+        }
+
+        [Fact]
+        public void ZipWithEnumerable_NoAsyncDisposeOnMoveNext()
+        {
+            var source = new Subject<int>();
+
+            var disposable = new SingleAssignmentDisposable();
+
+            var other = new MoveNextDisposeDetectEnumerable(disposable, true);
+
+            disposable.Disposable = source.Zip(other, (a, b) => a + b).Subscribe();
+
+            source.OnNext(1);
+
+            Assert.True(other.IsDisposed);
+            Assert.False(other.DisposedWhileMoveNext);
+            Assert.False(other.DisposedWhileCurrent);
+        }
+
+        [Fact]
+        public void ZipWithEnumerable_NoAsyncDisposeOnCurrent()
+        {
+            var source = new Subject<int>();
+
+            var disposable = new SingleAssignmentDisposable();
+
+            var other = new MoveNextDisposeDetectEnumerable(disposable, false);
+
+            disposable.Disposable = source.Zip(other, (a, b) => a + b).Subscribe();
+
+            source.OnNext(1);
+
+            Assert.True(other.IsDisposed);
+            Assert.False(other.DisposedWhileMoveNext);
+            Assert.False(other.DisposedWhileCurrent);
+        }
+
+        private class MoveNextDisposeDetectEnumerable : IEnumerable<int>, IEnumerator<int>
+        {
+            readonly IDisposable _disposable;
+
+            readonly bool _disposeOnMoveNext;
+
+            private bool _moveNextRunning;
+
+            private bool _currentRunning;
+
+            internal bool DisposedWhileMoveNext;
+
+            internal bool DisposedWhileCurrent;
+
+            internal bool IsDisposed;
+
+            internal MoveNextDisposeDetectEnumerable(IDisposable disposable, bool disposeOnMoveNext)
+            {
+                _disposable = disposable;
+                _disposeOnMoveNext = disposeOnMoveNext;
+            }
+            public int Current
+            {
+                get
+                {
+                    _currentRunning = true;
+                    if (!_disposeOnMoveNext)
+                    {
+                        _disposable.Dispose();
+                    }
+                    _currentRunning = false;
+                    return 0;
+                }
+            }
+
+            object IEnumerator.Current => Current;
+
+            public void Dispose()
+            {
+                DisposedWhileMoveNext = _moveNextRunning;
+                DisposedWhileCurrent = _currentRunning;
+                IsDisposed = true;
+            }
+
+            public IEnumerator<int> GetEnumerator()
+            {
+                return this;
+            }
+
+            public bool MoveNext()
+            {
+                _moveNextRunning = true;
+                if (_disposeOnMoveNext)
+                {
+                    _disposable.Dispose();
+                }
+                _moveNextRunning = false;
+                return true;
+            }
+
+            public void Reset()
+            {
+                throw new NotSupportedException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return this;
+            }
         }
 
         private IEnumerable<int> EnumerableNever(ManualResetEvent evt)


### PR DESCRIPTION
`IEnumerator.Dispose` should not be called while `MoveNext` or `Current` is executing as most implementations don't expect a concurrent dispose call I think.

This PR adds a basic trampoline around the calls to `MoveNext` and `Current`. This allows a mutual exclusion between them and Dispose while also remembering `Dispose` should be eventually called:

1. The operator's Dispose is invoked and `_enumerationInProgress` atomically updates to 1: no concurrent MoveNext is happening and the enumerator can be disposed. If `OnNext` runs at this point `_enumerationInProgress` atomically updates to 2 and the method quits without doing anything.
2. `OnNext` atomically changes `_enumerationInProgress` to 1 and calls `MoveNext`. A concurrent `Dispose` on the operator now updates `_enumerationInProgress` to 2 and doesn't dispose the enumerator. When `MoveNext` finishes, it decrements `_enumerationInProgress` and since this is non-zero, it knows to dispose the enumerator and quit without doing any further processing.


Fixes #132 