### PR TITLE
Avoid infinite generics recursion in SynchronizationContextScheduler

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Concurrency/SynchronizationContextScheduler.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/SynchronizationContextScheduler.cs
@@ -93,7 +93,8 @@ namespace System.Reactive.Concurrency
                 return Schedule(state, action);
             }
 
-            return DefaultScheduler.Instance.Schedule((scheduler: this, action, state), dt, (_, tuple) => tuple.scheduler.Schedule(tuple.state, tuple.action));
+            // Note that avoiding closure allocation here would introduce infinite generic recursion over the TState argument
+            return DefaultScheduler.Instance.Schedule(state, dt, (_, state1) => Schedule(state1, action));
         }
     }
 }


### PR DESCRIPTION
The infinitive generics recursion interacts poorly with AOT. The AOT compilers have hard figuring
out where the stop generating the code for generics with infinite recursion. They either fail or
produce large images by giving up once the generics get too complex.

This change reverts a small part of #500 that introduced infinite generic recursion and adds comment.

Fixes https://github.com/dotnet/corert/issues/7920
