### PR TITLE
use 3.1.300-preview to fix embedded pdb

### DIFF
--- a/Rx.NET/Source/global.json
+++ b/Rx.NET/Source/global.json
@@ -1,5 +1,8 @@
 {
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "2.0.54"
+  },
+  "sdk": {
+    "version": "3.1.300-preview"
   }
 }

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -35,7 +35,7 @@ stages:
     steps:
     - task: UseDotNet@2
       inputs:
-        version: '3.1.x'
+        version: '3.1.300-preview'
         performMultiLevelLookup: true
         includePreviewVersions: true
 

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -35,7 +35,7 @@ stages:
     steps:
     - task: UseDotNet@2
       inputs:
-        version: '3.1.300-preview'
+        version: '3.1.300'
         performMultiLevelLookup: true
         includePreviewVersions: true
 

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -33,7 +33,7 @@ stages:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 
     steps:
-    - task: UseDotNet@2
+    - task: UseDotNet@1
       inputs:
         version: '3.1.300-preview-015048'
         performMultiLevelLookup: true

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -35,7 +35,7 @@ stages:
     steps:
     - task: UseDotNet@2
       inputs:
-        version: '3.1.300'
+        version: '3.1.300-preview-015048'
         performMultiLevelLookup: true
         includePreviewVersions: true
 

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -33,7 +33,7 @@ stages:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 
     steps:
-    - task: UseDotNet@1
+    - task: DotNetCoreInstaller@1
       inputs:
         version: '3.1.300-preview-015048'
         performMultiLevelLookup: true

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -37,6 +37,7 @@ stages:
       inputs:
         version: '3.1.x'
         performMultiLevelLookup: true
+        includePreviewVersions: true
 
     - task: DotNetCoreCLI@2
       inputs:

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -33,7 +33,7 @@ stages:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 
     steps:
-    - task: DotNetCoreInstaller@1
+    - task: DotNetCoreInstaller@0
       inputs:
         version: '3.1.300-preview-015048'
         performMultiLevelLookup: true


### PR DESCRIPTION
A few generated files aren't properly included in the pdb. Fix should be in the 3.1.300 SDK.