### PR TITLE
Reduce #if checks

### DIFF
--- a/Rx.NET/Source/Directory.build.targets
+++ b/Rx.NET/Source/Directory.build.targets
@@ -15,24 +15,28 @@
   <PropertyGroup>  
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);HAS_WINRT</DefineConstants>
+  </PropertyGroup>
     
   <PropertyGroup Condition="'$(TargetFramework)' == 'net46'">
-    <DefineConstants>$(DefineConstants);HAS_TRACE;HAS_WINRT;HAS_WINFORMS;HAS_DISPATCHER;PREFER_ASYNC;HAS_TPL46;DESKTOPCLR</DefineConstants>
+    <DefineConstants>$(DefineConstants);HAS_WINFORMS;HAS_DISPATCHER;HAS_REMOTING;DESKTOPCLR</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'uap10.0'">
     <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
-    <DefineConstants>$(DefineConstants);NO_CODE_COVERAGE_ATTRIBUTE;HAS_WINRT;PREFER_ASYNC;HAS_TPL46;NO_REMOTING;NO_SERIALIZABLE;CRIPPLED_REFLECTION;NO_THREAD;WINDOWS</DefineConstants>
+    <DefineConstants>$(DefineConstants);NO_CODE_COVERAGE_ATTRIBUTE;NO_SERIALIZABLE;CRIPPLED_REFLECTION;NO_THREAD;NO_TRACE;WINDOWS</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'uap10.0.16299'">
-    <DefineConstants>$(DefineConstants);HAS_TRACE;HAS_WINRT;PREFER_ASYNC;HAS_TPL46;NO_REMOTING;WINDOWS</DefineConstants>
+    <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
     <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netcoreapp2.1'">
-    <DefineConstants>$(DefineConstants);HAS_TRACE;HAS_WINRT;PREFER_ASYNC;HAS_TPL46;NO_REMOTING</DefineConstants>
+    <DefineConstants>$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
-    <DefineConstants>$(DefineConstants);HAS_TRACE;HAS_WINRT;PREFER_ASYNC;HAS_TPL46;NO_REMOTING;HAS_WINFORMS;HAS_DISPATCHER;DESKTOPCLR</DefineConstants>
+    <DefineConstants>$(DefineConstants);HAS_WINFORMS;HAS_DISPATCHER;DESKTOPCLR</DefineConstants>
   </PropertyGroup>
 
 

--- a/Rx.NET/Source/src/System.Reactive/Internal/Constants.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/Constants.cs
@@ -21,9 +21,7 @@ namespace System.Reactive
 
     internal static class Constants_Linq
     {
-#if PREFER_ASYNC
         public const string UseAsync = "This blocking operation is no longer supported. Instead, use the async version in combination with C# and Visual Basic async/await support. In case you need a blocking operation, use Wait or convert the resulting observable sequence to a Task object and block.";
         public const string UseTaskFromAsyncPattern = "This conversion is no longer supported. Replace use of the Begin/End asynchronous method pair with a new Task-based async method, and convert the result using ToObservable. If no Task-based async method is available, use Task.Factory.FromAsync to obtain a Task object.";
-#endif
     }
 }

--- a/Rx.NET/Source/src/System.Reactive/Internal/HalfSerializer.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/HalfSerializer.cs
@@ -48,7 +48,7 @@ namespace System.Reactive
                     }
                 }
             }
-#if (HAS_TRACE)
+#if !NO_TRACE
             else if (error == null)
                 Trace.TraceWarning("OnNext called while another OnNext call was in progress on the same Observer.");
 #endif

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable.Async.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable.Async.cs
@@ -24,9 +24,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<IObservable<TResult>> FromAsyncPattern<TResult>(Func<AsyncCallback, object, IAsyncResult> begin, Func<IAsyncResult, TResult> end)
         {
             if (begin == null)
@@ -52,9 +50,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<TArg1, IObservable<TResult>> FromAsyncPattern<TArg1, TResult>(Func<TArg1, AsyncCallback, object, IAsyncResult> begin, Func<IAsyncResult, TResult> end)
         {
             if (begin == null)
@@ -81,9 +77,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<TArg1, TArg2, IObservable<TResult>> FromAsyncPattern<TArg1, TArg2, TResult>(Func<TArg1, TArg2, AsyncCallback, object, IAsyncResult> begin, Func<IAsyncResult, TResult> end)
         {
             if (begin == null)
@@ -111,9 +105,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<TArg1, TArg2, TArg3, IObservable<TResult>> FromAsyncPattern<TArg1, TArg2, TArg3, TResult>(Func<TArg1, TArg2, TArg3, AsyncCallback, object, IAsyncResult> begin, Func<IAsyncResult, TResult> end)
         {
             if (begin == null)
@@ -142,9 +134,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<TArg1, TArg2, TArg3, TArg4, IObservable<TResult>> FromAsyncPattern<TArg1, TArg2, TArg3, TArg4, TResult>(Func<TArg1, TArg2, TArg3, TArg4, AsyncCallback, object, IAsyncResult> begin, Func<IAsyncResult, TResult> end)
         {
             if (begin == null)
@@ -174,9 +164,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, IObservable<TResult>> FromAsyncPattern<TArg1, TArg2, TArg3, TArg4, TArg5, TResult>(Func<TArg1, TArg2, TArg3, TArg4, TArg5, AsyncCallback, object, IAsyncResult> begin, Func<IAsyncResult, TResult> end)
         {
             if (begin == null)
@@ -207,9 +195,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, IObservable<TResult>> FromAsyncPattern<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TResult>(Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, AsyncCallback, object, IAsyncResult> begin, Func<IAsyncResult, TResult> end)
         {
             if (begin == null)
@@ -241,9 +227,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, IObservable<TResult>> FromAsyncPattern<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TResult>(Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, AsyncCallback, object, IAsyncResult> begin, Func<IAsyncResult, TResult> end)
         {
             if (begin == null)
@@ -276,9 +260,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, IObservable<TResult>> FromAsyncPattern<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TResult>(Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, AsyncCallback, object, IAsyncResult> begin, Func<IAsyncResult, TResult> end)
         {
             if (begin == null)
@@ -312,9 +294,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, IObservable<TResult>> FromAsyncPattern<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TResult>(Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, AsyncCallback, object, IAsyncResult> begin, Func<IAsyncResult, TResult> end)
         {
             if (begin == null)
@@ -349,9 +329,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, IObservable<TResult>> FromAsyncPattern<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TResult>(Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, AsyncCallback, object, IAsyncResult> begin, Func<IAsyncResult, TResult> end)
         {
             if (begin == null)
@@ -387,9 +365,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TArg11, IObservable<TResult>> FromAsyncPattern<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TArg11, TResult>(Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TArg11, AsyncCallback, object, IAsyncResult> begin, Func<IAsyncResult, TResult> end)
         {
             if (begin == null)
@@ -426,9 +402,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TArg11, TArg12, IObservable<TResult>> FromAsyncPattern<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TArg11, TArg12, TResult>(Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TArg11, TArg12, AsyncCallback, object, IAsyncResult> begin, Func<IAsyncResult, TResult> end)
         {
             if (begin == null)
@@ -466,9 +440,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TArg11, TArg12, TArg13, IObservable<TResult>> FromAsyncPattern<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TArg11, TArg12, TArg13, TResult>(Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TArg11, TArg12, TArg13, AsyncCallback, object, IAsyncResult> begin, Func<IAsyncResult, TResult> end)
         {
             if (begin == null)
@@ -507,9 +479,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TArg11, TArg12, TArg13, TArg14, IObservable<TResult>> FromAsyncPattern<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TArg11, TArg12, TArg13, TArg14, TResult>(Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TArg11, TArg12, TArg13, TArg14, AsyncCallback, object, IAsyncResult> begin, Func<IAsyncResult, TResult> end)
         {
             if (begin == null)
@@ -537,9 +507,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result (represented as a Unit value) as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<IObservable<Unit>> FromAsyncPattern(Func<AsyncCallback, object, IAsyncResult> begin, Action<IAsyncResult> end)
         {
             if (begin == null)
@@ -564,9 +532,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result (represented as a Unit value) as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<TArg1, IObservable<Unit>> FromAsyncPattern<TArg1>(Func<TArg1, AsyncCallback, object, IAsyncResult> begin, Action<IAsyncResult> end)
         {
             if (begin == null)
@@ -592,9 +558,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result (represented as a Unit value) as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<TArg1, TArg2, IObservable<Unit>> FromAsyncPattern<TArg1, TArg2>(Func<TArg1, TArg2, AsyncCallback, object, IAsyncResult> begin, Action<IAsyncResult> end)
         {
             if (begin == null)
@@ -621,9 +585,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result (represented as a Unit value) as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<TArg1, TArg2, TArg3, IObservable<Unit>> FromAsyncPattern<TArg1, TArg2, TArg3>(Func<TArg1, TArg2, TArg3, AsyncCallback, object, IAsyncResult> begin, Action<IAsyncResult> end)
         {
             if (begin == null)
@@ -651,9 +613,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result (represented as a Unit value) as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<TArg1, TArg2, TArg3, TArg4, IObservable<Unit>> FromAsyncPattern<TArg1, TArg2, TArg3, TArg4>(Func<TArg1, TArg2, TArg3, TArg4, AsyncCallback, object, IAsyncResult> begin, Action<IAsyncResult> end)
         {
             if (begin == null)
@@ -682,9 +642,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result (represented as a Unit value) as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, IObservable<Unit>> FromAsyncPattern<TArg1, TArg2, TArg3, TArg4, TArg5>(Func<TArg1, TArg2, TArg3, TArg4, TArg5, AsyncCallback, object, IAsyncResult> begin, Action<IAsyncResult> end)
         {
             if (begin == null)
@@ -714,9 +672,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result (represented as a Unit value) as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, IObservable<Unit>> FromAsyncPattern<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6>(Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, AsyncCallback, object, IAsyncResult> begin, Action<IAsyncResult> end)
         {
             if (begin == null)
@@ -747,9 +703,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result (represented as a Unit value) as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, IObservable<Unit>> FromAsyncPattern<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7>(Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, AsyncCallback, object, IAsyncResult> begin, Action<IAsyncResult> end)
         {
             if (begin == null)
@@ -781,9 +735,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result (represented as a Unit value) as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, IObservable<Unit>> FromAsyncPattern<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8>(Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, AsyncCallback, object, IAsyncResult> begin, Action<IAsyncResult> end)
         {
             if (begin == null)
@@ -816,9 +768,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result (represented as a Unit value) as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, IObservable<Unit>> FromAsyncPattern<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9>(Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, AsyncCallback, object, IAsyncResult> begin, Action<IAsyncResult> end)
         {
             if (begin == null)
@@ -852,9 +802,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result (represented as a Unit value) as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, IObservable<Unit>> FromAsyncPattern<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10>(Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, AsyncCallback, object, IAsyncResult> begin, Action<IAsyncResult> end)
         {
             if (begin == null)
@@ -889,9 +837,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result (represented as a Unit value) as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TArg11, IObservable<Unit>> FromAsyncPattern<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TArg11>(Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TArg11, AsyncCallback, object, IAsyncResult> begin, Action<IAsyncResult> end)
         {
             if (begin == null)
@@ -927,9 +873,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result (represented as a Unit value) as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TArg11, TArg12, IObservable<Unit>> FromAsyncPattern<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TArg11, TArg12>(Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TArg11, TArg12, AsyncCallback, object, IAsyncResult> begin, Action<IAsyncResult> end)
         {
             if (begin == null)
@@ -966,9 +910,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result (represented as a Unit value) as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TArg11, TArg12, TArg13, IObservable<Unit>> FromAsyncPattern<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TArg11, TArg12, TArg13>(Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TArg11, TArg12, TArg13, AsyncCallback, object, IAsyncResult> begin, Action<IAsyncResult> end)
         {
             if (begin == null)
@@ -1006,9 +948,7 @@ namespace System.Reactive.Linq
         /// <returns>Function that can be used to start the asynchronous operation and retrieve the result (represented as a Unit value) as an observable sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="begin"/> or <paramref name="end"/> is null.</exception>
         /// <remarks>Each invocation of the resulting function will cause the asynchronous operation to be started. Subscription to the resulting sequence has no observable side-effect, and each subscription will produce the asynchronous operation's result.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseTaskFromAsyncPattern)]
-#endif
         public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TArg11, TArg12, TArg13, TArg14, IObservable<Unit>> FromAsyncPattern<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TArg11, TArg12, TArg13, TArg14>(Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TArg11, TArg12, TArg13, TArg14, AsyncCallback, object, IAsyncResult> begin, Action<IAsyncResult> end)
         {
             if (begin == null)

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable.Blocking.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable.Blocking.cs
@@ -110,9 +110,7 @@ namespace System.Reactive.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         /// <exception cref="InvalidOperationException">The source sequence is empty.</exception>
         /// <seealso cref="Observable.FirstAsync{TSource}(IObservable{TSource})"/>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseAsync)]
-#endif
         public static TSource First<TSource>(this IObservable<TSource> source)
         {
             if (source == null)
@@ -133,9 +131,7 @@ namespace System.Reactive.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="predicate"/> is null.</exception>
         /// <exception cref="InvalidOperationException">No element satisfies the condition in the predicate. -or- The source sequence is empty.</exception>
         /// <seealso cref="Observable.FirstAsync{TSource}(IObservable{TSource}, Func{TSource, bool})"/>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseAsync)]
-#endif
         public static TSource First<TSource>(this IObservable<TSource> source, Func<TSource, bool> predicate)
         {
             if (source == null)
@@ -163,9 +159,7 @@ namespace System.Reactive.Linq
         /// <returns>The first element in the observable sequence, or a default value if no such element exists.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         /// <seealso cref="Observable.FirstOrDefaultAsync{TSource}(IObservable{TSource})"/>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseAsync)]
-#endif
         public static TSource FirstOrDefault<TSource>(this IObservable<TSource> source)
         {
             if (source == null)
@@ -185,9 +179,7 @@ namespace System.Reactive.Linq
         /// <returns>The first element in the observable sequence that satisfies the condition in the predicate, or a default value if no such element exists.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="predicate"/> is null.</exception>
         /// <seealso cref="Observable.FirstOrDefaultAsync{TSource}(IObservable{TSource}, Func{TSource, bool})"/>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseAsync)]
-#endif
         public static TSource FirstOrDefault<TSource>(this IObservable<TSource> source, Func<TSource, bool> predicate)
         {
             if (source == null)
@@ -215,9 +207,7 @@ namespace System.Reactive.Linq
         /// <param name="onNext">Action to invoke for each element in the observable sequence.</param>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="onNext"/> is null.</exception>
         /// <remarks>Because of its blocking nature, this operator is mainly used for testing.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseAsync)]
-#endif
         public static void ForEach<TSource>(this IObservable<TSource> source, Action<TSource> onNext)
         {
             if (source == null)
@@ -241,9 +231,7 @@ namespace System.Reactive.Linq
         /// <param name="onNext">Action to invoke for each element in the observable sequence.</param>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="onNext"/> is null.</exception>
         /// <remarks>Because of its blocking nature, this operator is mainly used for testing.</remarks>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseAsync)]
-#endif
         public static void ForEach<TSource>(this IObservable<TSource> source, Action<TSource, int> onNext)
         {
             if (source == null)
@@ -293,9 +281,7 @@ namespace System.Reactive.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         /// <exception cref="InvalidOperationException">The source sequence is empty.</exception>
         /// <seealso cref="Observable.LastAsync{TSource}(IObservable{TSource})"/>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseAsync)]
-#endif
         public static TSource Last<TSource>(this IObservable<TSource> source)
         {
             if (source == null)
@@ -316,9 +302,7 @@ namespace System.Reactive.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="predicate"/> is null.</exception>
         /// <exception cref="InvalidOperationException">No element satisfies the condition in the predicate. -or- The source sequence is empty.</exception>
         /// <seealso cref="Observable.LastAsync{TSource}(IObservable{TSource}, Func{TSource, bool})"/>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseAsync)]
-#endif
         public static TSource Last<TSource>(this IObservable<TSource> source, Func<TSource, bool> predicate)
         {
             if (source == null)
@@ -346,9 +330,7 @@ namespace System.Reactive.Linq
         /// <returns>The last element in the observable sequence, or a default value if no such element exists.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         /// <seealso cref="Observable.LastOrDefaultAsync{TSource}(IObservable{TSource})"/>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseAsync)]
-#endif
         public static TSource LastOrDefault<TSource>(this IObservable<TSource> source)
         {
             if (source == null)
@@ -368,9 +350,7 @@ namespace System.Reactive.Linq
         /// <returns>The last element in the observable sequence that satisfies the condition in the predicate, or a default value if no such element exists.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="predicate"/> is null.</exception>
         /// <seealso cref="Observable.LastOrDefaultAsync{TSource}(IObservable{TSource}, Func{TSource, bool})"/>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseAsync)]
-#endif
         public static TSource LastOrDefault<TSource>(this IObservable<TSource> source, Func<TSource, bool> predicate)
         {
             if (source == null)
@@ -465,9 +445,7 @@ namespace System.Reactive.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         /// <exception cref="InvalidOperationException">The source sequence contains more than one element. -or- The source sequence is empty.</exception>
         /// <seealso cref="Observable.SingleAsync{TSource}(IObservable{TSource})"/>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseAsync)]
-#endif
         public static TSource Single<TSource>(this IObservable<TSource> source)
         {
             if (source == null)
@@ -488,9 +466,7 @@ namespace System.Reactive.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="predicate"/> is null.</exception>
         /// <exception cref="InvalidOperationException">No element satisfies the condition in the predicate. -or- More than one element satisfies the condition in the predicate. -or- The source sequence is empty.</exception>
         /// <seealso cref="Observable.SingleAsync{TSource}(IObservable{TSource}, Func{TSource, bool})"/>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseAsync)]
-#endif
         public static TSource Single<TSource>(this IObservable<TSource> source, Func<TSource, bool> predicate)
         {
             if (source == null)
@@ -519,9 +495,7 @@ namespace System.Reactive.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         /// <exception cref="InvalidOperationException">The source sequence contains more than one element.</exception>
         /// <seealso cref="Observable.SingleOrDefaultAsync{TSource}(IObservable{TSource})"/>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseAsync)]
-#endif
         public static TSource SingleOrDefault<TSource>(this IObservable<TSource> source)
         {
             if (source == null)
@@ -542,9 +516,7 @@ namespace System.Reactive.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="predicate"/> is null.</exception>
         /// <exception cref="InvalidOperationException">The sequence contains more than one element that satisfies the condition in the predicate.</exception>
         /// <seealso cref="Observable.SingleOrDefaultAsync{TSource}(IObservable{TSource}, Func{TSource, bool})"/>
-#if PREFER_ASYNC
         [Obsolete(Constants_Linq.UseAsync)]
-#endif
         public static TSource SingleOrDefault<TSource>(this IObservable<TSource> source, Func<TSource, bool> predicate)
         {
             if (source == null)

--- a/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Imperative.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Imperative.cs
@@ -49,11 +49,7 @@ namespace System.Reactive.Linq
             {
                 ctr = cancellationToken.Register(() =>
                 {
-#if HAS_TPL46
                     tcs.TrySetCanceled(cancellationToken);
-#else
-                    tcs.TrySetCanceled();
-#endif
                     subscription.Dispose();
                 });
             }

--- a/Rx.NET/Source/src/System.Reactive/Platforms/Desktop/Linq/Observable.Remoting.cs
+++ b/Rx.NET/Source/src/System.Reactive/Platforms/Desktop/Linq/Observable.Remoting.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
-#if !NO_REMOTING
+#if HAS_REMOTING
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.Remoting.Lifetime;

--- a/Rx.NET/Source/src/System.Reactive/Platforms/Desktop/Linq/QueryLanguage.Remoting.cs
+++ b/Rx.NET/Source/src/System.Reactive/Platforms/Desktop/Linq/QueryLanguage.Remoting.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
-#if !NO_REMOTING
+#if HAS_REMOTING
 using System.Reactive.Disposables;
 using System.Runtime.Remoting;
 using System.Runtime.Remoting.Lifetime;

--- a/Rx.NET/Source/src/System.Reactive/Threading/Tasks/TaskObservableExtensions.cs
+++ b/Rx.NET/Source/src/System.Reactive/Threading/Tasks/TaskObservableExtensions.cs
@@ -485,11 +485,7 @@ namespace System.Reactive.Threading.Tasks
             private void Cancel()
             {
                 Dispose();
-#if HAS_TPL46
                 _tcs.TrySetCanceled(_ct);
-#else
-                _tcs.TrySetCanceled();
-#endif
             }
         }
 

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/DefaultConcurrencyAbstractionLayerTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/DefaultConcurrencyAbstractionLayerTest.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
-#if !NO_REMOTING
+#if HAS_REMOTING
 using System;
 using System.Reactive.Concurrency;
 using System.Reactive.PlatformServices;

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/ObservableRemotingTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/ObservableRemotingTest.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
-#if !NO_REMOTING
+#if HAS_REMOTING
 
 using System;
 using System.Reactive.Linq;

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/SystemClockTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/SystemClockTest.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
-#if !NO_REMOTING && !XUNIT
+#if HAS_REMOTING && !XUNIT
 using System;
 using System.Collections.Generic;
 using System.Reactive;


### PR DESCRIPTION
Remove `#if` checks that are always true. Flip the `#if` checks to encode the exceptional case rather than the common case, thus reducing the number of `#define`s (e.g. `NO_TRACE` and `HAS_REMOTING` are the exceptions to the rule).

NB: For the time being, I'm leaving `HAS_WINRT` alone. I'll review these cases separately, because they're often combined with `CRIPPLED_REFLECTION` which also needs some closer look. If we can deprecate UAP 10.0 at some point, a lot more `#if` checks can go away.

NB: The `PREFER_ASYNC` stuff was used to control `[Obsolete]` attributes on various blocking members. I'll look into the steps towards final removal of these, given they've been marked as such for a long time (will review the history to make a call; alternatively, we can make the warning stronger and start removing a lot of code by layering the blocking ones on top of the non-blocking ones using the pattern we expect users to write, e.g. `.GetAwaiter().GetResult()`).