### PR TITLE
Fix crash in Buffer due to empty queue in tick

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Buffer.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Buffer.cs
@@ -361,8 +361,11 @@ namespace System.Reactive.Linq.ObservableImpl
                         //
                         if (isSpan)
                         {
-                            var s = _q.Dequeue();
-                            ForwardOnNext(s);
+                            if (_q.Count > 0)
+                            {
+                                var s = _q.Dequeue();
+                                ForwardOnNext(s);
+                            }
                         }
 
                         if (isShift)

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/BufferTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/BufferTest.cs
@@ -1305,6 +1305,19 @@ namespace ReactiveTests.Tests
             Observable.Range(1, 10, DefaultScheduler.Instance).Buffer(TimeSpan.FromDays(1), 3).Skip(1).First().AssertEqual(4, 5, 6);
         }
 
+        [Fact]
+        public void BufferWithTime_TickWhileOnCompleted()
+        {
+            var scheduler = new TestScheduler();
+
+            Observable.Return(1)
+                .Buffer(TimeSpan.FromMilliseconds(1), TimeSpan.FromMilliseconds(2), scheduler)
+                .Subscribe(v =>
+                {
+                    scheduler.AdvanceBy(TimeSpan.FromMilliseconds(1).Ticks);
+                });
+        }
+
         #endregion
 
     }


### PR DESCRIPTION
The queue in `Buffer.Timesliding._.Tick()` can become empty if the sequence terminates just before.

Fixes #1130.