### PR TITLE
Don't add duplicate FrameworkReference

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/build/System.Reactive.targets
+++ b/Rx.NET/Source/src/System.Reactive/build/System.Reactive.targets
@@ -7,6 +7,6 @@
     <Reference Condition="'$(UseWindowsRxVersion)' == 'true' "  Include="$(MSBuildThisFileDirectory)..\..\build\netcoreapp3.0\System.Reactive.dll" />
     <Reference Condition="'$(UseWindowsRxVersion)' != 'true' "  Include="$(MSBuildThisFileDirectory)..\..\lib\netstandard2.0\System.Reactive.dll" />
 
-    <FrameworkReference Condition="'$(UseWindowsRxVersion)' == 'true' " Include="Microsoft.WindowsDesktop.App" />
+    <FrameworkReference Include="Microsoft.WindowsDesktop.App" Condition="'$(UseWindowsRxVersion)' == 'true' and !@(FrameworkReference->AnyHaveMetadataValue('Identity', 'Microsoft.WindowsDesktop.App'))" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR adds a check to avoid adding a duplicate `FrameworkReference` item for `Microsoft.WindowsDesktop.App`, which caused the following warning:

> warning NETSDK1086: A FrameworkReference for 'Microsoft.WindowsDesktop.App' was included in the project. This is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs

The item was duplicated as it had different metadata:
![image](https://user-images.githubusercontent.com/7913492/86769440-753b6e80-c04f-11ea-95c5-64fcb6174ff8.png)

I'm not sure why that `FrameworkReference` item is needed (it was introduced in #1007), so there may be a better solution for this.

Fixes #1112 
