### PR TITLE
Reduce legacy reflection stuff

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Internal/CurrentPlatformEnlightenmentProvider.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/CurrentPlatformEnlightenmentProvider.cs
@@ -77,16 +77,13 @@ namespace System.Reactive.PlatformServices
                 //
                 if (Debugger.IsAttached)
                 {
-
-#if (CRIPPLED_REFLECTION && HAS_WINRT)
                     var ifType = t.GetTypeInfo();
-#else
-                    var ifType = t;
-#endif
+
                     var asm = new AssemblyName(ifType.Assembly.FullName)
                     {
                         Name = "System.Reactive"
                     };
+
                     var name = "System.Reactive.Linq.QueryDebugger, " + asm.FullName;
 
                     var dbg = Type.GetType(name, false);

--- a/Rx.NET/Source/src/System.Reactive/Internal/ReflectionUtils.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/ReflectionUtils.cs
@@ -29,7 +29,7 @@ namespace System.Reactive
 
             if (target == null)
             {
-                e = targetType.GetEventEx(eventName, isStatic: true);
+                e = targetType.GetEvent(eventName, BindingFlags.Public | BindingFlags.Static);
                 if (e == null)
                 {
                     throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Strings_Linq.COULD_NOT_FIND_STATIC_EVENT, eventName, targetType.FullName));
@@ -37,7 +37,7 @@ namespace System.Reactive
             }
             else
             {
-                e = targetType.GetEventEx(eventName, isStatic: false);
+                e = targetType.GetEvent(eventName, BindingFlags.Public | BindingFlags.Instance);
                 if (e == null)
                 {
                     throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Strings_Linq.COULD_NOT_FIND_INSTANCE_EVENT, eventName, targetType.FullName));
@@ -109,11 +109,6 @@ namespace System.Reactive
             {
                 throw new InvalidOperationException(Strings_Linq.EVENT_MUST_RETURN_VOID);
             }
-        }
-
-        public static EventInfo GetEventEx(this Type type, string name, bool isStatic)
-        {
-            return type.GetEvent(name, isStatic ? BindingFlags.Public | BindingFlags.Static : BindingFlags.Public | BindingFlags.Instance);
         }
 
 #if (CRIPPLED_REFLECTION && HAS_WINRT)


### PR DESCRIPTION
Remove some more legacy stuff due to the `TypeInfo` split of the reflection APIs back in the WinRT days. More stuff to follow.