### PR TITLE
Convert operator signatures to use ValueTask.

### DIFF
--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Joins/AsyncPattern.Generated.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Joins/AsyncPattern.Generated.cs
@@ -23,7 +23,7 @@ namespace System.Reactive.Joins
             return new AsyncPlan<TSource1, TResult>(this, selector);
         }
 
-        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, Task<TResult>> selector)
+        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, ValueTask<TResult>> selector)
         {
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
@@ -51,7 +51,7 @@ namespace System.Reactive.Joins
             return new AsyncPlan<TSource1, TSource2, TResult>(this, selector);
         }
 
-        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, Task<TResult>> selector)
+        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, ValueTask<TResult>> selector)
         {
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
@@ -81,7 +81,7 @@ namespace System.Reactive.Joins
             return new AsyncPlan<TSource1, TSource2, TSource3, TResult>(this, selector);
         }
 
-        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, TSource3, Task<TResult>> selector)
+        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, TSource3, ValueTask<TResult>> selector)
         {
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
@@ -113,7 +113,7 @@ namespace System.Reactive.Joins
             return new AsyncPlan<TSource1, TSource2, TSource3, TSource4, TResult>(this, selector);
         }
 
-        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, TSource3, TSource4, Task<TResult>> selector)
+        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, TSource3, TSource4, ValueTask<TResult>> selector)
         {
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
@@ -147,7 +147,7 @@ namespace System.Reactive.Joins
             return new AsyncPlan<TSource1, TSource2, TSource3, TSource4, TSource5, TResult>(this, selector);
         }
 
-        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, TSource3, TSource4, TSource5, Task<TResult>> selector)
+        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, TSource3, TSource4, TSource5, ValueTask<TResult>> selector)
         {
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
@@ -183,7 +183,7 @@ namespace System.Reactive.Joins
             return new AsyncPlan<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TResult>(this, selector);
         }
 
-        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, Task<TResult>> selector)
+        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, ValueTask<TResult>> selector)
         {
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
@@ -221,7 +221,7 @@ namespace System.Reactive.Joins
             return new AsyncPlan<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TResult>(this, selector);
         }
 
-        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, Task<TResult>> selector)
+        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, ValueTask<TResult>> selector)
         {
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
@@ -261,7 +261,7 @@ namespace System.Reactive.Joins
             return new AsyncPlan<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TResult>(this, selector);
         }
 
-        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, Task<TResult>> selector)
+        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, ValueTask<TResult>> selector)
         {
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
@@ -303,7 +303,7 @@ namespace System.Reactive.Joins
             return new AsyncPlan<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TResult>(this, selector);
         }
 
-        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, Task<TResult>> selector)
+        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, ValueTask<TResult>> selector)
         {
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
@@ -347,7 +347,7 @@ namespace System.Reactive.Joins
             return new AsyncPlan<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TResult>(this, selector);
         }
 
-        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, Task<TResult>> selector)
+        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, ValueTask<TResult>> selector)
         {
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
@@ -393,7 +393,7 @@ namespace System.Reactive.Joins
             return new AsyncPlan<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TResult>(this, selector);
         }
 
-        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, Task<TResult>> selector)
+        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, ValueTask<TResult>> selector)
         {
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
@@ -441,7 +441,7 @@ namespace System.Reactive.Joins
             return new AsyncPlan<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TResult>(this, selector);
         }
 
-        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, Task<TResult>> selector)
+        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, ValueTask<TResult>> selector)
         {
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
@@ -491,7 +491,7 @@ namespace System.Reactive.Joins
             return new AsyncPlan<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TResult>(this, selector);
         }
 
-        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, Task<TResult>> selector)
+        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, ValueTask<TResult>> selector)
         {
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
@@ -543,7 +543,7 @@ namespace System.Reactive.Joins
             return new AsyncPlan<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TResult>(this, selector);
         }
 
-        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, Task<TResult>> selector)
+        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, ValueTask<TResult>> selector)
         {
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
@@ -597,7 +597,7 @@ namespace System.Reactive.Joins
             return new AsyncPlan<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15, TResult>(this, selector);
         }
 
-        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15, Task<TResult>> selector)
+        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15, ValueTask<TResult>> selector)
         {
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
@@ -653,7 +653,7 @@ namespace System.Reactive.Joins
             return new AsyncPlan<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15, TSource16, TResult>(this, selector);
         }
 
-        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15, TSource16, Task<TResult>> selector)
+        public AsyncPlan<TResult> Then<TResult>(Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15, TSource16, ValueTask<TResult>> selector)
         {
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Joins/AsyncPattern.Generated.tt
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Joins/AsyncPattern.Generated.tt
@@ -49,7 +49,7 @@ for (var j = 1; j <= i; j++)
             return new AsyncPlan<<#=genArgs#>, TResult>(this, selector);
         }
 
-        public AsyncPlan<TResult> Then<TResult>(Func<<#=genArgs#>, Task<TResult>> selector)
+        public AsyncPlan<TResult> Then<TResult>(Func<<#=genArgs#>, ValueTask<TResult>> selector)
         {
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Joins/AsyncPlan.Generated.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Joins/AsyncPlan.Generated.cs
@@ -17,20 +17,20 @@ namespace System.Reactive.Joins
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1) => Task.FromResult(_selector(arg1));
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1) => new ValueTask<TResult>(_selector(arg1));
     }
 
     internal sealed class AsyncPlanWithTask<TSource1, TResult> : AsyncPlanBase<TSource1, TResult>
     {
-        private readonly Func<TSource1, Task<TResult>> _selector;
+        private readonly Func<TSource1, ValueTask<TResult>> _selector;
 
-        internal AsyncPlanWithTask(AsyncPattern<TSource1> expression, Func<TSource1, Task<TResult>> selector)
+        internal AsyncPlanWithTask(AsyncPattern<TSource1> expression, Func<TSource1, ValueTask<TResult>> selector)
             : base(expression)
         {
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1) => _selector(arg1);
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1) => _selector(arg1);
     }
 
     internal abstract class AsyncPlanBase<TSource1, TResult> : AsyncPlan<TResult>
@@ -42,9 +42,9 @@ namespace System.Reactive.Joins
             _expression = expression;
         }
 
-        protected abstract Task<TResult> EvalAsync(TSource1 arg1); // REVIEW: Consider the use of ValueTask<TResult>.
+        protected abstract ValueTask<TResult> EvalAsync(TSource1 arg1);
 
-        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, Task> deactivate)
+        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, ValueTask> deactivate)
         {
             var onError = new Func<Exception, ValueTask>(observer.OnErrorAsync);
 
@@ -93,20 +93,20 @@ namespace System.Reactive.Joins
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2) => Task.FromResult(_selector(arg1, arg2));
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2) => new ValueTask<TResult>(_selector(arg1, arg2));
     }
 
     internal sealed class AsyncPlanWithTask<TSource1, TSource2, TResult> : AsyncPlanBase<TSource1, TSource2, TResult>
     {
-        private readonly Func<TSource1, TSource2, Task<TResult>> _selector;
+        private readonly Func<TSource1, TSource2, ValueTask<TResult>> _selector;
 
-        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2> expression, Func<TSource1, TSource2, Task<TResult>> selector)
+        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2> expression, Func<TSource1, TSource2, ValueTask<TResult>> selector)
             : base(expression)
         {
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2) => _selector(arg1, arg2);
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2) => _selector(arg1, arg2);
     }
 
     internal abstract class AsyncPlanBase<TSource1, TSource2, TResult> : AsyncPlan<TResult>
@@ -118,9 +118,9 @@ namespace System.Reactive.Joins
             _expression = expression;
         }
 
-        protected abstract Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2); // REVIEW: Consider the use of ValueTask<TResult>.
+        protected abstract ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2);
 
-        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, Task> deactivate)
+        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, ValueTask> deactivate)
         {
             var onError = new Func<Exception, ValueTask>(observer.OnErrorAsync);
 
@@ -173,20 +173,20 @@ namespace System.Reactive.Joins
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3) => Task.FromResult(_selector(arg1, arg2, arg3));
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3) => new ValueTask<TResult>(_selector(arg1, arg2, arg3));
     }
 
     internal sealed class AsyncPlanWithTask<TSource1, TSource2, TSource3, TResult> : AsyncPlanBase<TSource1, TSource2, TSource3, TResult>
     {
-        private readonly Func<TSource1, TSource2, TSource3, Task<TResult>> _selector;
+        private readonly Func<TSource1, TSource2, TSource3, ValueTask<TResult>> _selector;
 
-        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2, TSource3> expression, Func<TSource1, TSource2, TSource3, Task<TResult>> selector)
+        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2, TSource3> expression, Func<TSource1, TSource2, TSource3, ValueTask<TResult>> selector)
             : base(expression)
         {
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3) => _selector(arg1, arg2, arg3);
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3) => _selector(arg1, arg2, arg3);
     }
 
     internal abstract class AsyncPlanBase<TSource1, TSource2, TSource3, TResult> : AsyncPlan<TResult>
@@ -198,9 +198,9 @@ namespace System.Reactive.Joins
             _expression = expression;
         }
 
-        protected abstract Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3); // REVIEW: Consider the use of ValueTask<TResult>.
+        protected abstract ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3);
 
-        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, Task> deactivate)
+        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, ValueTask> deactivate)
         {
             var onError = new Func<Exception, ValueTask>(observer.OnErrorAsync);
 
@@ -257,20 +257,20 @@ namespace System.Reactive.Joins
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4) => Task.FromResult(_selector(arg1, arg2, arg3, arg4));
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4) => new ValueTask<TResult>(_selector(arg1, arg2, arg3, arg4));
     }
 
     internal sealed class AsyncPlanWithTask<TSource1, TSource2, TSource3, TSource4, TResult> : AsyncPlanBase<TSource1, TSource2, TSource3, TSource4, TResult>
     {
-        private readonly Func<TSource1, TSource2, TSource3, TSource4, Task<TResult>> _selector;
+        private readonly Func<TSource1, TSource2, TSource3, TSource4, ValueTask<TResult>> _selector;
 
-        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2, TSource3, TSource4> expression, Func<TSource1, TSource2, TSource3, TSource4, Task<TResult>> selector)
+        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2, TSource3, TSource4> expression, Func<TSource1, TSource2, TSource3, TSource4, ValueTask<TResult>> selector)
             : base(expression)
         {
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4) => _selector(arg1, arg2, arg3, arg4);
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4) => _selector(arg1, arg2, arg3, arg4);
     }
 
     internal abstract class AsyncPlanBase<TSource1, TSource2, TSource3, TSource4, TResult> : AsyncPlan<TResult>
@@ -282,9 +282,9 @@ namespace System.Reactive.Joins
             _expression = expression;
         }
 
-        protected abstract Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4); // REVIEW: Consider the use of ValueTask<TResult>.
+        protected abstract ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4);
 
-        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, Task> deactivate)
+        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, ValueTask> deactivate)
         {
             var onError = new Func<Exception, ValueTask>(observer.OnErrorAsync);
 
@@ -345,20 +345,20 @@ namespace System.Reactive.Joins
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5) => Task.FromResult(_selector(arg1, arg2, arg3, arg4, arg5));
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5) => new ValueTask<TResult>(_selector(arg1, arg2, arg3, arg4, arg5));
     }
 
     internal sealed class AsyncPlanWithTask<TSource1, TSource2, TSource3, TSource4, TSource5, TResult> : AsyncPlanBase<TSource1, TSource2, TSource3, TSource4, TSource5, TResult>
     {
-        private readonly Func<TSource1, TSource2, TSource3, TSource4, TSource5, Task<TResult>> _selector;
+        private readonly Func<TSource1, TSource2, TSource3, TSource4, TSource5, ValueTask<TResult>> _selector;
 
-        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2, TSource3, TSource4, TSource5> expression, Func<TSource1, TSource2, TSource3, TSource4, TSource5, Task<TResult>> selector)
+        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2, TSource3, TSource4, TSource5> expression, Func<TSource1, TSource2, TSource3, TSource4, TSource5, ValueTask<TResult>> selector)
             : base(expression)
         {
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5) => _selector(arg1, arg2, arg3, arg4, arg5);
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5) => _selector(arg1, arg2, arg3, arg4, arg5);
     }
 
     internal abstract class AsyncPlanBase<TSource1, TSource2, TSource3, TSource4, TSource5, TResult> : AsyncPlan<TResult>
@@ -370,9 +370,9 @@ namespace System.Reactive.Joins
             _expression = expression;
         }
 
-        protected abstract Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5); // REVIEW: Consider the use of ValueTask<TResult>.
+        protected abstract ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5);
 
-        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, Task> deactivate)
+        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, ValueTask> deactivate)
         {
             var onError = new Func<Exception, ValueTask>(observer.OnErrorAsync);
 
@@ -437,20 +437,20 @@ namespace System.Reactive.Joins
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6) => Task.FromResult(_selector(arg1, arg2, arg3, arg4, arg5, arg6));
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6) => new ValueTask<TResult>(_selector(arg1, arg2, arg3, arg4, arg5, arg6));
     }
 
     internal sealed class AsyncPlanWithTask<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TResult> : AsyncPlanBase<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TResult>
     {
-        private readonly Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, Task<TResult>> _selector;
+        private readonly Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, ValueTask<TResult>> _selector;
 
-        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6> expression, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, Task<TResult>> selector)
+        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6> expression, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, ValueTask<TResult>> selector)
             : base(expression)
         {
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6) => _selector(arg1, arg2, arg3, arg4, arg5, arg6);
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6) => _selector(arg1, arg2, arg3, arg4, arg5, arg6);
     }
 
     internal abstract class AsyncPlanBase<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TResult> : AsyncPlan<TResult>
@@ -462,9 +462,9 @@ namespace System.Reactive.Joins
             _expression = expression;
         }
 
-        protected abstract Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6); // REVIEW: Consider the use of ValueTask<TResult>.
+        protected abstract ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6);
 
-        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, Task> deactivate)
+        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, ValueTask> deactivate)
         {
             var onError = new Func<Exception, ValueTask>(observer.OnErrorAsync);
 
@@ -533,20 +533,20 @@ namespace System.Reactive.Joins
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7) => Task.FromResult(_selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7));
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7) => new ValueTask<TResult>(_selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7));
     }
 
     internal sealed class AsyncPlanWithTask<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TResult> : AsyncPlanBase<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TResult>
     {
-        private readonly Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, Task<TResult>> _selector;
+        private readonly Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, ValueTask<TResult>> _selector;
 
-        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7> expression, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, Task<TResult>> selector)
+        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7> expression, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, ValueTask<TResult>> selector)
             : base(expression)
         {
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7) => _selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7) => _selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7);
     }
 
     internal abstract class AsyncPlanBase<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TResult> : AsyncPlan<TResult>
@@ -558,9 +558,9 @@ namespace System.Reactive.Joins
             _expression = expression;
         }
 
-        protected abstract Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7); // REVIEW: Consider the use of ValueTask<TResult>.
+        protected abstract ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7);
 
-        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, Task> deactivate)
+        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, ValueTask> deactivate)
         {
             var onError = new Func<Exception, ValueTask>(observer.OnErrorAsync);
 
@@ -633,20 +633,20 @@ namespace System.Reactive.Joins
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8) => Task.FromResult(_selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8));
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8) => new ValueTask<TResult>(_selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8));
     }
 
     internal sealed class AsyncPlanWithTask<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TResult> : AsyncPlanBase<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TResult>
     {
-        private readonly Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, Task<TResult>> _selector;
+        private readonly Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, ValueTask<TResult>> _selector;
 
-        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8> expression, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, Task<TResult>> selector)
+        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8> expression, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, ValueTask<TResult>> selector)
             : base(expression)
         {
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8) => _selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8) => _selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
     }
 
     internal abstract class AsyncPlanBase<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TResult> : AsyncPlan<TResult>
@@ -658,9 +658,9 @@ namespace System.Reactive.Joins
             _expression = expression;
         }
 
-        protected abstract Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8); // REVIEW: Consider the use of ValueTask<TResult>.
+        protected abstract ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8);
 
-        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, Task> deactivate)
+        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, ValueTask> deactivate)
         {
             var onError = new Func<Exception, ValueTask>(observer.OnErrorAsync);
 
@@ -737,20 +737,20 @@ namespace System.Reactive.Joins
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9) => Task.FromResult(_selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9));
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9) => new ValueTask<TResult>(_selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9));
     }
 
     internal sealed class AsyncPlanWithTask<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TResult> : AsyncPlanBase<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TResult>
     {
-        private readonly Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, Task<TResult>> _selector;
+        private readonly Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, ValueTask<TResult>> _selector;
 
-        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9> expression, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, Task<TResult>> selector)
+        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9> expression, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, ValueTask<TResult>> selector)
             : base(expression)
         {
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9) => _selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9) => _selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
     }
 
     internal abstract class AsyncPlanBase<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TResult> : AsyncPlan<TResult>
@@ -762,9 +762,9 @@ namespace System.Reactive.Joins
             _expression = expression;
         }
 
-        protected abstract Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9); // REVIEW: Consider the use of ValueTask<TResult>.
+        protected abstract ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9);
 
-        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, Task> deactivate)
+        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, ValueTask> deactivate)
         {
             var onError = new Func<Exception, ValueTask>(observer.OnErrorAsync);
 
@@ -845,20 +845,20 @@ namespace System.Reactive.Joins
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10) => Task.FromResult(_selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10));
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10) => new ValueTask<TResult>(_selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10));
     }
 
     internal sealed class AsyncPlanWithTask<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TResult> : AsyncPlanBase<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TResult>
     {
-        private readonly Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, Task<TResult>> _selector;
+        private readonly Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, ValueTask<TResult>> _selector;
 
-        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10> expression, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, Task<TResult>> selector)
+        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10> expression, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, ValueTask<TResult>> selector)
             : base(expression)
         {
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10) => _selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10) => _selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
     }
 
     internal abstract class AsyncPlanBase<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TResult> : AsyncPlan<TResult>
@@ -870,9 +870,9 @@ namespace System.Reactive.Joins
             _expression = expression;
         }
 
-        protected abstract Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10); // REVIEW: Consider the use of ValueTask<TResult>.
+        protected abstract ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10);
 
-        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, Task> deactivate)
+        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, ValueTask> deactivate)
         {
             var onError = new Func<Exception, ValueTask>(observer.OnErrorAsync);
 
@@ -957,20 +957,20 @@ namespace System.Reactive.Joins
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11) => Task.FromResult(_selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11));
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11) => new ValueTask<TResult>(_selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11));
     }
 
     internal sealed class AsyncPlanWithTask<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TResult> : AsyncPlanBase<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TResult>
     {
-        private readonly Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, Task<TResult>> _selector;
+        private readonly Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, ValueTask<TResult>> _selector;
 
-        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11> expression, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, Task<TResult>> selector)
+        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11> expression, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, ValueTask<TResult>> selector)
             : base(expression)
         {
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11) => _selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11) => _selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
     }
 
     internal abstract class AsyncPlanBase<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TResult> : AsyncPlan<TResult>
@@ -982,9 +982,9 @@ namespace System.Reactive.Joins
             _expression = expression;
         }
 
-        protected abstract Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11); // REVIEW: Consider the use of ValueTask<TResult>.
+        protected abstract ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11);
 
-        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, Task> deactivate)
+        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, ValueTask> deactivate)
         {
             var onError = new Func<Exception, ValueTask>(observer.OnErrorAsync);
 
@@ -1073,20 +1073,20 @@ namespace System.Reactive.Joins
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12) => Task.FromResult(_selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12));
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12) => new ValueTask<TResult>(_selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12));
     }
 
     internal sealed class AsyncPlanWithTask<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TResult> : AsyncPlanBase<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TResult>
     {
-        private readonly Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, Task<TResult>> _selector;
+        private readonly Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, ValueTask<TResult>> _selector;
 
-        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12> expression, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, Task<TResult>> selector)
+        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12> expression, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, ValueTask<TResult>> selector)
             : base(expression)
         {
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12) => _selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12) => _selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
     }
 
     internal abstract class AsyncPlanBase<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TResult> : AsyncPlan<TResult>
@@ -1098,9 +1098,9 @@ namespace System.Reactive.Joins
             _expression = expression;
         }
 
-        protected abstract Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12); // REVIEW: Consider the use of ValueTask<TResult>.
+        protected abstract ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12);
 
-        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, Task> deactivate)
+        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, ValueTask> deactivate)
         {
             var onError = new Func<Exception, ValueTask>(observer.OnErrorAsync);
 
@@ -1193,20 +1193,20 @@ namespace System.Reactive.Joins
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12, TSource13 arg13) => Task.FromResult(_selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13));
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12, TSource13 arg13) => new ValueTask<TResult>(_selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13));
     }
 
     internal sealed class AsyncPlanWithTask<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TResult> : AsyncPlanBase<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TResult>
     {
-        private readonly Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, Task<TResult>> _selector;
+        private readonly Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, ValueTask<TResult>> _selector;
 
-        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13> expression, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, Task<TResult>> selector)
+        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13> expression, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, ValueTask<TResult>> selector)
             : base(expression)
         {
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12, TSource13 arg13) => _selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12, TSource13 arg13) => _selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
     }
 
     internal abstract class AsyncPlanBase<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TResult> : AsyncPlan<TResult>
@@ -1218,9 +1218,9 @@ namespace System.Reactive.Joins
             _expression = expression;
         }
 
-        protected abstract Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12, TSource13 arg13); // REVIEW: Consider the use of ValueTask<TResult>.
+        protected abstract ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12, TSource13 arg13);
 
-        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, Task> deactivate)
+        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, ValueTask> deactivate)
         {
             var onError = new Func<Exception, ValueTask>(observer.OnErrorAsync);
 
@@ -1317,20 +1317,20 @@ namespace System.Reactive.Joins
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12, TSource13 arg13, TSource14 arg14) => Task.FromResult(_selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14));
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12, TSource13 arg13, TSource14 arg14) => new ValueTask<TResult>(_selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14));
     }
 
     internal sealed class AsyncPlanWithTask<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TResult> : AsyncPlanBase<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TResult>
     {
-        private readonly Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, Task<TResult>> _selector;
+        private readonly Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, ValueTask<TResult>> _selector;
 
-        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14> expression, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, Task<TResult>> selector)
+        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14> expression, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, ValueTask<TResult>> selector)
             : base(expression)
         {
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12, TSource13 arg13, TSource14 arg14) => _selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12, TSource13 arg13, TSource14 arg14) => _selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
     }
 
     internal abstract class AsyncPlanBase<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TResult> : AsyncPlan<TResult>
@@ -1342,9 +1342,9 @@ namespace System.Reactive.Joins
             _expression = expression;
         }
 
-        protected abstract Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12, TSource13 arg13, TSource14 arg14); // REVIEW: Consider the use of ValueTask<TResult>.
+        protected abstract ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12, TSource13 arg13, TSource14 arg14);
 
-        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, Task> deactivate)
+        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, ValueTask> deactivate)
         {
             var onError = new Func<Exception, ValueTask>(observer.OnErrorAsync);
 
@@ -1445,20 +1445,20 @@ namespace System.Reactive.Joins
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12, TSource13 arg13, TSource14 arg14, TSource15 arg15) => Task.FromResult(_selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15));
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12, TSource13 arg13, TSource14 arg14, TSource15 arg15) => new ValueTask<TResult>(_selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15));
     }
 
     internal sealed class AsyncPlanWithTask<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15, TResult> : AsyncPlanBase<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15, TResult>
     {
-        private readonly Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15, Task<TResult>> _selector;
+        private readonly Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15, ValueTask<TResult>> _selector;
 
-        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15> expression, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15, Task<TResult>> selector)
+        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15> expression, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15, ValueTask<TResult>> selector)
             : base(expression)
         {
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12, TSource13 arg13, TSource14 arg14, TSource15 arg15) => _selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15);
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12, TSource13 arg13, TSource14 arg14, TSource15 arg15) => _selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15);
     }
 
     internal abstract class AsyncPlanBase<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15, TResult> : AsyncPlan<TResult>
@@ -1470,9 +1470,9 @@ namespace System.Reactive.Joins
             _expression = expression;
         }
 
-        protected abstract Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12, TSource13 arg13, TSource14 arg14, TSource15 arg15); // REVIEW: Consider the use of ValueTask<TResult>.
+        protected abstract ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12, TSource13 arg13, TSource14 arg14, TSource15 arg15);
 
-        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, Task> deactivate)
+        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, ValueTask> deactivate)
         {
             var onError = new Func<Exception, ValueTask>(observer.OnErrorAsync);
 
@@ -1577,20 +1577,20 @@ namespace System.Reactive.Joins
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12, TSource13 arg13, TSource14 arg14, TSource15 arg15, TSource16 arg16) => Task.FromResult(_selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16));
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12, TSource13 arg13, TSource14 arg14, TSource15 arg15, TSource16 arg16) => new ValueTask<TResult>(_selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16));
     }
 
     internal sealed class AsyncPlanWithTask<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15, TSource16, TResult> : AsyncPlanBase<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15, TSource16, TResult>
     {
-        private readonly Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15, TSource16, Task<TResult>> _selector;
+        private readonly Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15, TSource16, ValueTask<TResult>> _selector;
 
-        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15, TSource16> expression, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15, TSource16, Task<TResult>> selector)
+        internal AsyncPlanWithTask(AsyncPattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15, TSource16> expression, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15, TSource16, ValueTask<TResult>> selector)
             : base(expression)
         {
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12, TSource13 arg13, TSource14 arg14, TSource15 arg15, TSource16 arg16) => _selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
+        protected override ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12, TSource13 arg13, TSource14 arg14, TSource15 arg15, TSource16 arg16) => _selector(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
     }
 
     internal abstract class AsyncPlanBase<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15, TSource16, TResult> : AsyncPlan<TResult>
@@ -1602,9 +1602,9 @@ namespace System.Reactive.Joins
             _expression = expression;
         }
 
-        protected abstract Task<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12, TSource13 arg13, TSource14 arg14, TSource15 arg15, TSource16 arg16); // REVIEW: Consider the use of ValueTask<TResult>.
+        protected abstract ValueTask<TResult> EvalAsync(TSource1 arg1, TSource2 arg2, TSource3 arg3, TSource4 arg4, TSource5 arg5, TSource6 arg6, TSource7 arg7, TSource8 arg8, TSource9 arg9, TSource10 arg10, TSource11 arg11, TSource12 arg12, TSource13 arg13, TSource14 arg14, TSource15 arg15, TSource16 arg16);
 
-        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, Task> deactivate)
+        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, ValueTask> deactivate)
         {
             var onError = new Func<Exception, ValueTask>(observer.OnErrorAsync);
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Joins/AsyncPlan.Generated.tt
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Joins/AsyncPlan.Generated.tt
@@ -31,20 +31,20 @@ for (var i = 1; i <= 16; i++)
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(<#=evalPars#>) => Task.FromResult(_selector(<#=pars#>));
+        protected override ValueTask<TResult> EvalAsync(<#=evalPars#>) => new ValueTask<TResult>(_selector(<#=pars#>));
     }
 
     internal sealed class AsyncPlanWithTask<<#=genArgs#>, TResult> : AsyncPlanBase<<#=genArgs#>, TResult>
     {
-        private readonly Func<<#=genArgs#>, Task<TResult>> _selector;
+        private readonly Func<<#=genArgs#>, ValueTask<TResult>> _selector;
 
-        internal AsyncPlanWithTask(AsyncPattern<<#=genArgs#>> expression, Func<<#=genArgs#>, Task<TResult>> selector)
+        internal AsyncPlanWithTask(AsyncPattern<<#=genArgs#>> expression, Func<<#=genArgs#>, ValueTask<TResult>> selector)
             : base(expression)
         {
             _selector = selector;
         }
 
-        protected override Task<TResult> EvalAsync(<#=evalPars#>) => _selector(<#=pars#>);
+        protected override ValueTask<TResult> EvalAsync(<#=evalPars#>) => _selector(<#=pars#>);
     }
 
     internal abstract class AsyncPlanBase<<#=genArgs#>, TResult> : AsyncPlan<TResult>
@@ -56,9 +56,9 @@ for (var i = 1; i <= 16; i++)
             _expression = expression;
         }
 
-        protected abstract Task<TResult> EvalAsync(<#=evalPars#>); // REVIEW: Consider the use of ValueTask<TResult>.
+        protected abstract ValueTask<TResult> EvalAsync(<#=evalPars#>);
 
-        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, Task> deactivate)
+        internal override ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, ValueTask> deactivate)
         {
             var onError = new Func<Exception, ValueTask>(observer.OnErrorAsync);
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Joins/AsyncPlan.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Joins/AsyncPlan.cs
@@ -13,7 +13,7 @@ namespace System.Reactive.Joins
         {
         }
 
-        internal abstract ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, Task> deactivate);
+        internal abstract ActiveAsyncPlan Activate(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObserver<TResult> observer, Func<ActiveAsyncPlan, ValueTask> deactivate);
 
         internal static AsyncJoinObserver<TSource> CreateObserver<TSource>(Dictionary<object, IAsyncJoinObserver> externalSubscriptions, IAsyncObservable<TSource> observable, Func<Exception, ValueTask> onError)
         {

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Aggregate.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Aggregate.cs
@@ -18,7 +18,7 @@ namespace System.Reactive.Linq
             return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, func)));
         }
 
-        public static IAsyncObservable<TSource> Aggregate<TSource>(this IAsyncObservable<TSource> source, Func<TSource, TSource, Task<TSource>> func)
+        public static IAsyncObservable<TSource> Aggregate<TSource>(this IAsyncObservable<TSource> source, Func<TSource, TSource, ValueTask<TSource>> func)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -38,7 +38,7 @@ namespace System.Reactive.Linq
             return Create<TResult>(observer => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, seed, func)));
         }
 
-        public static IAsyncObservable<TResult> Aggregate<TSource, TResult>(this IAsyncObservable<TSource> source, TResult seed, Func<TResult, TSource, Task<TResult>> func)
+        public static IAsyncObservable<TResult> Aggregate<TSource, TResult>(this IAsyncObservable<TSource> source, TResult seed, Func<TResult, TSource, ValueTask<TResult>> func)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -60,7 +60,7 @@ namespace System.Reactive.Linq
             return Create<TResult>(observer => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, seed, func, resultSelector)));
         }
 
-        public static IAsyncObservable<TResult> Aggregate<TSource, TAccumulate, TResult>(this IAsyncObservable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, Task<TAccumulate>> func, Func<TAccumulate, Task<TResult>> resultSelector)
+        public static IAsyncObservable<TResult> Aggregate<TSource, TAccumulate, TResult>(this IAsyncObservable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, ValueTask<TAccumulate>> func, Func<TAccumulate, ValueTask<TResult>> resultSelector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -122,7 +122,7 @@ namespace System.Reactive.Linq
             );
         }
 
-        public static IAsyncObserver<TSource> Aggregate<TSource>(IAsyncObserver<TSource> observer, Func<TSource, TSource, Task<TSource>> func)
+        public static IAsyncObserver<TSource> Aggregate<TSource>(IAsyncObserver<TSource> observer, Func<TSource, TSource, ValueTask<TSource>> func)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -179,14 +179,14 @@ namespace System.Reactive.Linq
             return Aggregate(observer, seed, func, a => a);
         }
 
-        public static IAsyncObserver<TSource> Aggregate<TSource, TResult>(IAsyncObserver<TResult> observer, TResult seed, Func<TResult, TSource, Task<TResult>> func)
+        public static IAsyncObserver<TSource> Aggregate<TSource, TResult>(IAsyncObserver<TResult> observer, TResult seed, Func<TResult, TSource, ValueTask<TResult>> func)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Aggregate<TSource, TResult, TResult>(observer, seed, (a, x) => func(a, x), a => Task.FromResult(a));
+            return Aggregate<TSource, TResult, TResult>(observer, seed, (a, x) => func(a, x), a => new ValueTask<TResult>(a));
         }
 
         public static IAsyncObserver<TSource> Aggregate<TSource, TAccumulate, TResult>(IAsyncObserver<TResult> observer, TAccumulate seed, Func<TAccumulate, TSource, TAccumulate> func, Func<TAccumulate, TResult> resultSelector)
@@ -234,7 +234,7 @@ namespace System.Reactive.Linq
             );
         }
 
-        public static IAsyncObserver<TSource> Aggregate<TSource, TAccumulate, TResult>(IAsyncObserver<TResult> observer, TAccumulate seed, Func<TAccumulate, TSource, Task<TAccumulate>> func, Func<TAccumulate, Task<TResult>> resultSelector)
+        public static IAsyncObserver<TSource> Aggregate<TSource, TAccumulate, TResult>(IAsyncObserver<TResult> observer, TAccumulate seed, Func<TAccumulate, TSource, ValueTask<TAccumulate>> func, Func<TAccumulate, ValueTask<TResult>> resultSelector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/All.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/All.cs
@@ -18,7 +18,7 @@ namespace System.Reactive.Linq
             return Create<bool>(observer => source.SubscribeSafeAsync(AsyncObserver.All(observer, predicate)));
         }
 
-        public static IAsyncObservable<bool> All<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<bool>> predicate)
+        public static IAsyncObservable<bool> All<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -68,7 +68,7 @@ namespace System.Reactive.Linq
             );
         }
 
-        public static IAsyncObserver<TSource> All<TSource>(IAsyncObserver<bool> observer, Func<TSource, Task<bool>> predicate)
+        public static IAsyncObserver<TSource> All<TSource>(IAsyncObserver<bool> observer, Func<TSource, ValueTask<bool>> predicate)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Any.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Any.cs
@@ -26,7 +26,7 @@ namespace System.Reactive.Linq
             return Create<bool>(observer => source.SubscribeSafeAsync(AsyncObserver.Any(observer, predicate)));
         }
 
-        public static IAsyncObservable<bool> Any<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<bool>> predicate)
+        public static IAsyncObservable<bool> Any<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -96,7 +96,7 @@ namespace System.Reactive.Linq
             );
         }
 
-        public static IAsyncObserver<TSource> Any<TSource>(IAsyncObserver<bool> observer, Func<TSource, Task<bool>> predicate)
+        public static IAsyncObserver<TSource> Any<TSource>(IAsyncObserver<bool> observer, Func<TSource, ValueTask<bool>> predicate)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Average.Generated.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Average.Generated.cs
@@ -26,7 +26,7 @@ namespace System.Reactive.Linq
             return Create<Double>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageInt32(observer, selector)));
         }
 
-        public static IAsyncObservable<Double> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Int32>> selector)
+        public static IAsyncObservable<Double> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int32>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -54,7 +54,7 @@ namespace System.Reactive.Linq
             return Create<Double?>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageNullableInt32(observer, selector)));
         }
 
-        public static IAsyncObservable<Double?> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Int32?>> selector)
+        public static IAsyncObservable<Double?> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int32?>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -82,7 +82,7 @@ namespace System.Reactive.Linq
             return Create<Double>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageInt64(observer, selector)));
         }
 
-        public static IAsyncObservable<Double> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Int64>> selector)
+        public static IAsyncObservable<Double> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int64>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -110,7 +110,7 @@ namespace System.Reactive.Linq
             return Create<Double?>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageNullableInt64(observer, selector)));
         }
 
-        public static IAsyncObservable<Double?> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Int64?>> selector)
+        public static IAsyncObservable<Double?> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int64?>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -138,7 +138,7 @@ namespace System.Reactive.Linq
             return Create<Single>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageSingle(observer, selector)));
         }
 
-        public static IAsyncObservable<Single> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Single>> selector)
+        public static IAsyncObservable<Single> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Single>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -166,7 +166,7 @@ namespace System.Reactive.Linq
             return Create<Single?>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageNullableSingle(observer, selector)));
         }
 
-        public static IAsyncObservable<Single?> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Single?>> selector)
+        public static IAsyncObservable<Single?> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Single?>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -194,7 +194,7 @@ namespace System.Reactive.Linq
             return Create<Double>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageDouble(observer, selector)));
         }
 
-        public static IAsyncObservable<Double> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Double>> selector)
+        public static IAsyncObservable<Double> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Double>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -222,7 +222,7 @@ namespace System.Reactive.Linq
             return Create<Double?>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageNullableDouble(observer, selector)));
         }
 
-        public static IAsyncObservable<Double?> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Double?>> selector)
+        public static IAsyncObservable<Double?> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Double?>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -250,7 +250,7 @@ namespace System.Reactive.Linq
             return Create<Decimal>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageDecimal(observer, selector)));
         }
 
-        public static IAsyncObservable<Decimal> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Decimal>> selector)
+        public static IAsyncObservable<Decimal> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Decimal>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -278,7 +278,7 @@ namespace System.Reactive.Linq
             return Create<Decimal?>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageNullableDecimal(observer, selector)));
         }
 
-        public static IAsyncObservable<Decimal?> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Decimal?>> selector)
+        public static IAsyncObservable<Decimal?> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Decimal?>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -302,7 +302,7 @@ namespace System.Reactive.Linq
             return Select(AverageInt32(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> AverageInt32<TSource>(IAsyncObserver<Double> observer, Func<TSource, Task<Int32>> selector)
+        public static IAsyncObserver<TSource> AverageInt32<TSource>(IAsyncObserver<Double> observer, Func<TSource, ValueTask<Int32>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -322,7 +322,7 @@ namespace System.Reactive.Linq
             return Select(AverageNullableInt32(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> AverageNullableInt32<TSource>(IAsyncObserver<Double?> observer, Func<TSource, Task<Int32?>> selector)
+        public static IAsyncObserver<TSource> AverageNullableInt32<TSource>(IAsyncObserver<Double?> observer, Func<TSource, ValueTask<Int32?>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -342,7 +342,7 @@ namespace System.Reactive.Linq
             return Select(AverageInt64(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> AverageInt64<TSource>(IAsyncObserver<Double> observer, Func<TSource, Task<Int64>> selector)
+        public static IAsyncObserver<TSource> AverageInt64<TSource>(IAsyncObserver<Double> observer, Func<TSource, ValueTask<Int64>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -362,7 +362,7 @@ namespace System.Reactive.Linq
             return Select(AverageNullableInt64(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> AverageNullableInt64<TSource>(IAsyncObserver<Double?> observer, Func<TSource, Task<Int64?>> selector)
+        public static IAsyncObserver<TSource> AverageNullableInt64<TSource>(IAsyncObserver<Double?> observer, Func<TSource, ValueTask<Int64?>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -382,7 +382,7 @@ namespace System.Reactive.Linq
             return Select(AverageSingle(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> AverageSingle<TSource>(IAsyncObserver<Single> observer, Func<TSource, Task<Single>> selector)
+        public static IAsyncObserver<TSource> AverageSingle<TSource>(IAsyncObserver<Single> observer, Func<TSource, ValueTask<Single>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -402,7 +402,7 @@ namespace System.Reactive.Linq
             return Select(AverageNullableSingle(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> AverageNullableSingle<TSource>(IAsyncObserver<Single?> observer, Func<TSource, Task<Single?>> selector)
+        public static IAsyncObserver<TSource> AverageNullableSingle<TSource>(IAsyncObserver<Single?> observer, Func<TSource, ValueTask<Single?>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -422,7 +422,7 @@ namespace System.Reactive.Linq
             return Select(AverageDouble(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> AverageDouble<TSource>(IAsyncObserver<Double> observer, Func<TSource, Task<Double>> selector)
+        public static IAsyncObserver<TSource> AverageDouble<TSource>(IAsyncObserver<Double> observer, Func<TSource, ValueTask<Double>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -442,7 +442,7 @@ namespace System.Reactive.Linq
             return Select(AverageNullableDouble(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> AverageNullableDouble<TSource>(IAsyncObserver<Double?> observer, Func<TSource, Task<Double?>> selector)
+        public static IAsyncObserver<TSource> AverageNullableDouble<TSource>(IAsyncObserver<Double?> observer, Func<TSource, ValueTask<Double?>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -462,7 +462,7 @@ namespace System.Reactive.Linq
             return Select(AverageDecimal(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> AverageDecimal<TSource>(IAsyncObserver<Decimal> observer, Func<TSource, Task<Decimal>> selector)
+        public static IAsyncObserver<TSource> AverageDecimal<TSource>(IAsyncObserver<Decimal> observer, Func<TSource, ValueTask<Decimal>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -482,7 +482,7 @@ namespace System.Reactive.Linq
             return Select(AverageNullableDecimal(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> AverageNullableDecimal<TSource>(IAsyncObserver<Decimal?> observer, Func<TSource, Task<Decimal?>> selector)
+        public static IAsyncObserver<TSource> AverageNullableDecimal<TSource>(IAsyncObserver<Decimal?> observer, Func<TSource, ValueTask<Decimal?>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Average.Generated.tt
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Average.Generated.tt
@@ -56,7 +56,7 @@ foreach (var t in types)
             return Create<<#=targetTypeName#>>(observer => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
         }
 
-        public static IAsyncObservable<<#=targetTypeName#>> <#=name#><TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<<#=sourceTypeName#>>> selector)
+        public static IAsyncObservable<<#=targetTypeName#>> <#=name#><TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<<#=sourceTypeName#>>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -97,7 +97,7 @@ foreach (var t in types)
             return Select(<#=name#><#=methodName#>(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> <#=name#><#=methodName#><TSource>(IAsyncObserver<<#=targetTypeName#>> observer, Func<TSource, Task<<#=sourceTypeName#>>> selector)
+        public static IAsyncObserver<TSource> <#=name#><#=methodName#><TSource>(IAsyncObserver<<#=targetTypeName#>> observer, Func<TSource, ValueTask<<#=sourceTypeName#>>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Case.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Case.cs
@@ -45,11 +45,11 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> Case<TValue, TResult>(Func<Task<TValue>> selector, IDictionary<TValue, IAsyncObservable<TResult>> sources) => Case(selector, sources, Empty<TResult>());
+        public static IAsyncObservable<TResult> Case<TValue, TResult>(Func<ValueTask<TValue>> selector, IDictionary<TValue, IAsyncObservable<TResult>> sources) => Case(selector, sources, Empty<TResult>());
 
-        public static IAsyncObservable<TResult> Case<TValue, TResult>(Func<Task<TValue>> selector, IDictionary<TValue, IAsyncObservable<TResult>> sources, IAsyncScheduler scheduler) => Case(selector, sources, Empty<TResult>(scheduler));
+        public static IAsyncObservable<TResult> Case<TValue, TResult>(Func<ValueTask<TValue>> selector, IDictionary<TValue, IAsyncObservable<TResult>> sources, IAsyncScheduler scheduler) => Case(selector, sources, Empty<TResult>(scheduler));
 
-        public static IAsyncObservable<TResult> Case<TValue, TResult>(Func<Task<TValue>> selector, IDictionary<TValue, IAsyncObservable<TResult>> sources, IAsyncObservable<TResult> defaultSource)
+        public static IAsyncObservable<TResult> Case<TValue, TResult>(Func<ValueTask<TValue>> selector, IDictionary<TValue, IAsyncObservable<TResult>> sources, IAsyncObservable<TResult> defaultSource)
         {
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Catch.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Catch.cs
@@ -30,7 +30,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TSource> Catch<TSource, TException>(this IAsyncObservable<TSource> source, Func<TException, Task<IAsyncObservable<TSource>>> handler)
+        public static IAsyncObservable<TSource> Catch<TSource, TException>(this IAsyncObservable<TSource> source, Func<TException, ValueTask<IAsyncObservable<TSource>>> handler)
             where TException : Exception
         {
             if (source == null)
@@ -102,10 +102,10 @@ namespace System.Reactive.Linq
             if (handler == null)
                 throw new ArgumentNullException(nameof(handler));
 
-            return Catch<TSource, TException>(observer, ex => Task.FromResult(handler(ex)));
+            return Catch<TSource, TException>(observer, ex => new ValueTask<IAsyncObservable<TSource>>(handler(ex)));
         }
 
-        public static (IAsyncObserver<TSource>, IAsyncDisposable) Catch<TSource, TException>(IAsyncObserver<TSource> observer, Func<TException, Task<IAsyncObservable<TSource>>> handler)
+        public static (IAsyncObserver<TSource>, IAsyncDisposable) Catch<TSource, TException>(IAsyncObserver<TSource> observer, Func<TException, ValueTask<IAsyncObservable<TSource>>> handler)
             where TException : Exception
         {
             if (observer == null)

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/CombineLatest.Generated.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/CombineLatest.Generated.cs
@@ -56,7 +56,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> CombineLatest<T1, T2, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, Func<T1, T2, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> CombineLatest<T1, T2, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, Func<T1, T2, ValueTask<TResult>> selector)
         {
             if (source1 == null)
                 throw new ArgumentNullException(nameof(source1));
@@ -132,7 +132,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> CombineLatest<T1, T2, T3, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, Func<T1, T2, T3, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> CombineLatest<T1, T2, T3, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, Func<T1, T2, T3, ValueTask<TResult>> selector)
         {
             if (source1 == null)
                 throw new ArgumentNullException(nameof(source1));
@@ -217,7 +217,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> CombineLatest<T1, T2, T3, T4, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, Func<T1, T2, T3, T4, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> CombineLatest<T1, T2, T3, T4, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, Func<T1, T2, T3, T4, ValueTask<TResult>> selector)
         {
             if (source1 == null)
                 throw new ArgumentNullException(nameof(source1));
@@ -311,7 +311,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> CombineLatest<T1, T2, T3, T4, T5, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, Func<T1, T2, T3, T4, T5, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> CombineLatest<T1, T2, T3, T4, T5, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, Func<T1, T2, T3, T4, T5, ValueTask<TResult>> selector)
         {
             if (source1 == null)
                 throw new ArgumentNullException(nameof(source1));
@@ -414,7 +414,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, Func<T1, T2, T3, T4, T5, T6, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, Func<T1, T2, T3, T4, T5, T6, ValueTask<TResult>> selector)
         {
             if (source1 == null)
                 throw new ArgumentNullException(nameof(source1));
@@ -526,7 +526,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, T7, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, Func<T1, T2, T3, T4, T5, T6, T7, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, T7, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, Func<T1, T2, T3, T4, T5, T6, T7, ValueTask<TResult>> selector)
         {
             if (source1 == null)
                 throw new ArgumentNullException(nameof(source1));
@@ -647,7 +647,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, Func<T1, T2, T3, T4, T5, T6, T7, T8, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, Func<T1, T2, T3, T4, T5, T6, T7, T8, ValueTask<TResult>> selector)
         {
             if (source1 == null)
                 throw new ArgumentNullException(nameof(source1));
@@ -777,7 +777,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, IAsyncObservable<T9> source9, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, IAsyncObservable<T9> source9, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, ValueTask<TResult>> selector)
         {
             if (source1 == null)
                 throw new ArgumentNullException(nameof(source1));
@@ -916,7 +916,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, IAsyncObservable<T9> source9, IAsyncObservable<T10> source10, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, IAsyncObservable<T9> source9, IAsyncObservable<T10> source10, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, ValueTask<TResult>> selector)
         {
             if (source1 == null)
                 throw new ArgumentNullException(nameof(source1));
@@ -1064,7 +1064,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, IAsyncObservable<T9> source9, IAsyncObservable<T10> source10, IAsyncObservable<T11> source11, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, IAsyncObservable<T9> source9, IAsyncObservable<T10> source10, IAsyncObservable<T11> source11, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, ValueTask<TResult>> selector)
         {
             if (source1 == null)
                 throw new ArgumentNullException(nameof(source1));
@@ -1221,7 +1221,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, IAsyncObservable<T9> source9, IAsyncObservable<T10> source10, IAsyncObservable<T11> source11, IAsyncObservable<T12> source12, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, IAsyncObservable<T9> source9, IAsyncObservable<T10> source10, IAsyncObservable<T11> source11, IAsyncObservable<T12> source12, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, ValueTask<TResult>> selector)
         {
             if (source1 == null)
                 throw new ArgumentNullException(nameof(source1));
@@ -1387,7 +1387,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, IAsyncObservable<T9> source9, IAsyncObservable<T10> source10, IAsyncObservable<T11> source11, IAsyncObservable<T12> source12, IAsyncObservable<T13> source13, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, IAsyncObservable<T9> source9, IAsyncObservable<T10> source10, IAsyncObservable<T11> source11, IAsyncObservable<T12> source12, IAsyncObservable<T13> source13, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, ValueTask<TResult>> selector)
         {
             if (source1 == null)
                 throw new ArgumentNullException(nameof(source1));
@@ -1562,7 +1562,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, IAsyncObservable<T9> source9, IAsyncObservable<T10> source10, IAsyncObservable<T11> source11, IAsyncObservable<T12> source12, IAsyncObservable<T13> source13, IAsyncObservable<T14> source14, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, IAsyncObservable<T9> source9, IAsyncObservable<T10> source10, IAsyncObservable<T11> source11, IAsyncObservable<T12> source12, IAsyncObservable<T13> source13, IAsyncObservable<T14> source14, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, ValueTask<TResult>> selector)
         {
             if (source1 == null)
                 throw new ArgumentNullException(nameof(source1));
@@ -1746,7 +1746,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, IAsyncObservable<T9> source9, IAsyncObservable<T10> source10, IAsyncObservable<T11> source11, IAsyncObservable<T12> source12, IAsyncObservable<T13> source13, IAsyncObservable<T14> source14, IAsyncObservable<T15> source15, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, IAsyncObservable<T9> source9, IAsyncObservable<T10> source10, IAsyncObservable<T11> source11, IAsyncObservable<T12> source12, IAsyncObservable<T13> source13, IAsyncObservable<T14> source14, IAsyncObservable<T15> source15, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, ValueTask<TResult>> selector)
         {
             if (source1 == null)
                 throw new ArgumentNullException(nameof(source1));
@@ -1927,10 +1927,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return CombineLatest<T1, T2, TResult>(observer, (x1, x2) => Task.FromResult(selector(x1, x2)));
+            return CombineLatest<T1, T2, TResult>(observer, (x1, x2) => new ValueTask<TResult>(selector(x1, x2)));
         }
 
-        public static (IAsyncObserver<T1>, IAsyncObserver<T2>) CombineLatest<T1, T2, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, Task<TResult>> selector)
+        public static (IAsyncObserver<T1>, IAsyncObserver<T2>) CombineLatest<T1, T2, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -2221,10 +2221,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return CombineLatest<T1, T2, T3, TResult>(observer, (x1, x2, x3) => Task.FromResult(selector(x1, x2, x3)));
+            return CombineLatest<T1, T2, T3, TResult>(observer, (x1, x2, x3) => new ValueTask<TResult>(selector(x1, x2, x3)));
         }
 
-        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>) CombineLatest<T1, T2, T3, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, Task<TResult>> selector)
+        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>) CombineLatest<T1, T2, T3, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -2618,10 +2618,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return CombineLatest<T1, T2, T3, T4, TResult>(observer, (x1, x2, x3, x4) => Task.FromResult(selector(x1, x2, x3, x4)));
+            return CombineLatest<T1, T2, T3, T4, TResult>(observer, (x1, x2, x3, x4) => new ValueTask<TResult>(selector(x1, x2, x3, x4)));
         }
 
-        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>) CombineLatest<T1, T2, T3, T4, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, Task<TResult>> selector)
+        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>) CombineLatest<T1, T2, T3, T4, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -3118,10 +3118,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return CombineLatest<T1, T2, T3, T4, T5, TResult>(observer, (x1, x2, x3, x4, x5) => Task.FromResult(selector(x1, x2, x3, x4, x5)));
+            return CombineLatest<T1, T2, T3, T4, T5, TResult>(observer, (x1, x2, x3, x4, x5) => new ValueTask<TResult>(selector(x1, x2, x3, x4, x5)));
         }
 
-        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>) CombineLatest<T1, T2, T3, T4, T5, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, Task<TResult>> selector)
+        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>) CombineLatest<T1, T2, T3, T4, T5, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -3721,10 +3721,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return CombineLatest<T1, T2, T3, T4, T5, T6, TResult>(observer, (x1, x2, x3, x4, x5, x6) => Task.FromResult(selector(x1, x2, x3, x4, x5, x6)));
+            return CombineLatest<T1, T2, T3, T4, T5, T6, TResult>(observer, (x1, x2, x3, x4, x5, x6) => new ValueTask<TResult>(selector(x1, x2, x3, x4, x5, x6)));
         }
 
-        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>) CombineLatest<T1, T2, T3, T4, T5, T6, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, Task<TResult>> selector)
+        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>) CombineLatest<T1, T2, T3, T4, T5, T6, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -4427,10 +4427,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return CombineLatest<T1, T2, T3, T4, T5, T6, T7, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7) => Task.FromResult(selector(x1, x2, x3, x4, x5, x6, x7)));
+            return CombineLatest<T1, T2, T3, T4, T5, T6, T7, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7) => new ValueTask<TResult>(selector(x1, x2, x3, x4, x5, x6, x7)));
         }
 
-        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>) CombineLatest<T1, T2, T3, T4, T5, T6, T7, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, Task<TResult>> selector)
+        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>) CombineLatest<T1, T2, T3, T4, T5, T6, T7, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -5236,10 +5236,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8) => Task.FromResult(selector(x1, x2, x3, x4, x5, x6, x7, x8)));
+            return CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8) => new ValueTask<TResult>(selector(x1, x2, x3, x4, x5, x6, x7, x8)));
         }
 
-        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>) CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, Task<TResult>> selector)
+        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>) CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -6148,10 +6148,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8, x9) => Task.FromResult(selector(x1, x2, x3, x4, x5, x6, x7, x8, x9)));
+            return CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8, x9) => new ValueTask<TResult>(selector(x1, x2, x3, x4, x5, x6, x7, x8, x9)));
         }
 
-        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>, IAsyncObserver<T9>) CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, Task<TResult>> selector)
+        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>, IAsyncObserver<T9>) CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -7163,10 +7163,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10) => Task.FromResult(selector(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10)));
+            return CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10) => new ValueTask<TResult>(selector(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10)));
         }
 
-        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>, IAsyncObserver<T9>, IAsyncObserver<T10>) CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Task<TResult>> selector)
+        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>, IAsyncObserver<T9>, IAsyncObserver<T10>) CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -8281,10 +8281,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11) => Task.FromResult(selector(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11)));
+            return CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11) => new ValueTask<TResult>(selector(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11)));
         }
 
-        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>, IAsyncObserver<T9>, IAsyncObserver<T10>, IAsyncObserver<T11>) CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, Task<TResult>> selector)
+        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>, IAsyncObserver<T9>, IAsyncObserver<T10>, IAsyncObserver<T11>) CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -9502,10 +9502,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12) => Task.FromResult(selector(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12)));
+            return CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12) => new ValueTask<TResult>(selector(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12)));
         }
 
-        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>, IAsyncObserver<T9>, IAsyncObserver<T10>, IAsyncObserver<T11>, IAsyncObserver<T12>) CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, Task<TResult>> selector)
+        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>, IAsyncObserver<T9>, IAsyncObserver<T10>, IAsyncObserver<T11>, IAsyncObserver<T12>) CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -10826,10 +10826,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13) => Task.FromResult(selector(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13)));
+            return CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13) => new ValueTask<TResult>(selector(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13)));
         }
 
-        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>, IAsyncObserver<T9>, IAsyncObserver<T10>, IAsyncObserver<T11>, IAsyncObserver<T12>, IAsyncObserver<T13>) CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, Task<TResult>> selector)
+        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>, IAsyncObserver<T9>, IAsyncObserver<T10>, IAsyncObserver<T11>, IAsyncObserver<T12>, IAsyncObserver<T13>) CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -12253,10 +12253,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14) => Task.FromResult(selector(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14)));
+            return CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14) => new ValueTask<TResult>(selector(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14)));
         }
 
-        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>, IAsyncObserver<T9>, IAsyncObserver<T10>, IAsyncObserver<T11>, IAsyncObserver<T12>, IAsyncObserver<T13>, IAsyncObserver<T14>) CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, Task<TResult>> selector)
+        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>, IAsyncObserver<T9>, IAsyncObserver<T10>, IAsyncObserver<T11>, IAsyncObserver<T12>, IAsyncObserver<T13>, IAsyncObserver<T14>) CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -13783,10 +13783,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) => Task.FromResult(selector(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15)));
+            return CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) => new ValueTask<TResult>(selector(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15)));
         }
 
-        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>, IAsyncObserver<T9>, IAsyncObserver<T10>, IAsyncObserver<T11>, IAsyncObserver<T12>, IAsyncObserver<T13>, IAsyncObserver<T14>, IAsyncObserver<T15>) CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, Task<TResult>> selector)
+        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>, IAsyncObserver<T9>, IAsyncObserver<T10>, IAsyncObserver<T11>, IAsyncObserver<T12>, IAsyncObserver<T13>, IAsyncObserver<T14>, IAsyncObserver<T15>) CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/CombineLatest.Generated.tt
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/CombineLatest.Generated.tt
@@ -93,7 +93,7 @@ for (var j = 1; j <= i; j++)
             });
         }
 
-        public static IAsyncObservable<TResult> CombineLatest<<#=genPars#>>(this <#=args#>, Func<<#=genArgs#>, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> CombineLatest<<#=genPars#>>(this <#=args#>, Func<<#=genArgs#>, ValueTask<TResult>> selector)
         {
 <#
 for (var j = 1; j <= i; j++)
@@ -225,10 +225,10 @@ for (var j = 1; j <= i; j++)
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return CombineLatest<<#=genPars#>>(observer, (<#=string.Join(", ", Enumerable.Range(1, i).Select(j => "x" + j))#>) => Task.FromResult(selector(<#=string.Join(", ", Enumerable.Range(1, i).Select(j => "x" + j))#>)));
+            return CombineLatest<<#=genPars#>>(observer, (<#=string.Join(", ", Enumerable.Range(1, i).Select(j => "x" + j))#>) => new ValueTask<TResult>(selector(<#=string.Join(", ", Enumerable.Range(1, i).Select(j => "x" + j))#>)));
         }
 
-        public static <#=res#> CombineLatest<<#=genPars#>>(IAsyncObserver<TResult> observer, Func<<#=genArgs#>, Task<TResult>> selector)
+        public static <#=res#> CombineLatest<<#=genPars#>>(IAsyncObserver<TResult> observer, Func<<#=genArgs#>, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Count.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Count.cs
@@ -26,7 +26,7 @@ namespace System.Reactive.Linq
             return Create<int>(observer => source.SubscribeSafeAsync(AsyncObserver.Count(observer, predicate)));
         }
 
-        public static IAsyncObservable<int> Count<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<bool>> predicate)
+        public static IAsyncObservable<int> Count<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -81,7 +81,7 @@ namespace System.Reactive.Linq
             return Where(Count<TSource>(observer), predicate);
         }
 
-        public static IAsyncObserver<TSource> Count<TSource>(IAsyncObserver<int> observer, Func<TSource, Task<bool>> predicate)
+        public static IAsyncObserver<TSource> Count<TSource>(IAsyncObserver<int> observer, Func<TSource, ValueTask<bool>> predicate)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Defer.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Defer.cs
@@ -15,12 +15,12 @@ namespace System.Reactive.Linq
             if (observableFactory == null)
                 throw new ArgumentNullException(nameof(observableFactory));
 
-            return Defer(() => Task.FromResult(observableFactory()));
+            return Defer(() => new ValueTask<IAsyncObservable<TSource>>(observableFactory()));
         }
 
-        public static IAsyncObservable<TSource> DeferAsync<TSource>(Func<Task<IAsyncObservable<TSource>>> observableFactory) => Defer(observableFactory);
+        public static IAsyncObservable<TSource> DeferAsync<TSource>(Func<ValueTask<IAsyncObservable<TSource>>> observableFactory) => Defer(observableFactory);
 
-        public static IAsyncObservable<TSource> Defer<TSource>(Func<Task<IAsyncObservable<TSource>>> observableFactory)
+        public static IAsyncObservable<TSource> Defer<TSource>(Func<ValueTask<IAsyncObservable<TSource>>> observableFactory)
         {
             if (observableFactory == null)
                 throw new ArgumentNullException(nameof(observableFactory));
@@ -43,9 +43,9 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TSource> DeferAsync<TSource>(Func<CancellationToken, Task<IAsyncObservable<TSource>>> observableFactory) => DeferAsync(observableFactory);
+        public static IAsyncObservable<TSource> DeferAsync<TSource>(Func<CancellationToken, ValueTask<IAsyncObservable<TSource>>> observableFactory) => DeferAsync(observableFactory);
 
-        public static IAsyncObservable<TSource> Defer<TSource>(Func<CancellationToken, Task<IAsyncObservable<TSource>>> observableFactory)
+        public static IAsyncObservable<TSource> Defer<TSource>(Func<CancellationToken, ValueTask<IAsyncObservable<TSource>>> observableFactory)
         {
             if (observableFactory == null)
                 throw new ArgumentNullException(nameof(observableFactory));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/DistinctUntilChanged.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/DistinctUntilChanged.cs
@@ -37,7 +37,7 @@ namespace System.Reactive.Linq
             return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.DistinctUntilChanged(observer, keySelector)));
         }
 
-        public static IAsyncObservable<TSource> DistinctUntilChanged<TSource, TKey>(IAsyncObservable<TSource> source, Func<TSource, Task<TKey>> keySelector)
+        public static IAsyncObservable<TSource> DistinctUntilChanged<TSource, TKey>(IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -59,7 +59,7 @@ namespace System.Reactive.Linq
             return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.DistinctUntilChanged(observer, keySelector, comparer)));
         }
 
-        public static IAsyncObservable<TSource> DistinctUntilChanged<TSource, TKey>(IAsyncObservable<TSource> source, Func<TSource, Task<TKey>> keySelector, IEqualityComparer<TKey> comparer)
+        public static IAsyncObservable<TSource> DistinctUntilChanged<TSource, TKey>(IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, IEqualityComparer<TKey> comparer)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -102,7 +102,7 @@ namespace System.Reactive.Linq
             return DistinctUntilChanged(observer, keySelector, EqualityComparer<TKey>.Default);
         }
 
-        public static IAsyncObserver<TSource> DistinctUntilChanged<TSource, TKey>(IAsyncObserver<TSource> observer, Func<TSource, Task<TKey>> keySelector)
+        public static IAsyncObserver<TSource> DistinctUntilChanged<TSource, TKey>(IAsyncObserver<TSource> observer, Func<TSource, ValueTask<TKey>> keySelector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -167,7 +167,7 @@ namespace System.Reactive.Linq
             );
         }
 
-        public static IAsyncObserver<TSource> DistinctUntilChanged<TSource, TKey>(IAsyncObserver<TSource> observer, Func<TSource, Task<TKey>> keySelector, IEqualityComparer<TKey> comparer)
+        public static IAsyncObserver<TSource> DistinctUntilChanged<TSource, TKey>(IAsyncObserver<TSource> observer, Func<TSource, ValueTask<TKey>> keySelector, IEqualityComparer<TKey> comparer)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/DoWhile.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/DoWhile.cs
@@ -69,7 +69,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TSource> DoWhile<TSource>(IAsyncObservable<TSource> source, Func<Task<bool>> condition)
+        public static IAsyncObservable<TSource> DoWhile<TSource>(IAsyncObservable<TSource> source, Func<ValueTask<bool>> condition)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/First.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/First.cs
@@ -10,7 +10,7 @@ namespace System.Reactive.Linq
     {
         public static IAsyncObservable<TSource> FirstAsync<TSource>(this IAsyncObservable<TSource> source) => First(source);
         public static IAsyncObservable<TSource> FirstAsync<TSource>(this IAsyncObservable<TSource> source, Func<TSource, bool> predicate) => First(source, predicate);
-        public static IAsyncObservable<TSource> FirstAsync<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<bool>> predicate) => First(source, predicate);
+        public static IAsyncObservable<TSource> FirstAsync<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate) => First(source, predicate);
 
         public static IAsyncObservable<TSource> First<TSource>(this IAsyncObservable<TSource> source)
         {
@@ -30,7 +30,7 @@ namespace System.Reactive.Linq
             return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.First(observer, predicate)));
         }
 
-        public static IAsyncObservable<TSource> First<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<bool>> predicate)
+        public static IAsyncObservable<TSource> First<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -72,7 +72,7 @@ namespace System.Reactive.Linq
             return Where(First(observer), predicate);
         }
 
-        public static IAsyncObserver<TSource> First<TSource>(IAsyncObserver<TSource> observer, Func<TSource, Task<bool>> predicate)
+        public static IAsyncObserver<TSource> First<TSource>(IAsyncObserver<TSource> observer, Func<TSource, ValueTask<bool>> predicate)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/FirstOrDefault.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/FirstOrDefault.cs
@@ -10,7 +10,7 @@ namespace System.Reactive.Linq
     {
         public static IAsyncObservable<TSource> FirstOrDefaultAsync<TSource>(this IAsyncObservable<TSource> source) => FirstOrDefault(source);
         public static IAsyncObservable<TSource> FirstOrDefaultAsync<TSource>(this IAsyncObservable<TSource> source, Func<TSource, bool> predicate) => FirstOrDefault(source, predicate);
-        public static IAsyncObservable<TSource> FirstOrDefaultAsync<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<bool>> predicate) => FirstOrDefault(source, predicate);
+        public static IAsyncObservable<TSource> FirstOrDefaultAsync<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate) => FirstOrDefault(source, predicate);
 
         public static IAsyncObservable<TSource> FirstOrDefault<TSource>(this IAsyncObservable<TSource> source)
         {
@@ -30,7 +30,7 @@ namespace System.Reactive.Linq
             return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.FirstOrDefault(observer, predicate)));
         }
 
-        public static IAsyncObservable<TSource> FirstOrDefault<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<bool>> predicate)
+        public static IAsyncObservable<TSource> FirstOrDefault<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -73,7 +73,7 @@ namespace System.Reactive.Linq
             return Where(FirstOrDefault(observer), predicate);
         }
 
-        public static IAsyncObserver<TSource> FirstOrDefault<TSource>(IAsyncObserver<TSource> observer, Func<TSource, Task<bool>> predicate)
+        public static IAsyncObserver<TSource> FirstOrDefault<TSource>(IAsyncObserver<TSource> observer, Func<TSource, ValueTask<bool>> predicate)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/For.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/For.cs
@@ -20,10 +20,10 @@ namespace System.Reactive.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            return For(source, x => Task.FromResult(resultSelector(x)));
+            return For(source, x => new ValueTask<IAsyncObservable<TResult>>(resultSelector(x)));
         }
 
-        public static IAsyncObservable<TResult> For<TSource, TResult>(IEnumerable<TSource> source, Func<TSource, Task<IAsyncObservable<TResult>>> resultSelector)
+        public static IAsyncObservable<TResult> For<TSource, TResult>(IEnumerable<TSource> source, Func<TSource, ValueTask<IAsyncObservable<TResult>>> resultSelector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/FromAsync.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/FromAsync.cs
@@ -10,7 +10,7 @@ namespace System.Reactive.Linq
 {
     partial class AsyncObservable
     {
-        public static IAsyncObservable<TResult> FromAsync<TResult>(Func<Task<TResult>> functionAsync)
+        public static IAsyncObservable<TResult> FromAsync<TResult>(Func<ValueTask<TResult>> functionAsync)
         {
             if (functionAsync == null)
                 throw new ArgumentNullException(nameof(functionAsync));
@@ -18,7 +18,7 @@ namespace System.Reactive.Linq
             return Defer(() => StartAsync(functionAsync));
         }
 
-        public static IAsyncObservable<TResult> FromAsync<TResult>(Func<Task<TResult>> functionAsync, IAsyncScheduler scheduler)
+        public static IAsyncObservable<TResult> FromAsync<TResult>(Func<ValueTask<TResult>> functionAsync, IAsyncScheduler scheduler)
         {
             if (functionAsync == null)
                 throw new ArgumentNullException(nameof(functionAsync));
@@ -28,7 +28,7 @@ namespace System.Reactive.Linq
             return Defer(() => StartAsync(functionAsync, scheduler));
         }
 
-        public static IAsyncObservable<TResult> FromAsync<TResult>(Func<CancellationToken, Task<TResult>> functionAsync)
+        public static IAsyncObservable<TResult> FromAsync<TResult>(Func<CancellationToken, ValueTask<TResult>> functionAsync)
         {
             if (functionAsync == null)
                 throw new ArgumentNullException(nameof(functionAsync));
@@ -36,7 +36,7 @@ namespace System.Reactive.Linq
             return Defer(() => StartAsync(functionAsync));
         }
 
-        public static IAsyncObservable<TResult> FromAsync<TResult>(Func<CancellationToken, Task<TResult>> functionAsync, IAsyncScheduler scheduler)
+        public static IAsyncObservable<TResult> FromAsync<TResult>(Func<CancellationToken, ValueTask<TResult>> functionAsync, IAsyncScheduler scheduler)
         {
             if (functionAsync == null)
                 throw new ArgumentNullException(nameof(functionAsync));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Generate.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Generate.cs
@@ -35,7 +35,7 @@ namespace System.Reactive.Linq
             return Create<TResult>(observer => AsyncObserver.Generate(observer, initialState, condition, iterate, resultSelector, scheduler));
         }
 
-        public static IAsyncObservable<TResult> Generate<TState, TResult>(TState initialState, Func<TState, Task<bool>> condition, Func<TState, Task<TState>> iterate, Func<TState, Task<TResult>> resultSelector)
+        public static IAsyncObservable<TResult> Generate<TState, TResult>(TState initialState, Func<TState, ValueTask<bool>> condition, Func<TState, ValueTask<TState>> iterate, Func<TState, ValueTask<TResult>> resultSelector)
         {
             if (condition == null)
                 throw new ArgumentNullException(nameof(condition));
@@ -47,7 +47,7 @@ namespace System.Reactive.Linq
             return Create<TResult>(observer => AsyncObserver.Generate(observer, initialState, condition, iterate, resultSelector));
         }
 
-        public static IAsyncObservable<TResult> Generate<TState, TResult>(TState initialState, Func<TState, Task<bool>> condition, Func<TState, Task<TState>> iterate, Func<TState, Task<TResult>> resultSelector, IAsyncScheduler scheduler)
+        public static IAsyncObservable<TResult> Generate<TState, TResult>(TState initialState, Func<TState, ValueTask<bool>> condition, Func<TState, ValueTask<TState>> iterate, Func<TState, ValueTask<TResult>> resultSelector, IAsyncScheduler scheduler)
         {
             if (condition == null)
                 throw new ArgumentNullException(nameof(condition));
@@ -91,7 +91,7 @@ namespace System.Reactive.Linq
             return Create<TResult>(observer => AsyncObserver.Generate(observer, initialState, condition, iterate, resultSelector, timeSelector, scheduler));
         }
 
-        public static IAsyncObservable<TResult> Generate<TState, TResult>(TState initialState, Func<TState, Task<bool>> condition, Func<TState, Task<TState>> iterate, Func<TState, Task<TResult>> resultSelector, Func<TState, Task<TimeSpan>> timeSelector)
+        public static IAsyncObservable<TResult> Generate<TState, TResult>(TState initialState, Func<TState, ValueTask<bool>> condition, Func<TState, ValueTask<TState>> iterate, Func<TState, ValueTask<TResult>> resultSelector, Func<TState, ValueTask<TimeSpan>> timeSelector)
         {
             if (condition == null)
                 throw new ArgumentNullException(nameof(condition));
@@ -105,7 +105,7 @@ namespace System.Reactive.Linq
             return Create<TResult>(observer => AsyncObserver.Generate(observer, initialState, condition, iterate, resultSelector, timeSelector));
         }
 
-        public static IAsyncObservable<TResult> Generate<TState, TResult>(TState initialState, Func<TState, Task<bool>> condition, Func<TState, Task<TState>> iterate, Func<TState, Task<TResult>> resultSelector, Func<TState, Task<TimeSpan>> timeSelector, IAsyncScheduler scheduler)
+        public static IAsyncObservable<TResult> Generate<TState, TResult>(TState initialState, Func<TState, ValueTask<bool>> condition, Func<TState, ValueTask<TState>> iterate, Func<TState, ValueTask<TResult>> resultSelector, Func<TState, ValueTask<TimeSpan>> timeSelector, IAsyncScheduler scheduler)
         {
             if (condition == null)
                 throw new ArgumentNullException(nameof(condition));
@@ -151,7 +151,7 @@ namespace System.Reactive.Linq
             return Create<TResult>(observer => AsyncObserver.Generate(observer, initialState, condition, iterate, resultSelector, timeSelector, scheduler));
         }
 
-        public static IAsyncObservable<TResult> Generate<TState, TResult>(TState initialState, Func<TState, Task<bool>> condition, Func<TState, Task<TState>> iterate, Func<TState, Task<TResult>> resultSelector, Func<TState, Task<DateTimeOffset>> timeSelector)
+        public static IAsyncObservable<TResult> Generate<TState, TResult>(TState initialState, Func<TState, ValueTask<bool>> condition, Func<TState, ValueTask<TState>> iterate, Func<TState, ValueTask<TResult>> resultSelector, Func<TState, ValueTask<DateTimeOffset>> timeSelector)
         {
             if (condition == null)
                 throw new ArgumentNullException(nameof(condition));
@@ -165,7 +165,7 @@ namespace System.Reactive.Linq
             return Create<TResult>(observer => AsyncObserver.Generate(observer, initialState, condition, iterate, resultSelector, timeSelector));
         }
 
-        public static IAsyncObservable<TResult> Generate<TState, TResult>(TState initialState, Func<TState, Task<bool>> condition, Func<TState, Task<TState>> iterate, Func<TState, Task<TResult>> resultSelector, Func<TState, Task<DateTimeOffset>> timeSelector, IAsyncScheduler scheduler)
+        public static IAsyncObservable<TResult> Generate<TState, TResult>(TState initialState, Func<TState, ValueTask<bool>> condition, Func<TState, ValueTask<TState>> iterate, Func<TState, ValueTask<TResult>> resultSelector, Func<TState, ValueTask<DateTimeOffset>> timeSelector, IAsyncScheduler scheduler)
         {
             if (condition == null)
                 throw new ArgumentNullException(nameof(condition));
@@ -195,7 +195,7 @@ namespace System.Reactive.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            return Generate(observer, initialState, s => Task.FromResult(condition(s)), s => Task.FromResult(iterate(s)), s => Task.FromResult(resultSelector(s)), TaskPoolAsyncScheduler.Default);
+            return Generate(observer, initialState, s => new ValueTask<bool>(condition(s)), s => new ValueTask<TState>(iterate(s)), s => new ValueTask<TResult>(resultSelector(s)), TaskPoolAsyncScheduler.Default);
         }
 
         public static ValueTask<IAsyncDisposable> Generate<TState, TResult>(IAsyncObserver<TResult> observer, TState initialState, Func<TState, bool> condition, Func<TState, TState> iterate, Func<TState, TResult> resultSelector, IAsyncScheduler scheduler)
@@ -211,10 +211,10 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Generate(observer, initialState, s => Task.FromResult(condition(s)), s => Task.FromResult(iterate(s)), s => Task.FromResult(resultSelector(s)), scheduler);
+            return Generate(observer, initialState, s => new ValueTask<bool>(condition(s)), s => new ValueTask<TState>(iterate(s)), s => new ValueTask<TResult>(resultSelector(s)), scheduler);
         }
 
-        public static ValueTask<IAsyncDisposable> Generate<TState, TResult>(IAsyncObserver<TResult> observer, TState initialState, Func<TState, Task<bool>> condition, Func<TState, Task<TState>> iterate, Func<TState, Task<TResult>> resultSelector)
+        public static ValueTask<IAsyncDisposable> Generate<TState, TResult>(IAsyncObserver<TResult> observer, TState initialState, Func<TState, ValueTask<bool>> condition, Func<TState, ValueTask<TState>> iterate, Func<TState, ValueTask<TResult>> resultSelector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -228,7 +228,7 @@ namespace System.Reactive.Linq
             return Generate(observer, initialState, condition, iterate, resultSelector, TaskPoolAsyncScheduler.Default);
         }
 
-        public static ValueTask<IAsyncDisposable> Generate<TState, TResult>(IAsyncObserver<TResult> observer, TState initialState, Func<TState, Task<bool>> condition, Func<TState, Task<TState>> iterate, Func<TState, Task<TResult>> resultSelector, IAsyncScheduler scheduler)
+        public static ValueTask<IAsyncDisposable> Generate<TState, TResult>(IAsyncObserver<TResult> observer, TState initialState, Func<TState, ValueTask<bool>> condition, Func<TState, ValueTask<TState>> iterate, Func<TState, ValueTask<TResult>> resultSelector, IAsyncScheduler scheduler)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -305,7 +305,7 @@ namespace System.Reactive.Linq
             if (timeSelector == null)
                 throw new ArgumentNullException(nameof(timeSelector));
 
-            return Generate(observer, initialState, s => Task.FromResult(condition(s)), s => Task.FromResult(iterate(s)), s => Task.FromResult(resultSelector(s)), s => Task.FromResult(timeSelector(s)), TaskPoolAsyncScheduler.Default);
+            return Generate(observer, initialState, s => new ValueTask<bool>(condition(s)), s => new ValueTask<TState>(iterate(s)), s => new ValueTask<TResult>(resultSelector(s)), s => new ValueTask<TimeSpan>(timeSelector(s)), TaskPoolAsyncScheduler.Default);
         }
 
         public static ValueTask<IAsyncDisposable> Generate<TState, TResult>(IAsyncObserver<TResult> observer, TState initialState, Func<TState, bool> condition, Func<TState, TState> iterate, Func<TState, TResult> resultSelector, Func<TState, TimeSpan> timeSelector, IAsyncScheduler scheduler)
@@ -323,10 +323,10 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Generate(observer, initialState, s => Task.FromResult(condition(s)), s => Task.FromResult(iterate(s)), s => Task.FromResult(resultSelector(s)), s => Task.FromResult(timeSelector(s)), scheduler);
+            return Generate(observer, initialState, s => new ValueTask<bool>(condition(s)), s => new ValueTask<TState>(iterate(s)), s => new ValueTask<TResult>(resultSelector(s)), s => new ValueTask<TimeSpan>(timeSelector(s)), scheduler);
         }
 
-        public static ValueTask<IAsyncDisposable> Generate<TState, TResult>(IAsyncObserver<TResult> observer, TState initialState, Func<TState, Task<bool>> condition, Func<TState, Task<TState>> iterate, Func<TState, Task<TResult>> resultSelector, Func<TState, Task<TimeSpan>> timeSelector)
+        public static ValueTask<IAsyncDisposable> Generate<TState, TResult>(IAsyncObserver<TResult> observer, TState initialState, Func<TState, ValueTask<bool>> condition, Func<TState, ValueTask<TState>> iterate, Func<TState, ValueTask<TResult>> resultSelector, Func<TState, ValueTask<TimeSpan>> timeSelector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -342,7 +342,7 @@ namespace System.Reactive.Linq
             return Generate(observer, initialState, condition, iterate, resultSelector, timeSelector, TaskPoolAsyncScheduler.Default);
         }
 
-        public static ValueTask<IAsyncDisposable> Generate<TState, TResult>(IAsyncObserver<TResult> observer, TState initialState, Func<TState, Task<bool>> condition, Func<TState, Task<TState>> iterate, Func<TState, Task<TResult>> resultSelector, Func<TState, Task<TimeSpan>> timeSelector, IAsyncScheduler scheduler)
+        public static ValueTask<IAsyncDisposable> Generate<TState, TResult>(IAsyncObserver<TResult> observer, TState initialState, Func<TState, ValueTask<bool>> condition, Func<TState, ValueTask<TState>> iterate, Func<TState, ValueTask<TResult>> resultSelector, Func<TState, ValueTask<TimeSpan>> timeSelector, IAsyncScheduler scheduler)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -425,7 +425,7 @@ namespace System.Reactive.Linq
             if (timeSelector == null)
                 throw new ArgumentNullException(nameof(timeSelector));
 
-            return Generate(observer, initialState, s => Task.FromResult(condition(s)), s => Task.FromResult(iterate(s)), s => Task.FromResult(resultSelector(s)), s => Task.FromResult(timeSelector(s)), TaskPoolAsyncScheduler.Default);
+            return Generate(observer, initialState, s => new ValueTask<bool>(condition(s)), s => new ValueTask<TState>(iterate(s)), s => new ValueTask<TResult>(resultSelector(s)), s => new ValueTask<DateTimeOffset>(timeSelector(s)), TaskPoolAsyncScheduler.Default);
         }
 
         public static ValueTask<IAsyncDisposable> Generate<TState, TResult>(IAsyncObserver<TResult> observer, TState initialState, Func<TState, bool> condition, Func<TState, TState> iterate, Func<TState, TResult> resultSelector, Func<TState, DateTimeOffset> timeSelector, IAsyncScheduler scheduler)
@@ -443,10 +443,10 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Generate(observer, initialState, s => Task.FromResult(condition(s)), s => Task.FromResult(iterate(s)), s => Task.FromResult(resultSelector(s)), s => Task.FromResult(timeSelector(s)), scheduler);
+            return Generate(observer, initialState, s => new ValueTask<bool>(condition(s)), s => new ValueTask<TState>(iterate(s)), s => new ValueTask<TResult>(resultSelector(s)), s => new ValueTask<DateTimeOffset>(timeSelector(s)), scheduler);
         }
 
-        public static ValueTask<IAsyncDisposable> Generate<TState, TResult>(IAsyncObserver<TResult> observer, TState initialState, Func<TState, Task<bool>> condition, Func<TState, Task<TState>> iterate, Func<TState, Task<TResult>> resultSelector, Func<TState, Task<DateTimeOffset>> timeSelector)
+        public static ValueTask<IAsyncDisposable> Generate<TState, TResult>(IAsyncObserver<TResult> observer, TState initialState, Func<TState, ValueTask<bool>> condition, Func<TState, ValueTask<TState>> iterate, Func<TState, ValueTask<TResult>> resultSelector, Func<TState, ValueTask<DateTimeOffset>> timeSelector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -462,7 +462,7 @@ namespace System.Reactive.Linq
             return Generate(observer, initialState, condition, iterate, resultSelector, timeSelector, TaskPoolAsyncScheduler.Default);
         }
 
-        public static ValueTask<IAsyncDisposable> Generate<TState, TResult>(IAsyncObserver<TResult> observer, TState initialState, Func<TState, Task<bool>> condition, Func<TState, Task<TState>> iterate, Func<TState, Task<TResult>> resultSelector, Func<TState, Task<DateTimeOffset>> timeSelector, IAsyncScheduler scheduler)
+        public static ValueTask<IAsyncDisposable> Generate<TState, TResult>(IAsyncObserver<TResult> observer, TState initialState, Func<TState, ValueTask<bool>> condition, Func<TState, ValueTask<TState>> iterate, Func<TState, ValueTask<TResult>> resultSelector, Func<TState, ValueTask<DateTimeOffset>> timeSelector, IAsyncScheduler scheduler)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/GroupBy.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/GroupBy.cs
@@ -115,7 +115,7 @@ namespace System.Reactive.Linq
             return Create<IGroupedAsyncObservable<TKey, TElement>>(observer => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector, elementSelector, capacity, comparer)));
         }
 
-        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupBy<TSource, TKey>(this IAsyncObservable<TSource> source, Func<TSource, Task<TKey>> keySelector)
+        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupBy<TSource, TKey>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -125,7 +125,7 @@ namespace System.Reactive.Linq
             return Create<IGroupedAsyncObservable<TKey, TSource>>(observer => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector)));
         }
 
-        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupBy<TSource, TKey>(this IAsyncObservable<TSource> source, Func<TSource, Task<TKey>> keySelector, IEqualityComparer<TKey> comparer)
+        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupBy<TSource, TKey>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, IEqualityComparer<TKey> comparer)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -137,7 +137,7 @@ namespace System.Reactive.Linq
             return Create<IGroupedAsyncObservable<TKey, TSource>>(observer => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector, comparer)));
         }
 
-        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupBy<TSource, TKey>(this IAsyncObservable<TSource> source, Func<TSource, Task<TKey>> keySelector, int capacity)
+        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupBy<TSource, TKey>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, int capacity)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -149,7 +149,7 @@ namespace System.Reactive.Linq
             return Create<IGroupedAsyncObservable<TKey, TSource>>(observer => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector, capacity)));
         }
 
-        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupBy<TSource, TKey>(this IAsyncObservable<TSource> source, Func<TSource, Task<TKey>> keySelector, int capacity, IEqualityComparer<TKey> comparer)
+        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupBy<TSource, TKey>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, int capacity, IEqualityComparer<TKey> comparer)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -163,7 +163,7 @@ namespace System.Reactive.Linq
             return Create<IGroupedAsyncObservable<TKey, TSource>>(observer => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector, capacity, comparer)));
         }
 
-        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IAsyncObservable<TSource> source, Func<TSource, Task<TKey>> keySelector, Func<TSource, Task<TElement>> elementSelector)
+        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -175,7 +175,7 @@ namespace System.Reactive.Linq
             return Create<IGroupedAsyncObservable<TKey, TElement>>(observer => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector, elementSelector)));
         }
 
-        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IAsyncObservable<TSource> source, Func<TSource, Task<TKey>> keySelector, Func<TSource, Task<TElement>> elementSelector, IEqualityComparer<TKey> comparer)
+        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, IEqualityComparer<TKey> comparer)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -189,7 +189,7 @@ namespace System.Reactive.Linq
             return Create<IGroupedAsyncObservable<TKey, TElement>>(observer => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector, elementSelector, comparer)));
         }
 
-        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IAsyncObservable<TSource> source, Func<TSource, Task<TKey>> keySelector, Func<TSource, Task<TElement>> elementSelector, int capacity)
+        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, int capacity)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -203,7 +203,7 @@ namespace System.Reactive.Linq
             return Create<IGroupedAsyncObservable<TKey, TElement>>(observer => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector, elementSelector, capacity)));
         }
 
-        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IAsyncObservable<TSource> source, Func<TSource, Task<TKey>> keySelector, Func<TSource, Task<TElement>> elementSelector, int capacity, IEqualityComparer<TKey> comparer)
+        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, int capacity, IEqualityComparer<TKey> comparer)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -287,7 +287,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return GroupBy(observer, subscription, x => Task.FromResult(keySelector(x)), capacity, comparer);
+            return GroupBy(observer, subscription, x => new ValueTask<TKey>(keySelector(x)), capacity, comparer);
         }
 
         public static (IAsyncObserver<TSource>, IAsyncDisposable) GroupBy<TSource, TKey, TElement>(IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, IAsyncDisposable subscription, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
@@ -351,10 +351,10 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return GroupBy<TSource, TKey, TElement>(observer, subscription, x => Task.FromResult(keySelector(x)), x => Task.FromResult(elementSelector(x)), capacity, comparer);
+            return GroupBy<TSource, TKey, TElement>(observer, subscription, x => new ValueTask<TKey>(keySelector(x)), x => new ValueTask<TElement>(elementSelector(x)), capacity, comparer);
         }
 
-        public static (IAsyncObserver<TSource>, IAsyncDisposable) GroupBy<TSource, TKey>(IAsyncObserver<IGroupedAsyncObservable<TKey, TSource>> observer, IAsyncDisposable subscription, Func<TSource, Task<TKey>> keySelector)
+        public static (IAsyncObserver<TSource>, IAsyncDisposable) GroupBy<TSource, TKey>(IAsyncObserver<IGroupedAsyncObservable<TKey, TSource>> observer, IAsyncDisposable subscription, Func<TSource, ValueTask<TKey>> keySelector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -366,7 +366,7 @@ namespace System.Reactive.Linq
             return GroupBy(observer, subscription, keySelector, int.MaxValue, EqualityComparer<TKey>.Default);
         }
 
-        public static (IAsyncObserver<TSource>, IAsyncDisposable) GroupBy<TSource, TKey>(IAsyncObserver<IGroupedAsyncObservable<TKey, TSource>> observer, IAsyncDisposable subscription, Func<TSource, Task<TKey>> keySelector, IEqualityComparer<TKey> comparer)
+        public static (IAsyncObserver<TSource>, IAsyncDisposable) GroupBy<TSource, TKey>(IAsyncObserver<IGroupedAsyncObservable<TKey, TSource>> observer, IAsyncDisposable subscription, Func<TSource, ValueTask<TKey>> keySelector, IEqualityComparer<TKey> comparer)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -380,7 +380,7 @@ namespace System.Reactive.Linq
             return GroupBy(observer, subscription, keySelector, int.MaxValue, comparer);
         }
 
-        public static (IAsyncObserver<TSource>, IAsyncDisposable) GroupBy<TSource, TKey>(IAsyncObserver<IGroupedAsyncObservable<TKey, TSource>> observer, IAsyncDisposable subscription, Func<TSource, Task<TKey>> keySelector, int capacity)
+        public static (IAsyncObserver<TSource>, IAsyncDisposable) GroupBy<TSource, TKey>(IAsyncObserver<IGroupedAsyncObservable<TKey, TSource>> observer, IAsyncDisposable subscription, Func<TSource, ValueTask<TKey>> keySelector, int capacity)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -394,7 +394,7 @@ namespace System.Reactive.Linq
             return GroupBy(observer, subscription, keySelector, capacity, EqualityComparer<TKey>.Default);
         }
 
-        public static (IAsyncObserver<TSource>, IAsyncDisposable) GroupBy<TSource, TKey>(IAsyncObserver<IGroupedAsyncObservable<TKey, TSource>> observer, IAsyncDisposable subscription, Func<TSource, Task<TKey>> keySelector, int capacity, IEqualityComparer<TKey> comparer)
+        public static (IAsyncObserver<TSource>, IAsyncDisposable) GroupBy<TSource, TKey>(IAsyncObserver<IGroupedAsyncObservable<TKey, TSource>> observer, IAsyncDisposable subscription, Func<TSource, ValueTask<TKey>> keySelector, int capacity, IEqualityComparer<TKey> comparer)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -407,10 +407,10 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return GroupBy(observer, subscription, keySelector, x => Task.FromResult(x), capacity, comparer);
+            return GroupBy(observer, subscription, keySelector, x => new ValueTask<TSource>(x), capacity, comparer);
         }
 
-        public static (IAsyncObserver<TSource>, IAsyncDisposable) GroupBy<TSource, TKey, TElement>(IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, IAsyncDisposable subscription, Func<TSource, Task<TKey>> keySelector, Func<TSource, Task<TElement>> elementSelector)
+        public static (IAsyncObserver<TSource>, IAsyncDisposable) GroupBy<TSource, TKey, TElement>(IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, IAsyncDisposable subscription, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -424,7 +424,7 @@ namespace System.Reactive.Linq
             return GroupBy(observer, subscription, keySelector, elementSelector, int.MaxValue, EqualityComparer<TKey>.Default);
         }
 
-        public static (IAsyncObserver<TSource>, IAsyncDisposable) GroupBy<TSource, TKey, TElement>(IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, IAsyncDisposable subscription, Func<TSource, Task<TKey>> keySelector, Func<TSource, Task<TElement>> elementSelector, IEqualityComparer<TKey> comparer)
+        public static (IAsyncObserver<TSource>, IAsyncDisposable) GroupBy<TSource, TKey, TElement>(IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, IAsyncDisposable subscription, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, IEqualityComparer<TKey> comparer)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -440,7 +440,7 @@ namespace System.Reactive.Linq
             return GroupBy(observer, subscription, keySelector, elementSelector, int.MaxValue, comparer);
         }
 
-        public static (IAsyncObserver<TSource>, IAsyncDisposable) GroupBy<TSource, TKey, TElement>(IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, IAsyncDisposable subscription, Func<TSource, Task<TKey>> keySelector, Func<TSource, Task<TElement>> elementSelector, int capacity)
+        public static (IAsyncObserver<TSource>, IAsyncDisposable) GroupBy<TSource, TKey, TElement>(IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, IAsyncDisposable subscription, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, int capacity)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -456,7 +456,7 @@ namespace System.Reactive.Linq
             return GroupBy(observer, subscription, keySelector, elementSelector, capacity, EqualityComparer<TKey>.Default);
         }
 
-        public static (IAsyncObserver<TSource>, IAsyncDisposable) GroupBy<TSource, TKey, TElement>(IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, IAsyncDisposable subscription, Func<TSource, Task<TKey>> keySelector, Func<TSource, Task<TElement>> elementSelector, int capacity, IEqualityComparer<TKey> comparer)
+        public static (IAsyncObserver<TSource>, IAsyncDisposable) GroupBy<TSource, TKey, TElement>(IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, IAsyncDisposable subscription, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, int capacity, IEqualityComparer<TKey> comparer)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/GroupByUntil.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/GroupByUntil.cs
@@ -133,7 +133,7 @@ namespace System.Reactive.Linq
             return Create<IGroupedAsyncObservable<TKey, TElement>>(observer => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, keySelector, elementSelector, durationSelector, capacity, comparer)));
         }
 
-        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupByUntil<TSource, TKey, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, Task<TKey>> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector)
+        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupByUntil<TSource, TKey, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -145,7 +145,7 @@ namespace System.Reactive.Linq
             return Create<IGroupedAsyncObservable<TKey, TSource>>(observer => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, keySelector, durationSelector)));
         }
 
-        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupByUntil<TSource, TKey, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, Task<TKey>> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, IEqualityComparer<TKey> comparer)
+        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupByUntil<TSource, TKey, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, IEqualityComparer<TKey> comparer)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -159,7 +159,7 @@ namespace System.Reactive.Linq
             return Create<IGroupedAsyncObservable<TKey, TSource>>(observer => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, keySelector, durationSelector, comparer)));
         }
 
-        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupByUntil<TSource, TKey, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, Task<TKey>> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, int capacity)
+        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupByUntil<TSource, TKey, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, int capacity)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -173,7 +173,7 @@ namespace System.Reactive.Linq
             return Create<IGroupedAsyncObservable<TKey, TSource>>(observer => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, keySelector, durationSelector, capacity)));
         }
 
-        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupByUntil<TSource, TKey, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, Task<TKey>> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, int capacity, IEqualityComparer<TKey> comparer)
+        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupByUntil<TSource, TKey, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, int capacity, IEqualityComparer<TKey> comparer)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -189,7 +189,7 @@ namespace System.Reactive.Linq
             return Create<IGroupedAsyncObservable<TKey, TSource>>(observer => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, keySelector, durationSelector, capacity, comparer)));
         }
 
-        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupByUntil<TSource, TKey, TElement, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, Task<TKey>> keySelector, Func<TSource, Task<TElement>> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector)
+        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupByUntil<TSource, TKey, TElement, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -203,7 +203,7 @@ namespace System.Reactive.Linq
             return Create<IGroupedAsyncObservable<TKey, TElement>>(observer => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, keySelector, elementSelector, durationSelector)));
         }
 
-        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupByUntil<TSource, TKey, TElement, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, Task<TKey>> keySelector, Func<TSource, Task<TElement>> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, IEqualityComparer<TKey> comparer)
+        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupByUntil<TSource, TKey, TElement, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, IEqualityComparer<TKey> comparer)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -219,7 +219,7 @@ namespace System.Reactive.Linq
             return Create<IGroupedAsyncObservable<TKey, TElement>>(observer => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, keySelector, elementSelector, durationSelector, comparer)));
         }
 
-        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupByUntil<TSource, TKey, TElement, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, Task<TKey>> keySelector, Func<TSource, Task<TElement>> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, int capacity)
+        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupByUntil<TSource, TKey, TElement, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, int capacity)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -235,7 +235,7 @@ namespace System.Reactive.Linq
             return Create<IGroupedAsyncObservable<TKey, TElement>>(observer => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, keySelector, elementSelector, durationSelector, capacity)));
         }
 
-        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupByUntil<TSource, TKey, TElement, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, Task<TKey>> keySelector, Func<TSource, Task<TElement>> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, int capacity, IEqualityComparer<TKey> comparer)
+        public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupByUntil<TSource, TKey, TElement, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, int capacity, IEqualityComparer<TKey> comparer)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -253,7 +253,7 @@ namespace System.Reactive.Linq
             return Create<IGroupedAsyncObservable<TKey, TElement>>(observer => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, keySelector, elementSelector, durationSelector, capacity, comparer)));
         }
 
-        private static async ValueTask<IAsyncDisposable> GroupByUntilCore<TSource, TKey, TElement, TDuration>(IAsyncObservable<TSource> source, IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, Func<IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>>, IAsyncDisposable, Task<(IAsyncObserver<TSource>, IAsyncDisposable)>> createObserver)
+        private static async ValueTask<IAsyncDisposable> GroupByUntilCore<TSource, TKey, TElement, TDuration>(IAsyncObservable<TSource> source, IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, Func<IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>>, IAsyncDisposable, ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)>> createObserver)
         {
             var d = new SingleAssignmentAsyncDisposable();
 
@@ -268,7 +268,7 @@ namespace System.Reactive.Linq
 
     partial class AsyncObserver
     {
-        public static Task<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TSource>> observer, IAsyncDisposable subscription, Func<TSource, TKey> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector)
+        public static ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TSource>> observer, IAsyncDisposable subscription, Func<TSource, TKey> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -282,7 +282,7 @@ namespace System.Reactive.Linq
             return GroupByUntil(observer, subscription, keySelector, durationSelector, int.MaxValue, EqualityComparer<TKey>.Default);
         }
 
-        public static Task<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TSource>> observer, IAsyncDisposable subscription, Func<TSource, TKey> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, IEqualityComparer<TKey> comparer)
+        public static ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TSource>> observer, IAsyncDisposable subscription, Func<TSource, TKey> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, IEqualityComparer<TKey> comparer)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -298,7 +298,7 @@ namespace System.Reactive.Linq
             return GroupByUntil(observer, subscription, keySelector, durationSelector, int.MaxValue, comparer);
         }
 
-        public static Task<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TSource>> observer, IAsyncDisposable subscription, Func<TSource, TKey> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, int capacity)
+        public static ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TSource>> observer, IAsyncDisposable subscription, Func<TSource, TKey> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, int capacity)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -314,7 +314,7 @@ namespace System.Reactive.Linq
             return GroupByUntil(observer, subscription, keySelector, durationSelector, capacity, EqualityComparer<TKey>.Default);
         }
 
-        public static Task<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TSource>> observer, IAsyncDisposable subscription, Func<TSource, TKey> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, int capacity, IEqualityComparer<TKey> comparer)
+        public static ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TSource>> observer, IAsyncDisposable subscription, Func<TSource, TKey> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, int capacity, IEqualityComparer<TKey> comparer)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -329,10 +329,10 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return GroupByUntil(observer, subscription, x => Task.FromResult(keySelector(x)), durationSelector, capacity, comparer);
+            return GroupByUntil(observer, subscription, x => new ValueTask<TKey>(keySelector(x)), durationSelector, capacity, comparer);
         }
 
-        public static Task<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TElement, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, IAsyncDisposable subscription, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector)
+        public static ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TElement, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, IAsyncDisposable subscription, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -348,7 +348,7 @@ namespace System.Reactive.Linq
             return GroupByUntil(observer, subscription, keySelector, elementSelector, durationSelector, int.MaxValue, EqualityComparer<TKey>.Default);
         }
 
-        public static Task<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TElement, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, IAsyncDisposable subscription, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, IEqualityComparer<TKey> comparer)
+        public static ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TElement, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, IAsyncDisposable subscription, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, IEqualityComparer<TKey> comparer)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -366,7 +366,7 @@ namespace System.Reactive.Linq
             return GroupByUntil(observer, subscription, keySelector, elementSelector, durationSelector, int.MaxValue, comparer);
         }
 
-        public static Task<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TElement, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, IAsyncDisposable subscription, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, int capacity)
+        public static ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TElement, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, IAsyncDisposable subscription, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, int capacity)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -384,7 +384,7 @@ namespace System.Reactive.Linq
             return GroupByUntil(observer, subscription, keySelector, elementSelector, durationSelector, capacity, EqualityComparer<TKey>.Default);
         }
 
-        public static Task<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TElement, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, IAsyncDisposable subscription, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, int capacity, IEqualityComparer<TKey> comparer)
+        public static ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TElement, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, IAsyncDisposable subscription, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, int capacity, IEqualityComparer<TKey> comparer)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -401,10 +401,10 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return GroupByUntil<TSource, TKey, TElement, TDuration>(observer, subscription, x => Task.FromResult(keySelector(x)), x => Task.FromResult(elementSelector(x)), durationSelector, capacity, comparer);
+            return GroupByUntil<TSource, TKey, TElement, TDuration>(observer, subscription, x => new ValueTask<TKey>(keySelector(x)), x => new ValueTask<TElement>(elementSelector(x)), durationSelector, capacity, comparer);
         }
 
-        public static Task<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TSource>> observer, IAsyncDisposable subscription, Func<TSource, Task<TKey>> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector)
+        public static ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TSource>> observer, IAsyncDisposable subscription, Func<TSource, ValueTask<TKey>> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -418,7 +418,7 @@ namespace System.Reactive.Linq
             return GroupByUntil(observer, subscription, keySelector, durationSelector, int.MaxValue, EqualityComparer<TKey>.Default);
         }
 
-        public static Task<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TSource>> observer, IAsyncDisposable subscription, Func<TSource, Task<TKey>> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, IEqualityComparer<TKey> comparer)
+        public static ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TSource>> observer, IAsyncDisposable subscription, Func<TSource, ValueTask<TKey>> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, IEqualityComparer<TKey> comparer)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -434,7 +434,7 @@ namespace System.Reactive.Linq
             return GroupByUntil(observer, subscription, keySelector, durationSelector, int.MaxValue, comparer);
         }
 
-        public static Task<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TSource>> observer, IAsyncDisposable subscription, Func<TSource, Task<TKey>> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, int capacity)
+        public static ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TSource>> observer, IAsyncDisposable subscription, Func<TSource, ValueTask<TKey>> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, int capacity)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -450,7 +450,7 @@ namespace System.Reactive.Linq
             return GroupByUntil(observer, subscription, keySelector, durationSelector, capacity, EqualityComparer<TKey>.Default);
         }
 
-        public static Task<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TSource>> observer, IAsyncDisposable subscription, Func<TSource, Task<TKey>> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, int capacity, IEqualityComparer<TKey> comparer)
+        public static ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TSource>> observer, IAsyncDisposable subscription, Func<TSource, ValueTask<TKey>> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, int capacity, IEqualityComparer<TKey> comparer)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -465,10 +465,10 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return GroupByUntil(observer, subscription, keySelector, x => Task.FromResult(x), durationSelector, capacity, comparer);
+            return GroupByUntil(observer, subscription, keySelector, x => new ValueTask<TSource>(x), durationSelector, capacity, comparer);
         }
 
-        public static Task<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TElement, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, IAsyncDisposable subscription, Func<TSource, Task<TKey>> keySelector, Func<TSource, Task<TElement>> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector)
+        public static ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TElement, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, IAsyncDisposable subscription, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -484,7 +484,7 @@ namespace System.Reactive.Linq
             return GroupByUntil(observer, subscription, keySelector, elementSelector, durationSelector, int.MaxValue, EqualityComparer<TKey>.Default);
         }
 
-        public static Task<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TElement, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, IAsyncDisposable subscription, Func<TSource, Task<TKey>> keySelector, Func<TSource, Task<TElement>> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, IEqualityComparer<TKey> comparer)
+        public static ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TElement, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, IAsyncDisposable subscription, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, IEqualityComparer<TKey> comparer)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -502,7 +502,7 @@ namespace System.Reactive.Linq
             return GroupByUntil(observer, subscription, keySelector, elementSelector, durationSelector, int.MaxValue, comparer);
         }
 
-        public static Task<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TElement, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, IAsyncDisposable subscription, Func<TSource, Task<TKey>> keySelector, Func<TSource, Task<TElement>> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, int capacity)
+        public static ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TElement, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, IAsyncDisposable subscription, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, int capacity)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -520,7 +520,7 @@ namespace System.Reactive.Linq
             return GroupByUntil(observer, subscription, keySelector, elementSelector, durationSelector, capacity, EqualityComparer<TKey>.Default);
         }
 
-        public static Task<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TElement, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, IAsyncDisposable subscription, Func<TSource, Task<TKey>> keySelector, Func<TSource, Task<TElement>> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, int capacity, IEqualityComparer<TKey> comparer)
+        public static ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)> GroupByUntil<TSource, TKey, TElement, TDuration>(IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, IAsyncDisposable subscription, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, int capacity, IEqualityComparer<TKey> comparer)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -542,7 +542,7 @@ namespace System.Reactive.Linq
             // REVIEW: Concurrent execution of a duration callback and an event could lead to an OnNext call being queued in an AsyncLockObserver
             //         after a duration callback makes an OnCompleted call. This seems to be the case in sync Rx as well.
 
-            async Task<(IAsyncObserver<TSource>, IAsyncDisposable)> CoreAsync()
+            async ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)> CoreAsync()
             {
                 var d = new CompositeAsyncDisposable();
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/If.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/If.cs
@@ -39,11 +39,11 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> If<TResult>(Func<Task<bool>> condition, IAsyncObservable<TResult> thenSource) => If(condition, thenSource, Empty<TResult>());
+        public static IAsyncObservable<TResult> If<TResult>(Func<ValueTask<bool>> condition, IAsyncObservable<TResult> thenSource) => If(condition, thenSource, Empty<TResult>());
 
-        public static IAsyncObservable<TResult> If<TResult>(Func<Task<bool>> condition, IAsyncObservable<TResult> thenSource, IAsyncScheduler scheduler) => If(condition, thenSource, Empty<TResult>(scheduler));
+        public static IAsyncObservable<TResult> If<TResult>(Func<ValueTask<bool>> condition, IAsyncObservable<TResult> thenSource, IAsyncScheduler scheduler) => If(condition, thenSource, Empty<TResult>(scheduler));
 
-        public static IAsyncObservable<TResult> If<TResult>(Func<Task<bool>> condition, IAsyncObservable<TResult> thenSource, IAsyncObservable<TResult> elseSource)
+        public static IAsyncObservable<TResult> If<TResult>(Func<ValueTask<bool>> condition, IAsyncObservable<TResult> thenSource, IAsyncObservable<TResult> elseSource)
         {
             if (condition == null)
                 throw new ArgumentNullException(nameof(condition));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Last.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Last.cs
@@ -10,7 +10,7 @@ namespace System.Reactive.Linq
     {
         public static IAsyncObservable<TSource> LastAsync<TSource>(this IAsyncObservable<TSource> source) => Last(source);
         public static IAsyncObservable<TSource> LastAsync<TSource>(this IAsyncObservable<TSource> source, Func<TSource, bool> predicate) => Last(source, predicate);
-        public static IAsyncObservable<TSource> LastAsync<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<bool>> predicate) => Last(source, predicate);
+        public static IAsyncObservable<TSource> LastAsync<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate) => Last(source, predicate);
 
         public static IAsyncObservable<TSource> Last<TSource>(this IAsyncObservable<TSource> source)
         {
@@ -30,7 +30,7 @@ namespace System.Reactive.Linq
             return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.Last(observer, predicate)));
         }
 
-        public static IAsyncObservable<TSource> Last<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<bool>> predicate)
+        public static IAsyncObservable<TSource> Last<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -85,7 +85,7 @@ namespace System.Reactive.Linq
             return Where(Last(observer), predicate);
         }
 
-        public static IAsyncObserver<TSource> Last<TSource>(IAsyncObserver<TSource> observer, Func<TSource, Task<bool>> predicate)
+        public static IAsyncObserver<TSource> Last<TSource>(IAsyncObserver<TSource> observer, Func<TSource, ValueTask<bool>> predicate)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/LastOrDefault.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/LastOrDefault.cs
@@ -10,7 +10,7 @@ namespace System.Reactive.Linq
     {
         public static IAsyncObservable<TSource> LastOrDefaultAsync<TSource>(this IAsyncObservable<TSource> source) => LastOrDefault(source);
         public static IAsyncObservable<TSource> LastOrDefaultAsync<TSource>(this IAsyncObservable<TSource> source, Func<TSource, bool> predicate) => LastOrDefault(source, predicate);
-        public static IAsyncObservable<TSource> LastOrDefaultAsync<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<bool>> predicate) => LastOrDefault(source, predicate);
+        public static IAsyncObservable<TSource> LastOrDefaultAsync<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate) => LastOrDefault(source, predicate);
 
         public static IAsyncObservable<TSource> LastOrDefault<TSource>(this IAsyncObservable<TSource> source)
         {
@@ -30,7 +30,7 @@ namespace System.Reactive.Linq
             return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.LastOrDefault(observer, predicate)));
         }
 
-        public static IAsyncObservable<TSource> LastOrDefault<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<bool>> predicate)
+        public static IAsyncObservable<TSource> LastOrDefault<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -78,7 +78,7 @@ namespace System.Reactive.Linq
             return Where(LastOrDefault(observer), predicate);
         }
 
-        public static IAsyncObserver<TSource> LastOrDefault<TSource>(IAsyncObserver<TSource> observer, Func<TSource, Task<bool>> predicate)
+        public static IAsyncObserver<TSource> LastOrDefault<TSource>(IAsyncObserver<TSource> observer, Func<TSource, ValueTask<bool>> predicate)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/LongCount.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/LongCount.cs
@@ -26,7 +26,7 @@ namespace System.Reactive.Linq
             return Create<long>(observer => source.SubscribeSafeAsync(AsyncObserver.LongCount(observer, predicate)));
         }
 
-        public static IAsyncObservable<long> LongCount<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<bool>> predicate)
+        public static IAsyncObservable<long> LongCount<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -81,7 +81,7 @@ namespace System.Reactive.Linq
             return Where(LongCount<TSource>(observer), predicate);
         }
 
-        public static IAsyncObserver<TSource> LongCount<TSource>(IAsyncObserver<long> observer, Func<TSource, Task<bool>> predicate)
+        public static IAsyncObserver<TSource> LongCount<TSource>(IAsyncObserver<long> observer, Func<TSource, ValueTask<bool>> predicate)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Max.Generated.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Max.Generated.cs
@@ -26,7 +26,7 @@ namespace System.Reactive.Linq
             return Create<Int32>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxInt32(observer, selector)));
         }
 
-        public static IAsyncObservable<Int32> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Int32>> selector)
+        public static IAsyncObservable<Int32> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int32>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -54,7 +54,7 @@ namespace System.Reactive.Linq
             return Create<Int32?>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxNullableInt32(observer, selector)));
         }
 
-        public static IAsyncObservable<Int32?> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Int32?>> selector)
+        public static IAsyncObservable<Int32?> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int32?>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -82,7 +82,7 @@ namespace System.Reactive.Linq
             return Create<Int64>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxInt64(observer, selector)));
         }
 
-        public static IAsyncObservable<Int64> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Int64>> selector)
+        public static IAsyncObservable<Int64> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int64>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -110,7 +110,7 @@ namespace System.Reactive.Linq
             return Create<Int64?>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxNullableInt64(observer, selector)));
         }
 
-        public static IAsyncObservable<Int64?> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Int64?>> selector)
+        public static IAsyncObservable<Int64?> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int64?>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -138,7 +138,7 @@ namespace System.Reactive.Linq
             return Create<Single>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxSingle(observer, selector)));
         }
 
-        public static IAsyncObservable<Single> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Single>> selector)
+        public static IAsyncObservable<Single> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Single>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -166,7 +166,7 @@ namespace System.Reactive.Linq
             return Create<Single?>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxNullableSingle(observer, selector)));
         }
 
-        public static IAsyncObservable<Single?> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Single?>> selector)
+        public static IAsyncObservable<Single?> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Single?>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -194,7 +194,7 @@ namespace System.Reactive.Linq
             return Create<Double>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxDouble(observer, selector)));
         }
 
-        public static IAsyncObservable<Double> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Double>> selector)
+        public static IAsyncObservable<Double> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Double>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -222,7 +222,7 @@ namespace System.Reactive.Linq
             return Create<Double?>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxNullableDouble(observer, selector)));
         }
 
-        public static IAsyncObservable<Double?> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Double?>> selector)
+        public static IAsyncObservable<Double?> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Double?>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -250,7 +250,7 @@ namespace System.Reactive.Linq
             return Create<Decimal>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxDecimal(observer, selector)));
         }
 
-        public static IAsyncObservable<Decimal> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Decimal>> selector)
+        public static IAsyncObservable<Decimal> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Decimal>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -278,7 +278,7 @@ namespace System.Reactive.Linq
             return Create<Decimal?>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxNullableDecimal(observer, selector)));
         }
 
-        public static IAsyncObservable<Decimal?> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Decimal?>> selector)
+        public static IAsyncObservable<Decimal?> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Decimal?>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -302,7 +302,7 @@ namespace System.Reactive.Linq
             return Select(MaxInt32(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> MaxInt32<TSource>(IAsyncObserver<Int32> observer, Func<TSource, Task<Int32>> selector)
+        public static IAsyncObserver<TSource> MaxInt32<TSource>(IAsyncObserver<Int32> observer, Func<TSource, ValueTask<Int32>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -322,7 +322,7 @@ namespace System.Reactive.Linq
             return Select(MaxNullableInt32(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> MaxNullableInt32<TSource>(IAsyncObserver<Int32?> observer, Func<TSource, Task<Int32?>> selector)
+        public static IAsyncObserver<TSource> MaxNullableInt32<TSource>(IAsyncObserver<Int32?> observer, Func<TSource, ValueTask<Int32?>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -342,7 +342,7 @@ namespace System.Reactive.Linq
             return Select(MaxInt64(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> MaxInt64<TSource>(IAsyncObserver<Int64> observer, Func<TSource, Task<Int64>> selector)
+        public static IAsyncObserver<TSource> MaxInt64<TSource>(IAsyncObserver<Int64> observer, Func<TSource, ValueTask<Int64>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -362,7 +362,7 @@ namespace System.Reactive.Linq
             return Select(MaxNullableInt64(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> MaxNullableInt64<TSource>(IAsyncObserver<Int64?> observer, Func<TSource, Task<Int64?>> selector)
+        public static IAsyncObserver<TSource> MaxNullableInt64<TSource>(IAsyncObserver<Int64?> observer, Func<TSource, ValueTask<Int64?>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -382,7 +382,7 @@ namespace System.Reactive.Linq
             return Select(MaxSingle(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> MaxSingle<TSource>(IAsyncObserver<Single> observer, Func<TSource, Task<Single>> selector)
+        public static IAsyncObserver<TSource> MaxSingle<TSource>(IAsyncObserver<Single> observer, Func<TSource, ValueTask<Single>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -402,7 +402,7 @@ namespace System.Reactive.Linq
             return Select(MaxNullableSingle(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> MaxNullableSingle<TSource>(IAsyncObserver<Single?> observer, Func<TSource, Task<Single?>> selector)
+        public static IAsyncObserver<TSource> MaxNullableSingle<TSource>(IAsyncObserver<Single?> observer, Func<TSource, ValueTask<Single?>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -422,7 +422,7 @@ namespace System.Reactive.Linq
             return Select(MaxDouble(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> MaxDouble<TSource>(IAsyncObserver<Double> observer, Func<TSource, Task<Double>> selector)
+        public static IAsyncObserver<TSource> MaxDouble<TSource>(IAsyncObserver<Double> observer, Func<TSource, ValueTask<Double>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -442,7 +442,7 @@ namespace System.Reactive.Linq
             return Select(MaxNullableDouble(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> MaxNullableDouble<TSource>(IAsyncObserver<Double?> observer, Func<TSource, Task<Double?>> selector)
+        public static IAsyncObserver<TSource> MaxNullableDouble<TSource>(IAsyncObserver<Double?> observer, Func<TSource, ValueTask<Double?>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -462,7 +462,7 @@ namespace System.Reactive.Linq
             return Select(MaxDecimal(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> MaxDecimal<TSource>(IAsyncObserver<Decimal> observer, Func<TSource, Task<Decimal>> selector)
+        public static IAsyncObserver<TSource> MaxDecimal<TSource>(IAsyncObserver<Decimal> observer, Func<TSource, ValueTask<Decimal>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -482,7 +482,7 @@ namespace System.Reactive.Linq
             return Select(MaxNullableDecimal(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> MaxNullableDecimal<TSource>(IAsyncObserver<Decimal?> observer, Func<TSource, Task<Decimal?>> selector)
+        public static IAsyncObserver<TSource> MaxNullableDecimal<TSource>(IAsyncObserver<Decimal?> observer, Func<TSource, ValueTask<Decimal?>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Max.Generated.tt
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Max.Generated.tt
@@ -45,7 +45,7 @@ foreach (var t in types)
             return Create<<#=typeName#>>(observer => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
         }
 
-        public static IAsyncObservable<<#=typeName#>> <#=name#><TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<<#=typeName#>>> selector)
+        public static IAsyncObservable<<#=typeName#>> <#=name#><TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<<#=typeName#>>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -82,7 +82,7 @@ foreach (var t in types)
             return Select(<#=name#><#=methodName#>(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> <#=name#><#=methodName#><TSource>(IAsyncObserver<<#=typeName#>> observer, Func<TSource, Task<<#=typeName#>>> selector)
+        public static IAsyncObserver<TSource> <#=name#><#=methodName#><TSource>(IAsyncObserver<<#=typeName#>> observer, Func<TSource, ValueTask<<#=typeName#>>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/MaxBy.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/MaxBy.cs
@@ -31,7 +31,7 @@ namespace System.Reactive.Linq
             return Create<IList<TSource>>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxBy(observer, keySelector, comparer)));
         }
 
-        public static IAsyncObservable<IList<TSource>> MaxBy<TSource, TKey>(IAsyncObservable<TSource> source, Func<TSource, Task<TKey>> keySelector)
+        public static IAsyncObservable<IList<TSource>> MaxBy<TSource, TKey>(IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -41,7 +41,7 @@ namespace System.Reactive.Linq
             return Create<IList<TSource>>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxBy(observer, keySelector)));
         }
 
-        public static IAsyncObservable<IList<TSource>> MaxBy<TSource, TKey>(IAsyncObservable<TSource> source, Func<TSource, Task<TKey>> keySelector, IComparer<TKey> comparer)
+        public static IAsyncObservable<IList<TSource>> MaxBy<TSource, TKey>(IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, IComparer<TKey> comparer)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -63,7 +63,7 @@ namespace System.Reactive.Linq
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return MaxBy(observer, x => Task.FromResult(keySelector(x)), Comparer<TKey>.Default);
+            return MaxBy(observer, x => new ValueTask<TKey>(keySelector(x)), Comparer<TKey>.Default);
         }
 
         public static IAsyncObserver<TSource> MaxBy<TSource, TKey>(IAsyncObserver<IList<TSource>> observer, Func<TSource, TKey> keySelector, IComparer<TKey> comparer)
@@ -75,10 +75,10 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return MaxBy(observer, x => Task.FromResult(keySelector(x)), comparer);
+            return MaxBy(observer, x => new ValueTask<TKey>(keySelector(x)), comparer);
         }
 
-        public static IAsyncObserver<TSource> MaxBy<TSource, TKey>(IAsyncObserver<IList<TSource>> observer, Func<TSource, Task<TKey>> keySelector)
+        public static IAsyncObserver<TSource> MaxBy<TSource, TKey>(IAsyncObserver<IList<TSource>> observer, Func<TSource, ValueTask<TKey>> keySelector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -88,7 +88,7 @@ namespace System.Reactive.Linq
             return MaxBy(observer, keySelector, Comparer<TKey>.Default);
         }
 
-        public static IAsyncObserver<TSource> MaxBy<TSource, TKey>(IAsyncObserver<IList<TSource>> observer, Func<TSource, Task<TKey>> keySelector, IComparer<TKey> comparer)
+        public static IAsyncObserver<TSource> MaxBy<TSource, TKey>(IAsyncObserver<IList<TSource>> observer, Func<TSource, ValueTask<TKey>> keySelector, IComparer<TKey> comparer)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Min.Generated.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Min.Generated.cs
@@ -26,7 +26,7 @@ namespace System.Reactive.Linq
             return Create<Int32>(observer => source.SubscribeSafeAsync(AsyncObserver.MinInt32(observer, selector)));
         }
 
-        public static IAsyncObservable<Int32> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Int32>> selector)
+        public static IAsyncObservable<Int32> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int32>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -54,7 +54,7 @@ namespace System.Reactive.Linq
             return Create<Int32?>(observer => source.SubscribeSafeAsync(AsyncObserver.MinNullableInt32(observer, selector)));
         }
 
-        public static IAsyncObservable<Int32?> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Int32?>> selector)
+        public static IAsyncObservable<Int32?> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int32?>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -82,7 +82,7 @@ namespace System.Reactive.Linq
             return Create<Int64>(observer => source.SubscribeSafeAsync(AsyncObserver.MinInt64(observer, selector)));
         }
 
-        public static IAsyncObservable<Int64> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Int64>> selector)
+        public static IAsyncObservable<Int64> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int64>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -110,7 +110,7 @@ namespace System.Reactive.Linq
             return Create<Int64?>(observer => source.SubscribeSafeAsync(AsyncObserver.MinNullableInt64(observer, selector)));
         }
 
-        public static IAsyncObservable<Int64?> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Int64?>> selector)
+        public static IAsyncObservable<Int64?> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int64?>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -138,7 +138,7 @@ namespace System.Reactive.Linq
             return Create<Single>(observer => source.SubscribeSafeAsync(AsyncObserver.MinSingle(observer, selector)));
         }
 
-        public static IAsyncObservable<Single> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Single>> selector)
+        public static IAsyncObservable<Single> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Single>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -166,7 +166,7 @@ namespace System.Reactive.Linq
             return Create<Single?>(observer => source.SubscribeSafeAsync(AsyncObserver.MinNullableSingle(observer, selector)));
         }
 
-        public static IAsyncObservable<Single?> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Single?>> selector)
+        public static IAsyncObservable<Single?> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Single?>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -194,7 +194,7 @@ namespace System.Reactive.Linq
             return Create<Double>(observer => source.SubscribeSafeAsync(AsyncObserver.MinDouble(observer, selector)));
         }
 
-        public static IAsyncObservable<Double> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Double>> selector)
+        public static IAsyncObservable<Double> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Double>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -222,7 +222,7 @@ namespace System.Reactive.Linq
             return Create<Double?>(observer => source.SubscribeSafeAsync(AsyncObserver.MinNullableDouble(observer, selector)));
         }
 
-        public static IAsyncObservable<Double?> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Double?>> selector)
+        public static IAsyncObservable<Double?> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Double?>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -250,7 +250,7 @@ namespace System.Reactive.Linq
             return Create<Decimal>(observer => source.SubscribeSafeAsync(AsyncObserver.MinDecimal(observer, selector)));
         }
 
-        public static IAsyncObservable<Decimal> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Decimal>> selector)
+        public static IAsyncObservable<Decimal> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Decimal>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -278,7 +278,7 @@ namespace System.Reactive.Linq
             return Create<Decimal?>(observer => source.SubscribeSafeAsync(AsyncObserver.MinNullableDecimal(observer, selector)));
         }
 
-        public static IAsyncObservable<Decimal?> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Decimal?>> selector)
+        public static IAsyncObservable<Decimal?> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Decimal?>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -302,7 +302,7 @@ namespace System.Reactive.Linq
             return Select(MinInt32(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> MinInt32<TSource>(IAsyncObserver<Int32> observer, Func<TSource, Task<Int32>> selector)
+        public static IAsyncObserver<TSource> MinInt32<TSource>(IAsyncObserver<Int32> observer, Func<TSource, ValueTask<Int32>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -322,7 +322,7 @@ namespace System.Reactive.Linq
             return Select(MinNullableInt32(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> MinNullableInt32<TSource>(IAsyncObserver<Int32?> observer, Func<TSource, Task<Int32?>> selector)
+        public static IAsyncObserver<TSource> MinNullableInt32<TSource>(IAsyncObserver<Int32?> observer, Func<TSource, ValueTask<Int32?>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -342,7 +342,7 @@ namespace System.Reactive.Linq
             return Select(MinInt64(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> MinInt64<TSource>(IAsyncObserver<Int64> observer, Func<TSource, Task<Int64>> selector)
+        public static IAsyncObserver<TSource> MinInt64<TSource>(IAsyncObserver<Int64> observer, Func<TSource, ValueTask<Int64>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -362,7 +362,7 @@ namespace System.Reactive.Linq
             return Select(MinNullableInt64(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> MinNullableInt64<TSource>(IAsyncObserver<Int64?> observer, Func<TSource, Task<Int64?>> selector)
+        public static IAsyncObserver<TSource> MinNullableInt64<TSource>(IAsyncObserver<Int64?> observer, Func<TSource, ValueTask<Int64?>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -382,7 +382,7 @@ namespace System.Reactive.Linq
             return Select(MinSingle(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> MinSingle<TSource>(IAsyncObserver<Single> observer, Func<TSource, Task<Single>> selector)
+        public static IAsyncObserver<TSource> MinSingle<TSource>(IAsyncObserver<Single> observer, Func<TSource, ValueTask<Single>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -402,7 +402,7 @@ namespace System.Reactive.Linq
             return Select(MinNullableSingle(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> MinNullableSingle<TSource>(IAsyncObserver<Single?> observer, Func<TSource, Task<Single?>> selector)
+        public static IAsyncObserver<TSource> MinNullableSingle<TSource>(IAsyncObserver<Single?> observer, Func<TSource, ValueTask<Single?>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -422,7 +422,7 @@ namespace System.Reactive.Linq
             return Select(MinDouble(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> MinDouble<TSource>(IAsyncObserver<Double> observer, Func<TSource, Task<Double>> selector)
+        public static IAsyncObserver<TSource> MinDouble<TSource>(IAsyncObserver<Double> observer, Func<TSource, ValueTask<Double>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -442,7 +442,7 @@ namespace System.Reactive.Linq
             return Select(MinNullableDouble(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> MinNullableDouble<TSource>(IAsyncObserver<Double?> observer, Func<TSource, Task<Double?>> selector)
+        public static IAsyncObserver<TSource> MinNullableDouble<TSource>(IAsyncObserver<Double?> observer, Func<TSource, ValueTask<Double?>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -462,7 +462,7 @@ namespace System.Reactive.Linq
             return Select(MinDecimal(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> MinDecimal<TSource>(IAsyncObserver<Decimal> observer, Func<TSource, Task<Decimal>> selector)
+        public static IAsyncObserver<TSource> MinDecimal<TSource>(IAsyncObserver<Decimal> observer, Func<TSource, ValueTask<Decimal>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -482,7 +482,7 @@ namespace System.Reactive.Linq
             return Select(MinNullableDecimal(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> MinNullableDecimal<TSource>(IAsyncObserver<Decimal?> observer, Func<TSource, Task<Decimal?>> selector)
+        public static IAsyncObserver<TSource> MinNullableDecimal<TSource>(IAsyncObserver<Decimal?> observer, Func<TSource, ValueTask<Decimal?>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Min.Generated.tt
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Min.Generated.tt
@@ -45,7 +45,7 @@ foreach (var t in types)
             return Create<<#=typeName#>>(observer => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
         }
 
-        public static IAsyncObservable<<#=typeName#>> <#=name#><TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<<#=typeName#>>> selector)
+        public static IAsyncObservable<<#=typeName#>> <#=name#><TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<<#=typeName#>>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -82,7 +82,7 @@ foreach (var t in types)
             return Select(<#=name#><#=methodName#>(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> <#=name#><#=methodName#><TSource>(IAsyncObserver<<#=typeName#>> observer, Func<TSource, Task<<#=typeName#>>> selector)
+        public static IAsyncObserver<TSource> <#=name#><#=methodName#><TSource>(IAsyncObserver<<#=typeName#>> observer, Func<TSource, ValueTask<<#=typeName#>>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/MinBy.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/MinBy.cs
@@ -31,7 +31,7 @@ namespace System.Reactive.Linq
             return Create<IList<TSource>>(observer => source.SubscribeSafeAsync(AsyncObserver.MinBy(observer, keySelector, comparer)));
         }
 
-        public static IAsyncObservable<IList<TSource>> MinBy<TSource, TKey>(IAsyncObservable<TSource> source, Func<TSource, Task<TKey>> keySelector)
+        public static IAsyncObservable<IList<TSource>> MinBy<TSource, TKey>(IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -41,7 +41,7 @@ namespace System.Reactive.Linq
             return Create<IList<TSource>>(observer => source.SubscribeSafeAsync(AsyncObserver.MinBy(observer, keySelector)));
         }
 
-        public static IAsyncObservable<IList<TSource>> MinBy<TSource, TKey>(IAsyncObservable<TSource> source, Func<TSource, Task<TKey>> keySelector, IComparer<TKey> comparer)
+        public static IAsyncObservable<IList<TSource>> MinBy<TSource, TKey>(IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, IComparer<TKey> comparer)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -63,7 +63,7 @@ namespace System.Reactive.Linq
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return MinBy(observer, x => Task.FromResult(keySelector(x)), Comparer<TKey>.Default);
+            return MinBy(observer, x => new ValueTask<TKey>(keySelector(x)), Comparer<TKey>.Default);
         }
 
         public static IAsyncObserver<TSource> MinBy<TSource, TKey>(IAsyncObserver<IList<TSource>> observer, Func<TSource, TKey> keySelector, IComparer<TKey> comparer)
@@ -75,10 +75,10 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return MinBy(observer, x => Task.FromResult(keySelector(x)), comparer);
+            return MinBy(observer, x => new ValueTask<TKey>(keySelector(x)), comparer);
         }
 
-        public static IAsyncObserver<TSource> MinBy<TSource, TKey>(IAsyncObserver<IList<TSource>> observer, Func<TSource, Task<TKey>> keySelector)
+        public static IAsyncObserver<TSource> MinBy<TSource, TKey>(IAsyncObserver<IList<TSource>> observer, Func<TSource, ValueTask<TKey>> keySelector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -88,7 +88,7 @@ namespace System.Reactive.Linq
             return MinBy(observer, keySelector, Comparer<TKey>.Default);
         }
 
-        public static IAsyncObserver<TSource> MinBy<TSource, TKey>(IAsyncObserver<IList<TSource>> observer, Func<TSource, Task<TKey>> keySelector, IComparer<TKey> comparer)
+        public static IAsyncObserver<TSource> MinBy<TSource, TKey>(IAsyncObserver<IList<TSource>> observer, Func<TSource, ValueTask<TKey>> keySelector, IComparer<TKey> comparer)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Multicast.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Multicast.cs
@@ -27,17 +27,17 @@ namespace System.Reactive.Linq
             if (subjectFactory == null)
                 throw new ArgumentNullException(nameof(subjectFactory));
 
-            return Multicast(source, () => Task.FromResult<IAsyncSubject<TSource, TSource>>(subjectFactory()), x => Task.FromResult(x));
+            return Multicast(source, () => new ValueTask<IAsyncSubject<TSource, TSource>>(subjectFactory()), x => new ValueTask<IAsyncObservable<TSource>>(x));
         }
 
-        public static IAsyncObservable<TSource> Multicast<TSource>(this IAsyncObservable<TSource> source, Func<Task<IAsyncSubject<TSource>>> subjectFactory)
+        public static IAsyncObservable<TSource> Multicast<TSource>(this IAsyncObservable<TSource> source, Func<ValueTask<IAsyncSubject<TSource>>> subjectFactory)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
             if (subjectFactory == null)
                 throw new ArgumentNullException(nameof(subjectFactory));
 
-            return Multicast<TSource, TSource, TSource>(source, async () => await subjectFactory().ConfigureAwait(false), x => Task.FromResult(x));
+            return Multicast<TSource, TSource, TSource>(source, async () => await subjectFactory().ConfigureAwait(false), x => new ValueTask<IAsyncObservable<TSource>>(x));
         }
 
         public static IAsyncObservable<TResult> Multicast<TSource, TIntermediate, TResult>(this IAsyncObservable<TSource> source, Func<IAsyncSubject<TSource, TIntermediate>> subjectFactory, Func<IAsyncObservable<TIntermediate>, IAsyncObservable<TResult>> selector)
@@ -49,10 +49,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Multicast(source, () => Task.FromResult(subjectFactory()), x => Task.FromResult(selector(x)));
+            return Multicast(source, () => new ValueTask<IAsyncSubject<TSource, TIntermediate>>(subjectFactory()), x => new ValueTask<IAsyncObservable<TResult>>(selector(x)));
         }
 
-        public static IAsyncObservable<TResult> Multicast<TSource, TIntermediate, TResult>(this IAsyncObservable<TSource> source, Func<Task<IAsyncSubject<TSource, TIntermediate>>> subjectFactory, Func<IAsyncObservable<TIntermediate>, Task<IAsyncObservable<TResult>>> selector)
+        public static IAsyncObservable<TResult> Multicast<TSource, TIntermediate, TResult>(this IAsyncObservable<TSource> source, Func<ValueTask<IAsyncSubject<TSource, TIntermediate>>> subjectFactory, Func<IAsyncObservable<TIntermediate>, ValueTask<IAsyncObservable<TResult>>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Publish.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Publish.cs
@@ -47,24 +47,24 @@ namespace System.Reactive.Linq
             return Multicast(source, () => new SequentialBehaviorAsyncSubject<TSource>(value), selector);
         }
 
-        public static IAsyncObservable<TResult> Publish<TSource, TResult>(this IAsyncObservable<TSource> source, Func<IAsyncObservable<TSource>, Task<IAsyncObservable<TResult>>> selector)
+        public static IAsyncObservable<TResult> Publish<TSource, TResult>(this IAsyncObservable<TSource> source, Func<IAsyncObservable<TSource>, ValueTask<IAsyncObservable<TResult>>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Multicast(source, () => Task.FromResult<IAsyncSubject<TSource, TSource>>(new SequentialSimpleAsyncSubject<TSource>()), selector);
+            return Multicast(source, () => new ValueTask<IAsyncSubject<TSource, TSource>>(new SequentialSimpleAsyncSubject<TSource>()), selector);
         }
 
-        public static IAsyncObservable<TResult> Publish<TSource, TResult>(this IAsyncObservable<TSource> source, Func<IAsyncObservable<TSource>, Task<IAsyncObservable<TResult>>> selector, TSource value)
+        public static IAsyncObservable<TResult> Publish<TSource, TResult>(this IAsyncObservable<TSource> source, Func<IAsyncObservable<TSource>, ValueTask<IAsyncObservable<TResult>>> selector, TSource value)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Multicast(source, () => Task.FromResult<IAsyncSubject<TSource, TSource>>(new SequentialBehaviorAsyncSubject<TSource>(value)), selector);
+            return Multicast(source, () => new ValueTask<IAsyncSubject<TSource, TSource>>(new SequentialBehaviorAsyncSubject<TSource>(value)), selector);
         }
     }
 }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/PublishLast.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/PublishLast.cs
@@ -29,14 +29,14 @@ namespace System.Reactive.Linq
             return Multicast(source, () => new SequentialAsyncAsyncSubject<TSource>(), selector);
         }
 
-        public static IAsyncObservable<TResult> PublishLast<TSource, TResult>(this IAsyncObservable<TSource> source, Func<IAsyncObservable<TSource>, Task<IAsyncObservable<TResult>>> selector)
+        public static IAsyncObservable<TResult> PublishLast<TSource, TResult>(this IAsyncObservable<TSource> source, Func<IAsyncObservable<TSource>, ValueTask<IAsyncObservable<TResult>>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Multicast(source, () => Task.FromResult<IAsyncSubject<TSource, TSource>>(new SequentialAsyncAsyncSubject<TSource>()), selector);
+            return Multicast(source, () => new ValueTask<IAsyncSubject<TSource, TSource>>(new SequentialAsyncAsyncSubject<TSource>()), selector);
         }
     }
 }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Replay.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Replay.cs
@@ -204,17 +204,17 @@ namespace System.Reactive.Linq
             return Multicast(source, () => new SequentialReplayAsyncSubject<TSource>(bufferSize, window, scheduler), selector);
         }
 
-        public static IAsyncObservable<TResult> Replay<TSource, TResult>(this IAsyncObservable<TSource> source, Func<IAsyncObservable<TSource>, Task<IAsyncObservable<TResult>>> selector)
+        public static IAsyncObservable<TResult> Replay<TSource, TResult>(this IAsyncObservable<TSource> source, Func<IAsyncObservable<TSource>, ValueTask<IAsyncObservable<TResult>>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Multicast(source, () => Task.FromResult<IAsyncSubject<TSource, TSource>>(new SequentialReplayAsyncSubject<TSource>()), selector);
+            return Multicast(source, () => new ValueTask<IAsyncSubject<TSource, TSource>>(new SequentialReplayAsyncSubject<TSource>()), selector);
         }
 
-        public static IAsyncObservable<TResult> Replay<TSource, TResult>(this IAsyncObservable<TSource> source, Func<IAsyncObservable<TSource>, Task<IAsyncObservable<TResult>>> selector, IAsyncScheduler scheduler)
+        public static IAsyncObservable<TResult> Replay<TSource, TResult>(this IAsyncObservable<TSource> source, Func<IAsyncObservable<TSource>, ValueTask<IAsyncObservable<TResult>>> selector, IAsyncScheduler scheduler)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -223,10 +223,10 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Multicast(source, () => Task.FromResult<IAsyncSubject<TSource, TSource>>(new SequentialReplayAsyncSubject<TSource>(scheduler)), selector);
+            return Multicast(source, () => new ValueTask<IAsyncSubject<TSource, TSource>>(new SequentialReplayAsyncSubject<TSource>(scheduler)), selector);
         }
 
-        public static IAsyncObservable<TResult> Replay<TSource, TResult>(this IAsyncObservable<TSource> source, Func<IAsyncObservable<TSource>, Task<IAsyncObservable<TResult>>> selector, int bufferSize)
+        public static IAsyncObservable<TResult> Replay<TSource, TResult>(this IAsyncObservable<TSource> source, Func<IAsyncObservable<TSource>, ValueTask<IAsyncObservable<TResult>>> selector, int bufferSize)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -235,10 +235,10 @@ namespace System.Reactive.Linq
             if (bufferSize < 0)
                 throw new ArgumentOutOfRangeException(nameof(bufferSize));
 
-            return Multicast(source, () => Task.FromResult<IAsyncSubject<TSource, TSource>>(new SequentialReplayAsyncSubject<TSource>(bufferSize)), selector);
+            return Multicast(source, () => new ValueTask<IAsyncSubject<TSource, TSource>>(new SequentialReplayAsyncSubject<TSource>(bufferSize)), selector);
         }
 
-        public static IAsyncObservable<TResult> Replay<TSource, TResult>(this IAsyncObservable<TSource> source, Func<IAsyncObservable<TSource>, Task<IAsyncObservable<TResult>>> selector, int bufferSize, IAsyncScheduler scheduler)
+        public static IAsyncObservable<TResult> Replay<TSource, TResult>(this IAsyncObservable<TSource> source, Func<IAsyncObservable<TSource>, ValueTask<IAsyncObservable<TResult>>> selector, int bufferSize, IAsyncScheduler scheduler)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -249,10 +249,10 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Multicast(source, () => Task.FromResult<IAsyncSubject<TSource, TSource>>(new SequentialReplayAsyncSubject<TSource>(bufferSize, scheduler)), selector);
+            return Multicast(source, () => new ValueTask<IAsyncSubject<TSource, TSource>>(new SequentialReplayAsyncSubject<TSource>(bufferSize, scheduler)), selector);
         }
 
-        public static IAsyncObservable<TResult> Replay<TSource, TResult>(this IAsyncObservable<TSource> source, Func<IAsyncObservable<TSource>, Task<IAsyncObservable<TResult>>> selector, TimeSpan window)
+        public static IAsyncObservable<TResult> Replay<TSource, TResult>(this IAsyncObservable<TSource> source, Func<IAsyncObservable<TSource>, ValueTask<IAsyncObservable<TResult>>> selector, TimeSpan window)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -261,10 +261,10 @@ namespace System.Reactive.Linq
             if (window < TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException(nameof(window));
 
-            return Multicast(source, () => Task.FromResult<IAsyncSubject<TSource, TSource>>(new SequentialReplayAsyncSubject<TSource>(window)), selector);
+            return Multicast(source, () => new ValueTask<IAsyncSubject<TSource, TSource>>(new SequentialReplayAsyncSubject<TSource>(window)), selector);
         }
 
-        public static IAsyncObservable<TResult> Replay<TSource, TResult>(this IAsyncObservable<TSource> source, Func<IAsyncObservable<TSource>, Task<IAsyncObservable<TResult>>> selector, TimeSpan window, IAsyncScheduler scheduler)
+        public static IAsyncObservable<TResult> Replay<TSource, TResult>(this IAsyncObservable<TSource> source, Func<IAsyncObservable<TSource>, ValueTask<IAsyncObservable<TResult>>> selector, TimeSpan window, IAsyncScheduler scheduler)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -275,24 +275,10 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Multicast(source, () => Task.FromResult<IAsyncSubject<TSource, TSource>>(new SequentialReplayAsyncSubject<TSource>(window, scheduler)), selector);
+            return Multicast(source, () => new ValueTask<IAsyncSubject<TSource, TSource>>(new SequentialReplayAsyncSubject<TSource>(window, scheduler)), selector);
         }
 
-        public static IAsyncObservable<TResult> Replay<TSource, TResult>(this IAsyncObservable<TSource> source, Func<IAsyncObservable<TSource>, Task<IAsyncObservable<TResult>>> selector, int bufferSize, TimeSpan window)
-        {
-            if (source == null)
-                throw new ArgumentNullException(nameof(source));
-            if (selector == null)
-                throw new ArgumentNullException(nameof(selector));
-            if (bufferSize < 0)
-                throw new ArgumentOutOfRangeException(nameof(bufferSize));
-            if (window < TimeSpan.Zero)
-                throw new ArgumentOutOfRangeException(nameof(window));
-
-            return Multicast(source, () => Task.FromResult<IAsyncSubject<TSource, TSource>>(new SequentialReplayAsyncSubject<TSource>(bufferSize, window)), selector);
-        }
-
-        public static IAsyncObservable<TResult> Replay<TSource, TResult>(this IAsyncObservable<TSource> source, Func<IAsyncObservable<TSource>, Task<IAsyncObservable<TResult>>> selector, int bufferSize, TimeSpan window, IAsyncScheduler scheduler)
+        public static IAsyncObservable<TResult> Replay<TSource, TResult>(this IAsyncObservable<TSource> source, Func<IAsyncObservable<TSource>, ValueTask<IAsyncObservable<TResult>>> selector, int bufferSize, TimeSpan window)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -302,10 +288,24 @@ namespace System.Reactive.Linq
                 throw new ArgumentOutOfRangeException(nameof(bufferSize));
             if (window < TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException(nameof(window));
+
+            return Multicast(source, () => new ValueTask<IAsyncSubject<TSource, TSource>>(new SequentialReplayAsyncSubject<TSource>(bufferSize, window)), selector);
+        }
+
+        public static IAsyncObservable<TResult> Replay<TSource, TResult>(this IAsyncObservable<TSource> source, Func<IAsyncObservable<TSource>, ValueTask<IAsyncObservable<TResult>>> selector, int bufferSize, TimeSpan window, IAsyncScheduler scheduler)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+            if (selector == null)
+                throw new ArgumentNullException(nameof(selector));
+            if (bufferSize < 0)
+                throw new ArgumentOutOfRangeException(nameof(bufferSize));
+            if (window < TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(window));
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Multicast(source, () => Task.FromResult<IAsyncSubject<TSource, TSource>>(new SequentialReplayAsyncSubject<TSource>(bufferSize, window, scheduler)), selector);
+            return Multicast(source, () => new ValueTask<IAsyncSubject<TSource, TSource>>(new SequentialReplayAsyncSubject<TSource>(bufferSize, window, scheduler)), selector);
         }
     }
 }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Scan.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Scan.cs
@@ -18,7 +18,7 @@ namespace System.Reactive.Linq
             return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.Scan(observer, func)));
         }
 
-        public static IAsyncObservable<TSource> Scan<TSource>(this IAsyncObservable<TSource> source, Func<TSource, TSource, Task<TSource>> func)
+        public static IAsyncObservable<TSource> Scan<TSource>(this IAsyncObservable<TSource> source, Func<TSource, TSource, ValueTask<TSource>> func)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -38,7 +38,7 @@ namespace System.Reactive.Linq
             return Create<TResult>(observer => source.SubscribeSafeAsync(AsyncObserver.Scan(observer, seed, func)));
         }
 
-        public static IAsyncObservable<TResult> Scan<TSource, TResult>(this IAsyncObservable<TSource> source, TResult seed, Func<TResult, TSource, Task<TResult>> func)
+        public static IAsyncObservable<TResult> Scan<TSource, TResult>(this IAsyncObservable<TSource> source, TResult seed, Func<TResult, TSource, ValueTask<TResult>> func)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -89,7 +89,7 @@ namespace System.Reactive.Linq
             );
         }
 
-        public static IAsyncObserver<TSource> Scan<TSource>(IAsyncObserver<TSource> observer, Func<TSource, TSource, Task<TSource>> func)
+        public static IAsyncObserver<TSource> Scan<TSource>(IAsyncObserver<TSource> observer, Func<TSource, TSource, ValueTask<TSource>> func)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -156,7 +156,7 @@ namespace System.Reactive.Linq
             );
         }
 
-        public static IAsyncObserver<TSource> Scan<TSource, TResult>(IAsyncObserver<TResult> observer, TResult seed, Func<TResult, TSource, Task<TResult>> func)
+        public static IAsyncObserver<TSource> Scan<TSource, TResult>(IAsyncObserver<TResult> observer, TResult seed, Func<TResult, TSource, ValueTask<TResult>> func)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Select.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Select.cs
@@ -18,7 +18,7 @@ namespace System.Reactive.Linq
             return Create<TResult>(observer => source.SubscribeSafeAsync(AsyncObserver.Select(observer, selector)));
         }
 
-        public static IAsyncObservable<TResult> Select<TSource, TResult>(this IAsyncObservable<TSource> source, Func<TSource, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> Select<TSource, TResult>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TResult>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -38,7 +38,7 @@ namespace System.Reactive.Linq
             return Create<TResult>(observer => source.SubscribeSafeAsync(AsyncObserver.Select(observer, selector)));
         }
 
-        public static IAsyncObservable<TResult> Select<TSource, TResult>(this IAsyncObservable<TSource> source, Func<TSource, int, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> Select<TSource, TResult>(this IAsyncObservable<TSource> source, Func<TSource, int, ValueTask<TResult>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -80,7 +80,7 @@ namespace System.Reactive.Linq
             );
         }
 
-        public static IAsyncObserver<TSource> Select<TSource, TResult>(IAsyncObserver<TResult> observer, Func<TSource, Task<TResult>> selector)
+        public static IAsyncObserver<TSource> Select<TSource, TResult>(IAsyncObserver<TResult> observer, Func<TSource, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -140,7 +140,7 @@ namespace System.Reactive.Linq
             );
         }
 
-        public static IAsyncObserver<TSource> Select<TSource, TResult>(IAsyncObserver<TResult> observer, Func<TSource, int, Task<TResult>> selector)
+        public static IAsyncObserver<TSource> Select<TSource, TResult>(IAsyncObserver<TResult> observer, Func<TSource, int, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SelectMany.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SelectMany.cs
@@ -27,7 +27,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> SelectMany<TSource, TResult>(this IAsyncObservable<TSource> source, Func<TSource, Task<IAsyncObservable<TResult>>> selector)
+        public static IAsyncObservable<TResult> SelectMany<TSource, TResult>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<IAsyncObservable<TResult>>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -63,7 +63,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> SelectMany<TSource, TCollection, TResult>(this IAsyncObservable<TSource> source, Func<TSource, Task<IAsyncObservable<TCollection>>> collectionSelector, Func<TSource, TCollection, Task<TResult>> resultSelector)
+        public static IAsyncObservable<TResult> SelectMany<TSource, TCollection, TResult>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<IAsyncObservable<TCollection>>> collectionSelector, Func<TSource, TCollection, ValueTask<TResult>> resultSelector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -99,7 +99,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> SelectMany<TSource, TResult>(this IAsyncObservable<TSource> source, Func<TSource, int, Task<IAsyncObservable<TResult>>> selector)
+        public static IAsyncObservable<TResult> SelectMany<TSource, TResult>(this IAsyncObservable<TSource> source, Func<TSource, int, ValueTask<IAsyncObservable<TResult>>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -135,7 +135,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> SelectMany<TSource, TCollection, TResult>(this IAsyncObservable<TSource> source, Func<TSource, int, Task<IAsyncObservable<TCollection>>> collectionSelector, Func<TSource, int, TCollection, int, Task<TResult>> resultSelector)
+        public static IAsyncObservable<TResult> SelectMany<TSource, TCollection, TResult>(this IAsyncObservable<TSource> source, Func<TSource, int, ValueTask<IAsyncObservable<TCollection>>> collectionSelector, Func<TSource, int, TCollection, int, ValueTask<TResult>> resultSelector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -164,17 +164,17 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return SelectMany<TSource, TResult, TResult>(observer, x => Task.FromResult(selector(x)), (x, y) => Task.FromResult(y));
+            return SelectMany<TSource, TResult, TResult>(observer, x => new ValueTask<IAsyncObservable<TResult>>(selector(x)), (x, y) => new ValueTask<TResult>(y));
         }
 
-        public static (IAsyncObserver<TSource>, IAsyncDisposable) SelectMany<TSource, TResult>(IAsyncObserver<TResult> observer, Func<TSource, Task<IAsyncObservable<TResult>>> selector)
+        public static (IAsyncObserver<TSource>, IAsyncDisposable) SelectMany<TSource, TResult>(IAsyncObserver<TResult> observer, Func<TSource, ValueTask<IAsyncObservable<TResult>>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return SelectMany<TSource, TResult, TResult>(observer, selector, (x, y) => Task.FromResult(y));
+            return SelectMany<TSource, TResult, TResult>(observer, selector, (x, y) => new ValueTask<TResult>(y));
         }
 
         public static (IAsyncObserver<TSource>, IAsyncDisposable) SelectMany<TSource, TCollection, TResult>(IAsyncObserver<TResult> observer, Func<TSource, IAsyncObservable<TCollection>> collectionSelector, Func<TSource, TCollection, TResult> resultSelector)
@@ -186,10 +186,10 @@ namespace System.Reactive.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            return SelectMany<TSource, TCollection, TResult>(observer, x => Task.FromResult(collectionSelector(x)), (x, y) => Task.FromResult(resultSelector(x, y)));
+            return SelectMany<TSource, TCollection, TResult>(observer, x => new ValueTask<IAsyncObservable<TCollection>>(collectionSelector(x)), (x, y) => new ValueTask<TResult>(resultSelector(x, y)));
         }
 
-        public static (IAsyncObserver<TSource>, IAsyncDisposable) SelectMany<TSource, TCollection, TResult>(IAsyncObserver<TResult> observer, Func<TSource, Task<IAsyncObservable<TCollection>>> collectionSelector, Func<TSource, TCollection, Task<TResult>> resultSelector)
+        public static (IAsyncObserver<TSource>, IAsyncDisposable) SelectMany<TSource, TCollection, TResult>(IAsyncObserver<TResult> observer, Func<TSource, ValueTask<IAsyncObservable<TCollection>>> collectionSelector, Func<TSource, TCollection, ValueTask<TResult>> resultSelector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -296,17 +296,17 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return SelectMany<TSource, TResult, TResult>(observer, (x, i) => Task.FromResult(selector(x, i)), (x, i, y, j) => Task.FromResult(y));
+            return SelectMany<TSource, TResult, TResult>(observer, (x, i) => new ValueTask<IAsyncObservable<TResult>>(selector(x, i)), (x, i, y, j) => new ValueTask<TResult>(y));
         }
 
-        public static (IAsyncObserver<TSource>, IAsyncDisposable) SelectMany<TSource, TResult>(IAsyncObserver<TResult> observer, Func<TSource, int, Task<IAsyncObservable<TResult>>> selector)
+        public static (IAsyncObserver<TSource>, IAsyncDisposable) SelectMany<TSource, TResult>(IAsyncObserver<TResult> observer, Func<TSource, int, ValueTask<IAsyncObservable<TResult>>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return SelectMany<TSource, TResult, TResult>(observer, selector, (x, i, y, j) => Task.FromResult(y));
+            return SelectMany<TSource, TResult, TResult>(observer, selector, (x, i, y, j) => new ValueTask<TResult>(y));
         }
 
         public static (IAsyncObserver<TSource>, IAsyncDisposable) SelectMany<TSource, TCollection, TResult>(IAsyncObserver<TResult> observer, Func<TSource, int, IAsyncObservable<TCollection>> collectionSelector, Func<TSource, int, TCollection, int, TResult> resultSelector)
@@ -318,10 +318,10 @@ namespace System.Reactive.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            return SelectMany<TSource, TCollection, TResult>(observer, (x, i) => Task.FromResult(collectionSelector(x, i)), (x, i, y, j) => Task.FromResult(resultSelector(x, i, y, j)));
+            return SelectMany<TSource, TCollection, TResult>(observer, (x, i) => new ValueTask<IAsyncObservable<TCollection>>(collectionSelector(x, i)), (x, i, y, j) => new ValueTask<TResult>(resultSelector(x, i, y, j)));
         }
 
-        public static (IAsyncObserver<TSource>, IAsyncDisposable) SelectMany<TSource, TCollection, TResult>(IAsyncObserver<TResult> observer, Func<TSource, int, Task<IAsyncObservable<TCollection>>> collectionSelector, Func<TSource, int, TCollection, int, Task<TResult>> resultSelector)
+        public static (IAsyncObserver<TSource>, IAsyncDisposable) SelectMany<TSource, TCollection, TResult>(IAsyncObserver<TResult> observer, Func<TSource, int, ValueTask<IAsyncObservable<TCollection>>> collectionSelector, Func<TSource, int, TCollection, int, ValueTask<TResult>> resultSelector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -330,8 +330,8 @@ namespace System.Reactive.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            Func<(TSource item, int i), Task<IAsyncObservable<(TCollection item, int i)>>> collectionSelectorWithIndex = async t => (await collectionSelector(t.item, t.i).ConfigureAwait(false)).Select((item, i) => (item, i));
-            Func<(TSource item, int i), (TCollection item, int i), Task<TResult>> resultSelectorWithIndex = (outer, inner) => resultSelector(outer.item, outer.i, inner.item, inner.i);
+            Func<(TSource item, int i), ValueTask<IAsyncObservable<(TCollection item, int i)>>> collectionSelectorWithIndex = async t => (await collectionSelector(t.item, t.i).ConfigureAwait(false)).Select((item, i) => (item, i));
+            Func<(TSource item, int i), (TCollection item, int i), ValueTask<TResult>> resultSelectorWithIndex = (outer, inner) => resultSelector(outer.item, outer.i, inner.item, inner.i);
 
             var (outerObserverWithIndex, disposable) = SelectMany(observer, collectionSelectorWithIndex, resultSelectorWithIndex);
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Single.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Single.cs
@@ -10,7 +10,7 @@ namespace System.Reactive.Linq
     {
         public static IAsyncObservable<TSource> SingleAsync<TSource>(this IAsyncObservable<TSource> source) => Single(source);
         public static IAsyncObservable<TSource> SingleAsync<TSource>(this IAsyncObservable<TSource> source, Func<TSource, bool> predicate) => Single(source, predicate);
-        public static IAsyncObservable<TSource> SingleAsync<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<bool>> predicate) => Single(source, predicate);
+        public static IAsyncObservable<TSource> SingleAsync<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate) => Single(source, predicate);
 
         public static IAsyncObservable<TSource> Single<TSource>(this IAsyncObservable<TSource> source)
         {
@@ -30,7 +30,7 @@ namespace System.Reactive.Linq
             return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.Single(observer, predicate)));
         }
 
-        public static IAsyncObservable<TSource> Single<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<bool>> predicate)
+        public static IAsyncObservable<TSource> Single<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -89,7 +89,7 @@ namespace System.Reactive.Linq
             return Where(Single(observer), predicate);
         }
 
-        public static IAsyncObserver<TSource> Single<TSource>(IAsyncObserver<TSource> observer, Func<TSource, Task<bool>> predicate)
+        public static IAsyncObserver<TSource> Single<TSource>(IAsyncObserver<TSource> observer, Func<TSource, ValueTask<bool>> predicate)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SingleOrDefault.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SingleOrDefault.cs
@@ -10,7 +10,7 @@ namespace System.Reactive.Linq
     {
         public static IAsyncObservable<TSource> SingleOrDefaultAsync<TSource>(this IAsyncObservable<TSource> source) => SingleOrDefault(source);
         public static IAsyncObservable<TSource> SingleOrDefaultAsync<TSource>(this IAsyncObservable<TSource> source, Func<TSource, bool> predicate) => SingleOrDefault(source, predicate);
-        public static IAsyncObservable<TSource> SingleOrDefaultAsync<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<bool>> predicate) => SingleOrDefault(source, predicate);
+        public static IAsyncObservable<TSource> SingleOrDefaultAsync<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate) => SingleOrDefault(source, predicate);
 
         public static IAsyncObservable<TSource> SingleOrDefault<TSource>(this IAsyncObservable<TSource> source)
         {
@@ -30,7 +30,7 @@ namespace System.Reactive.Linq
             return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.SingleOrDefault(observer, predicate)));
         }
 
-        public static IAsyncObservable<TSource> SingleOrDefault<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<bool>> predicate)
+        public static IAsyncObservable<TSource> SingleOrDefault<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -82,7 +82,7 @@ namespace System.Reactive.Linq
             return Where(SingleOrDefault(observer), predicate);
         }
 
-        public static IAsyncObserver<TSource> SingleOrDefault<TSource>(IAsyncObserver<TSource> observer, Func<TSource, Task<bool>> predicate)
+        public static IAsyncObserver<TSource> SingleOrDefault<TSource>(IAsyncObserver<TSource> observer, Func<TSource, ValueTask<bool>> predicate)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SkipWhile.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SkipWhile.cs
@@ -18,7 +18,7 @@ namespace System.Reactive.Linq
             return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.SkipWhile(observer, predicate)));
         }
 
-        public static IAsyncObservable<TSource> SkipWhile<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<bool>> predicate)
+        public static IAsyncObservable<TSource> SkipWhile<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -38,7 +38,7 @@ namespace System.Reactive.Linq
             return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.SkipWhile(observer, predicate)));
         }
 
-        public static IAsyncObservable<TSource> SkipWhile<TSource>(this IAsyncObservable<TSource> source, Func<TSource, int, Task<bool>> predicate)
+        public static IAsyncObservable<TSource> SkipWhile<TSource>(this IAsyncObservable<TSource> source, Func<TSource, int, ValueTask<bool>> predicate)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -86,7 +86,7 @@ namespace System.Reactive.Linq
             );
         }
 
-        public static IAsyncObserver<TSource> SkipWhile<TSource>(IAsyncObserver<TSource> observer, Func<TSource, Task<bool>> predicate)
+        public static IAsyncObserver<TSource> SkipWhile<TSource>(IAsyncObserver<TSource> observer, Func<TSource, ValueTask<bool>> predicate)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -157,7 +157,7 @@ namespace System.Reactive.Linq
             );
         }
 
-        public static IAsyncObserver<TSource> SkipWhile<TSource>(IAsyncObserver<TSource> observer, Func<TSource, int, Task<bool>> predicate)
+        public static IAsyncObserver<TSource> SkipWhile<TSource>(IAsyncObserver<TSource> observer, Func<TSource, int, ValueTask<bool>> predicate)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/StartAsync.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/StartAsync.cs
@@ -11,9 +11,9 @@ namespace System.Reactive.Linq
 {
     partial class AsyncObservable
     {
-        public static IAsyncObservable<TSource> StartAsync<TSource>(Func<Task<TSource>> functionAsync) => StartAsync(functionAsync, ImmediateAsyncScheduler.Instance);
+        public static IAsyncObservable<TSource> StartAsync<TSource>(Func<ValueTask<TSource>> functionAsync) => StartAsync(functionAsync, ImmediateAsyncScheduler.Instance);
 
-        public static IAsyncObservable<TSource> StartAsync<TSource>(Func<Task<TSource>> functionAsync, IAsyncScheduler scheduler)
+        public static IAsyncObservable<TSource> StartAsync<TSource>(Func<ValueTask<TSource>> functionAsync, IAsyncScheduler scheduler)
         {
             if (functionAsync == null)
                 throw new ArgumentNullException(nameof(functionAsync));
@@ -24,7 +24,7 @@ namespace System.Reactive.Linq
 
             try
             {
-                task = functionAsync();
+                task = functionAsync().AsTask();
             }
             catch (Exception ex)
             {
@@ -34,9 +34,9 @@ namespace System.Reactive.Linq
             return task.ToAsyncObservable(scheduler);
         }
 
-        public static IAsyncObservable<TSource> StartAsync<TSource>(Func<CancellationToken, Task<TSource>> functionAsync) => StartAsync(functionAsync, ImmediateAsyncScheduler.Instance);
+        public static IAsyncObservable<TSource> StartAsync<TSource>(Func<CancellationToken, ValueTask<TSource>> functionAsync) => StartAsync(functionAsync, ImmediateAsyncScheduler.Instance);
 
-        public static IAsyncObservable<TSource> StartAsync<TSource>(Func<CancellationToken, Task<TSource>> functionAsync, IAsyncScheduler scheduler)
+        public static IAsyncObservable<TSource> StartAsync<TSource>(Func<CancellationToken, ValueTask<TSource>> functionAsync, IAsyncScheduler scheduler)
         {
             if (functionAsync == null)
                 throw new ArgumentNullException(nameof(functionAsync));
@@ -49,7 +49,7 @@ namespace System.Reactive.Linq
 
             try
             {
-                task = functionAsync(cancel.Token);
+                task = functionAsync(cancel.Token).AsTask();
             }
             catch (Exception ex)
             {

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Sum.Generated.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Sum.Generated.cs
@@ -26,7 +26,7 @@ namespace System.Reactive.Linq
             return Create<Int32>(observer => source.SubscribeSafeAsync(AsyncObserver.SumInt32(observer, selector)));
         }
 
-        public static IAsyncObservable<Int32> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Int32>> selector)
+        public static IAsyncObservable<Int32> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int32>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -54,7 +54,7 @@ namespace System.Reactive.Linq
             return Create<Int32?>(observer => source.SubscribeSafeAsync(AsyncObserver.SumNullableInt32(observer, selector)));
         }
 
-        public static IAsyncObservable<Int32?> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Int32?>> selector)
+        public static IAsyncObservable<Int32?> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int32?>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -82,7 +82,7 @@ namespace System.Reactive.Linq
             return Create<Int64>(observer => source.SubscribeSafeAsync(AsyncObserver.SumInt64(observer, selector)));
         }
 
-        public static IAsyncObservable<Int64> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Int64>> selector)
+        public static IAsyncObservable<Int64> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int64>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -110,7 +110,7 @@ namespace System.Reactive.Linq
             return Create<Int64?>(observer => source.SubscribeSafeAsync(AsyncObserver.SumNullableInt64(observer, selector)));
         }
 
-        public static IAsyncObservable<Int64?> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Int64?>> selector)
+        public static IAsyncObservable<Int64?> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int64?>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -138,7 +138,7 @@ namespace System.Reactive.Linq
             return Create<Single>(observer => source.SubscribeSafeAsync(AsyncObserver.SumSingle(observer, selector)));
         }
 
-        public static IAsyncObservable<Single> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Single>> selector)
+        public static IAsyncObservable<Single> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Single>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -166,7 +166,7 @@ namespace System.Reactive.Linq
             return Create<Single?>(observer => source.SubscribeSafeAsync(AsyncObserver.SumNullableSingle(observer, selector)));
         }
 
-        public static IAsyncObservable<Single?> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Single?>> selector)
+        public static IAsyncObservable<Single?> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Single?>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -194,7 +194,7 @@ namespace System.Reactive.Linq
             return Create<Double>(observer => source.SubscribeSafeAsync(AsyncObserver.SumDouble(observer, selector)));
         }
 
-        public static IAsyncObservable<Double> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Double>> selector)
+        public static IAsyncObservable<Double> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Double>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -222,7 +222,7 @@ namespace System.Reactive.Linq
             return Create<Double?>(observer => source.SubscribeSafeAsync(AsyncObserver.SumNullableDouble(observer, selector)));
         }
 
-        public static IAsyncObservable<Double?> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Double?>> selector)
+        public static IAsyncObservable<Double?> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Double?>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -250,7 +250,7 @@ namespace System.Reactive.Linq
             return Create<Decimal>(observer => source.SubscribeSafeAsync(AsyncObserver.SumDecimal(observer, selector)));
         }
 
-        public static IAsyncObservable<Decimal> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Decimal>> selector)
+        public static IAsyncObservable<Decimal> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Decimal>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -278,7 +278,7 @@ namespace System.Reactive.Linq
             return Create<Decimal?>(observer => source.SubscribeSafeAsync(AsyncObserver.SumNullableDecimal(observer, selector)));
         }
 
-        public static IAsyncObservable<Decimal?> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<Decimal?>> selector)
+        public static IAsyncObservable<Decimal?> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Decimal?>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -302,7 +302,7 @@ namespace System.Reactive.Linq
             return Select(SumInt32(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> SumInt32<TSource>(IAsyncObserver<Int32> observer, Func<TSource, Task<Int32>> selector)
+        public static IAsyncObserver<TSource> SumInt32<TSource>(IAsyncObserver<Int32> observer, Func<TSource, ValueTask<Int32>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -322,7 +322,7 @@ namespace System.Reactive.Linq
             return Select(SumNullableInt32(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> SumNullableInt32<TSource>(IAsyncObserver<Int32?> observer, Func<TSource, Task<Int32?>> selector)
+        public static IAsyncObserver<TSource> SumNullableInt32<TSource>(IAsyncObserver<Int32?> observer, Func<TSource, ValueTask<Int32?>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -342,7 +342,7 @@ namespace System.Reactive.Linq
             return Select(SumInt64(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> SumInt64<TSource>(IAsyncObserver<Int64> observer, Func<TSource, Task<Int64>> selector)
+        public static IAsyncObserver<TSource> SumInt64<TSource>(IAsyncObserver<Int64> observer, Func<TSource, ValueTask<Int64>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -362,7 +362,7 @@ namespace System.Reactive.Linq
             return Select(SumNullableInt64(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> SumNullableInt64<TSource>(IAsyncObserver<Int64?> observer, Func<TSource, Task<Int64?>> selector)
+        public static IAsyncObserver<TSource> SumNullableInt64<TSource>(IAsyncObserver<Int64?> observer, Func<TSource, ValueTask<Int64?>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -382,7 +382,7 @@ namespace System.Reactive.Linq
             return Select(SumSingle(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> SumSingle<TSource>(IAsyncObserver<Single> observer, Func<TSource, Task<Single>> selector)
+        public static IAsyncObserver<TSource> SumSingle<TSource>(IAsyncObserver<Single> observer, Func<TSource, ValueTask<Single>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -402,7 +402,7 @@ namespace System.Reactive.Linq
             return Select(SumNullableSingle(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> SumNullableSingle<TSource>(IAsyncObserver<Single?> observer, Func<TSource, Task<Single?>> selector)
+        public static IAsyncObserver<TSource> SumNullableSingle<TSource>(IAsyncObserver<Single?> observer, Func<TSource, ValueTask<Single?>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -422,7 +422,7 @@ namespace System.Reactive.Linq
             return Select(SumDouble(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> SumDouble<TSource>(IAsyncObserver<Double> observer, Func<TSource, Task<Double>> selector)
+        public static IAsyncObserver<TSource> SumDouble<TSource>(IAsyncObserver<Double> observer, Func<TSource, ValueTask<Double>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -442,7 +442,7 @@ namespace System.Reactive.Linq
             return Select(SumNullableDouble(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> SumNullableDouble<TSource>(IAsyncObserver<Double?> observer, Func<TSource, Task<Double?>> selector)
+        public static IAsyncObserver<TSource> SumNullableDouble<TSource>(IAsyncObserver<Double?> observer, Func<TSource, ValueTask<Double?>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -462,7 +462,7 @@ namespace System.Reactive.Linq
             return Select(SumDecimal(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> SumDecimal<TSource>(IAsyncObserver<Decimal> observer, Func<TSource, Task<Decimal>> selector)
+        public static IAsyncObserver<TSource> SumDecimal<TSource>(IAsyncObserver<Decimal> observer, Func<TSource, ValueTask<Decimal>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -482,7 +482,7 @@ namespace System.Reactive.Linq
             return Select(SumNullableDecimal(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> SumNullableDecimal<TSource>(IAsyncObserver<Decimal?> observer, Func<TSource, Task<Decimal?>> selector)
+        public static IAsyncObserver<TSource> SumNullableDecimal<TSource>(IAsyncObserver<Decimal?> observer, Func<TSource, ValueTask<Decimal?>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Sum.Generated.tt
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Sum.Generated.tt
@@ -45,7 +45,7 @@ foreach (var t in types)
             return Create<<#=typeName#>>(observer => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
         }
 
-        public static IAsyncObservable<<#=typeName#>> <#=name#><TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<<#=typeName#>>> selector)
+        public static IAsyncObservable<<#=typeName#>> <#=name#><TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<<#=typeName#>>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -82,7 +82,7 @@ foreach (var t in types)
             return Select(<#=name#><#=methodName#>(observer), selector);
         }
 
-        public static IAsyncObserver<TSource> <#=name#><#=methodName#><TSource>(IAsyncObserver<<#=typeName#>> observer, Func<TSource, Task<<#=typeName#>>> selector)
+        public static IAsyncObserver<TSource> <#=name#><#=methodName#><TSource>(IAsyncObserver<<#=typeName#>> observer, Func<TSource, ValueTask<<#=typeName#>>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeWhile.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeWhile.cs
@@ -18,7 +18,7 @@ namespace System.Reactive.Linq
             return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.TakeWhile(observer, predicate)));
         }
 
-        public static IAsyncObservable<TSource> TakeWhile<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<bool>> predicate)
+        public static IAsyncObservable<TSource> TakeWhile<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -38,7 +38,7 @@ namespace System.Reactive.Linq
             return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.TakeWhile(observer, predicate)));
         }
 
-        public static IAsyncObservable<TSource> TakeWhile<TSource>(this IAsyncObservable<TSource> source, Func<TSource, int, Task<bool>> predicate)
+        public static IAsyncObservable<TSource> TakeWhile<TSource>(this IAsyncObservable<TSource> source, Func<TSource, int, ValueTask<bool>> predicate)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -87,7 +87,7 @@ namespace System.Reactive.Linq
             );
         }
 
-        public static IAsyncObserver<TSource> TakeWhile<TSource>(IAsyncObserver<TSource> observer, Func<TSource, Task<bool>> predicate)
+        public static IAsyncObserver<TSource> TakeWhile<TSource>(IAsyncObserver<TSource> observer, Func<TSource, ValueTask<bool>> predicate)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -161,7 +161,7 @@ namespace System.Reactive.Linq
             );
         }
 
-        public static IAsyncObserver<TSource> TakeWhile<TSource>(IAsyncObserver<TSource> observer, Func<TSource, int, Task<bool>> predicate)
+        public static IAsyncObserver<TSource> TakeWhile<TSource>(IAsyncObserver<TSource> observer, Func<TSource, int, ValueTask<bool>> predicate)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Then.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Then.cs
@@ -21,7 +21,7 @@ namespace System.Reactive.Linq
             return new AsyncPattern<TSource>(source).Then(selector);
         }
 
-        public static AsyncPlan<TResult> Then<TSource, TResult>(this IAsyncObservable<TSource> source, Func<TSource, Task<TResult>> selector)
+        public static AsyncPlan<TResult> Then<TSource, TResult>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TResult>> selector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ToDictionary.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ToDictionary.cs
@@ -35,7 +35,7 @@ namespace System.Reactive.Linq
             return Create<IDictionary<TKey, TValue>>(observer => source.SubscribeSafeAsync(AsyncObserver.ToDictionary(observer, keySelector, valueSelector, comparer)));
         }
 
-        public static IAsyncObservable<IDictionary<TKey, TValue>> ToDictionary<TSource, TKey, TValue>(this IAsyncObservable<TSource> source, Func<TSource, Task<TKey>> keySelector, Func<TSource, Task<TValue>> valueSelector)
+        public static IAsyncObservable<IDictionary<TKey, TValue>> ToDictionary<TSource, TKey, TValue>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TValue>> valueSelector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -47,7 +47,7 @@ namespace System.Reactive.Linq
             return Create<IDictionary<TKey, TValue>>(observer => source.SubscribeSafeAsync(AsyncObserver.ToDictionary(observer, keySelector, valueSelector)));
         }
 
-        public static IAsyncObservable<IDictionary<TKey, TValue>> ToDictionary<TSource, TKey, TValue>(this IAsyncObservable<TSource> source, Func<TSource, Task<TKey>> keySelector, Func<TSource, Task<TValue>> valueSelector, IEqualityComparer<TKey> comparer)
+        public static IAsyncObservable<IDictionary<TKey, TValue>> ToDictionary<TSource, TKey, TValue>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TValue>> valueSelector, IEqualityComparer<TKey> comparer)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -103,7 +103,7 @@ namespace System.Reactive.Linq
             );
         }
 
-        public static IAsyncObserver<TSource> ToDictionary<TSource, TKey, TValue>(IAsyncObserver<IDictionary<TKey, TValue>> observer, Func<TSource, Task<TKey>> keySelector, Func<TSource, Task<TValue>> valueSelector)
+        public static IAsyncObserver<TSource> ToDictionary<TSource, TKey, TValue>(IAsyncObserver<IDictionary<TKey, TValue>> observer, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TValue>> valueSelector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -115,7 +115,7 @@ namespace System.Reactive.Linq
             return ToDictionary(observer, keySelector, valueSelector, EqualityComparer<TKey>.Default);
         }
 
-        public static IAsyncObserver<TSource> ToDictionary<TSource, TKey, TValue>(IAsyncObserver<IDictionary<TKey, TValue>> observer, Func<TSource, Task<TKey>> keySelector, Func<TSource, Task<TValue>> valueSelector, IEqualityComparer<TKey> comparer)
+        public static IAsyncObserver<TSource> ToDictionary<TSource, TKey, TValue>(IAsyncObserver<IDictionary<TKey, TValue>> observer, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TValue>> valueSelector, IEqualityComparer<TKey> comparer)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -138,7 +138,7 @@ namespace System.Reactive.Linq
 
                     return d;
                 },
-                d => Task.FromResult<IDictionary<TKey, TValue>>(d)
+                d => new ValueTask<IDictionary<TKey, TValue>>(d)
             );
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ToLookup.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ToLookup.cs
@@ -36,7 +36,7 @@ namespace System.Reactive.Linq
             return Create<ILookup<TKey, TValue>>(observer => source.SubscribeSafeAsync(AsyncObserver.ToLookup(observer, keySelector, valueSelector, comparer)));
         }
 
-        public static IAsyncObservable<ILookup<TKey, TValue>> ToLookup<TSource, TKey, TValue>(this IAsyncObservable<TSource> source, Func<TSource, Task<TKey>> keySelector, Func<TSource, Task<TValue>> valueSelector)
+        public static IAsyncObservable<ILookup<TKey, TValue>> ToLookup<TSource, TKey, TValue>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TValue>> valueSelector)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -48,7 +48,7 @@ namespace System.Reactive.Linq
             return Create<ILookup<TKey, TValue>>(observer => source.SubscribeSafeAsync(AsyncObserver.ToLookup(observer, keySelector, valueSelector)));
         }
 
-        public static IAsyncObservable<ILookup<TKey, TValue>> ToLookup<TSource, TKey, TValue>(this IAsyncObservable<TSource> source, Func<TSource, Task<TKey>> keySelector, Func<TSource, Task<TValue>> valueSelector, IEqualityComparer<TKey> comparer)
+        public static IAsyncObservable<ILookup<TKey, TValue>> ToLookup<TSource, TKey, TValue>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TValue>> valueSelector, IEqualityComparer<TKey> comparer)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -104,7 +104,7 @@ namespace System.Reactive.Linq
             );
         }
 
-        public static IAsyncObserver<TSource> ToLookup<TSource, TKey, TValue>(IAsyncObserver<ILookup<TKey, TValue>> observer, Func<TSource, Task<TKey>> keySelector, Func<TSource, Task<TValue>> valueSelector)
+        public static IAsyncObserver<TSource> ToLookup<TSource, TKey, TValue>(IAsyncObserver<ILookup<TKey, TValue>> observer, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TValue>> valueSelector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -116,7 +116,7 @@ namespace System.Reactive.Linq
             return ToLookup(observer, keySelector, valueSelector, EqualityComparer<TKey>.Default);
         }
 
-        public static IAsyncObserver<TSource> ToLookup<TSource, TKey, TValue>(IAsyncObserver<ILookup<TKey, TValue>> observer, Func<TSource, Task<TKey>> keySelector, Func<TSource, Task<TValue>> valueSelector, IEqualityComparer<TKey> comparer)
+        public static IAsyncObserver<TSource> ToLookup<TSource, TKey, TValue>(IAsyncObserver<ILookup<TKey, TValue>> observer, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TValue>> valueSelector, IEqualityComparer<TKey> comparer)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -139,7 +139,7 @@ namespace System.Reactive.Linq
 
                     return d;
                 },
-                d => Task.FromResult<ILookup<TKey, TValue>>(d)
+                d => new ValueTask<ILookup<TKey, TValue>>(d)
             );
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Using.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Using.cs
@@ -56,7 +56,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> UsingAsync<TResult, TResource>(Func<Task<TResource>> resourceFactory, Func<TResource, Task<IAsyncObservable<TResult>>> observableFactory)
+        public static IAsyncObservable<TResult> UsingAsync<TResult, TResource>(Func<ValueTask<TResource>> resourceFactory, Func<TResource, ValueTask<IAsyncObservable<TResult>>> observableFactory)
             where TResource : IDisposable
         {
             if (resourceFactory == null)
@@ -158,7 +158,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> UsingAwaitAsync<TResult, TResource>(Func<Task<TResource>> resourceFactory, Func<TResource, Task<IAsyncObservable<TResult>>> observableFactory)
+        public static IAsyncObservable<TResult> UsingAwaitAsync<TResult, TResource>(Func<ValueTask<TResource>> resourceFactory, Func<TResource, ValueTask<IAsyncObservable<TResult>>> observableFactory)
             where TResource : IAsyncDisposable
         {
             if (resourceFactory == null)

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Where.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Where.cs
@@ -18,7 +18,7 @@ namespace System.Reactive.Linq
             return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.Where(observer, predicate)));
         }
 
-        public static IAsyncObservable<TSource> Where<TSource>(this IAsyncObservable<TSource> source, Func<TSource, Task<bool>> predicate)
+        public static IAsyncObservable<TSource> Where<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -38,7 +38,7 @@ namespace System.Reactive.Linq
             return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.Where(observer, predicate)));
         }
 
-        public static IAsyncObservable<TSource> Where<TSource>(this IAsyncObservable<TSource> source, Func<TSource, int, Task<bool>> predicate)
+        public static IAsyncObservable<TSource> Where<TSource>(this IAsyncObservable<TSource> source, Func<TSource, int, ValueTask<bool>> predicate)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -83,7 +83,7 @@ namespace System.Reactive.Linq
             );
         }
 
-        public static IAsyncObserver<TSource> Where<TSource>(IAsyncObserver<TSource> observer, Func<TSource, Task<bool>> predicate)
+        public static IAsyncObserver<TSource> Where<TSource>(IAsyncObserver<TSource> observer, Func<TSource, ValueTask<bool>> predicate)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -149,7 +149,7 @@ namespace System.Reactive.Linq
             );
         }
 
-        public static IAsyncObserver<TSource> Where<TSource>(IAsyncObserver<TSource> observer, Func<TSource, int, Task<bool>> predicate)
+        public static IAsyncObserver<TSource> Where<TSource>(IAsyncObserver<TSource> observer, Func<TSource, int, ValueTask<bool>> predicate)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/While.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/While.cs
@@ -64,7 +64,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TSource> While<TSource>(Func<Task<bool>> condition, IAsyncObservable<TSource> source)
+        public static IAsyncObservable<TSource> While<TSource>(Func<ValueTask<bool>> condition, IAsyncObservable<TSource> source)
         {
             if (condition == null)
                 throw new ArgumentNullException(nameof(condition));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Window.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Window.cs
@@ -168,7 +168,7 @@ namespace System.Reactive.Linq
             return subscription;
         }
 
-        private static async ValueTask<IAsyncDisposable> WindowAsyncCore<TSource>(IAsyncObservable<TSource> source, IAsyncObserver<IAsyncObservable<TSource>> observer, Func<IAsyncObserver<IAsyncObservable<TSource>>, IAsyncDisposable, Task<(IAsyncObserver<TSource>, IAsyncDisposable)>> createObserverAsync)
+        private static async ValueTask<IAsyncDisposable> WindowAsyncCore<TSource>(IAsyncObservable<TSource> source, IAsyncObserver<IAsyncObservable<TSource>> observer, Func<IAsyncObserver<IAsyncObservable<TSource>>, IAsyncDisposable, ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)>> createObserverAsync)
         {
             var d = new SingleAssignmentAsyncDisposable();
 
@@ -253,9 +253,9 @@ namespace System.Reactive.Linq
                 );
         }
 
-        public static Task<(IAsyncObserver<TSource>, IAsyncDisposable)> Window<TSource>(IAsyncObserver<IAsyncObservable<TSource>> observer, IAsyncDisposable subscription, TimeSpan timeSpan) => Window(observer, subscription, timeSpan, TaskPoolAsyncScheduler.Default);
+        public static ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)> Window<TSource>(IAsyncObserver<IAsyncObservable<TSource>> observer, IAsyncDisposable subscription, TimeSpan timeSpan) => Window(observer, subscription, timeSpan, TaskPoolAsyncScheduler.Default);
 
-        public static Task<(IAsyncObserver<TSource>, IAsyncDisposable)> Window<TSource>(IAsyncObserver<IAsyncObservable<TSource>> observer, IAsyncDisposable subscription, TimeSpan timeSpan, IAsyncScheduler scheduler)
+        public static ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)> Window<TSource>(IAsyncObserver<IAsyncObservable<TSource>> observer, IAsyncDisposable subscription, TimeSpan timeSpan, IAsyncScheduler scheduler)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -281,7 +281,7 @@ namespace System.Reactive.Linq
                 await observer.OnNextAsync(wrapper).ConfigureAwait(false);
             }
 
-            async Task<(IAsyncObserver<TSource>, IAsyncDisposable)> CoreAsync()
+            async ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)> CoreAsync()
             {
                 await d.AddAsync(subscription).ConfigureAwait(false);
 
@@ -337,9 +337,9 @@ namespace System.Reactive.Linq
             return CoreAsync();
         }
 
-        public static Task<(IAsyncObserver<TSource>, IAsyncDisposable)> Window<TSource>(IAsyncObserver<IAsyncObservable<TSource>> observer, IAsyncDisposable subscription, TimeSpan timeSpan, TimeSpan timeShift) => Window(observer, subscription, timeSpan, timeShift, TaskPoolAsyncScheduler.Default);
+        public static ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)> Window<TSource>(IAsyncObserver<IAsyncObservable<TSource>> observer, IAsyncDisposable subscription, TimeSpan timeSpan, TimeSpan timeShift) => Window(observer, subscription, timeSpan, timeShift, TaskPoolAsyncScheduler.Default);
 
-        public static Task<(IAsyncObserver<TSource>, IAsyncDisposable)> Window<TSource>(IAsyncObserver<IAsyncObservable<TSource>> observer, IAsyncDisposable subscription, TimeSpan timeSpan, TimeSpan timeShift, IAsyncScheduler scheduler)
+        public static ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)> Window<TSource>(IAsyncObserver<IAsyncObservable<TSource>> observer, IAsyncDisposable subscription, TimeSpan timeSpan, TimeSpan timeShift, IAsyncScheduler scheduler)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -440,7 +440,7 @@ namespace System.Reactive.Linq
                 await inner.AssignAsync(task).ConfigureAwait(false);
             }
 
-            async Task<(IAsyncObserver<TSource>, IAsyncDisposable)> CoreAsync()
+            async ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)> CoreAsync()
             {
                 await d.AddAsync(subscription).ConfigureAwait(false);
                 await d.AddAsync(timer).ConfigureAwait(false);
@@ -493,9 +493,9 @@ namespace System.Reactive.Linq
             return CoreAsync();
         }
 
-        public static Task<(IAsyncObserver<TSource>, IAsyncDisposable)> Window<TSource>(IAsyncObserver<IAsyncObservable<TSource>> observer, IAsyncDisposable subscription, TimeSpan timeSpan, int count) => Window(observer, subscription, timeSpan, count, TaskPoolAsyncScheduler.Default);
+        public static ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)> Window<TSource>(IAsyncObserver<IAsyncObservable<TSource>> observer, IAsyncDisposable subscription, TimeSpan timeSpan, int count) => Window(observer, subscription, timeSpan, count, TaskPoolAsyncScheduler.Default);
 
-        public static Task<(IAsyncObserver<TSource>, IAsyncDisposable)> Window<TSource>(IAsyncObserver<IAsyncObservable<TSource>> observer, IAsyncDisposable subscription, TimeSpan timeSpan, int count, IAsyncScheduler scheduler)
+        public static ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)> Window<TSource>(IAsyncObserver<IAsyncObservable<TSource>> observer, IAsyncDisposable subscription, TimeSpan timeSpan, int count, IAsyncScheduler scheduler)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -553,7 +553,7 @@ namespace System.Reactive.Linq
                 return window;
             }
 
-            async Task<(IAsyncObserver<TSource>, IAsyncDisposable)> CoreAsync()
+            async ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)> CoreAsync()
             {
                 await d.AddAsync(subscription).ConfigureAwait(false);
                 await d.AddAsync(timer).ConfigureAwait(false);
@@ -612,7 +612,7 @@ namespace System.Reactive.Linq
             return CoreAsync();
         }
 
-        public static Task<(IAsyncObserver<TSource>, IAsyncObserver<TWindowBoundary>, IAsyncDisposable)> Window<TSource, TWindowBoundary>(IAsyncObserver<IAsyncObservable<TSource>> observer, IAsyncDisposable subscription)
+        public static ValueTask<(IAsyncObserver<TSource>, IAsyncObserver<TWindowBoundary>, IAsyncDisposable)> Window<TSource, TWindowBoundary>(IAsyncObserver<IAsyncObservable<TSource>> observer, IAsyncDisposable subscription)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -631,7 +631,7 @@ namespace System.Reactive.Linq
                 await observer.OnNextAsync(wrapper).ConfigureAwait(false);
             }
 
-            async Task<(IAsyncObserver<TSource>, IAsyncObserver<TWindowBoundary>, IAsyncDisposable)> CoreAsync()
+            async ValueTask<(IAsyncObserver<TSource>, IAsyncObserver<TWindowBoundary>, IAsyncDisposable)> CoreAsync()
             {
                 await CreateWindowAsync().ConfigureAwait(false);
 
@@ -695,7 +695,7 @@ namespace System.Reactive.Linq
             return CoreAsync();
         }
 
-        public static Task<(IAsyncObserver<TSource>, IAsyncDisposable, IAsyncDisposable)> Window<TSource, TWindowClosing>(IAsyncObserver<IAsyncObservable<TSource>> observer, Func<IAsyncObservable<TWindowClosing>> windowClosingSelector, IAsyncDisposable subscription)
+        public static ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable, IAsyncDisposable)> Window<TSource, TWindowClosing>(IAsyncObserver<IAsyncObservable<TSource>> observer, Func<IAsyncObservable<TWindowClosing>> windowClosingSelector, IAsyncDisposable subscription)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -772,7 +772,7 @@ namespace System.Reactive.Linq
                 await closingSubscription.AssignAsync(closingSubscriptionInner).ConfigureAwait(false);
             }
 
-            async Task<(IAsyncObserver<TSource>, IAsyncDisposable, IAsyncDisposable)> CoreAsync()
+            async ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable, IAsyncDisposable)> CoreAsync()
             {
                 await CreateWindowAsync().ConfigureAwait(false);
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/WithLatestFrom.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/WithLatestFrom.cs
@@ -52,7 +52,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> WithLatestFrom<TFirst, TSecond, TResult>(this IAsyncObservable<TFirst> first, IAsyncObservable<TSecond> second, Func<TFirst, TSecond, Task<TResult>> resultSelector)
+        public static IAsyncObservable<TResult> WithLatestFrom<TFirst, TSecond, TResult>(this IAsyncObservable<TFirst> first, IAsyncObservable<TSecond> second, Func<TFirst, TSecond, ValueTask<TResult>> resultSelector)
         {
             if (first == null)
                 throw new ArgumentNullException(nameof(first));
@@ -84,10 +84,10 @@ namespace System.Reactive.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            return WithLatestFrom<TFirst, TSecond, TResult>(observer, (x, y) => Task.FromResult(resultSelector(x, y)));
+            return WithLatestFrom<TFirst, TSecond, TResult>(observer, (x, y) => new ValueTask<TResult>(resultSelector(x, y)));
         }
 
-        public static (IAsyncObserver<TFirst>, IAsyncObserver<TSecond>) WithLatestFrom<TFirst, TSecond, TResult>(IAsyncObserver<TResult> observer, Func<TFirst, TSecond, Task<TResult>> resultSelector)
+        public static (IAsyncObserver<TFirst>, IAsyncObserver<TSecond>) WithLatestFrom<TFirst, TSecond, TResult>(IAsyncObserver<TResult> observer, Func<TFirst, TSecond, ValueTask<TResult>> resultSelector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Zip.Generated.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Zip.Generated.cs
@@ -57,7 +57,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> Zip<T1, T2, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, Func<T1, T2, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> Zip<T1, T2, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, Func<T1, T2, ValueTask<TResult>> selector)
         {
             if (source1 == null)
                 throw new ArgumentNullException(nameof(source1));
@@ -133,7 +133,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> Zip<T1, T2, T3, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, Func<T1, T2, T3, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> Zip<T1, T2, T3, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, Func<T1, T2, T3, ValueTask<TResult>> selector)
         {
             if (source1 == null)
                 throw new ArgumentNullException(nameof(source1));
@@ -218,7 +218,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> Zip<T1, T2, T3, T4, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, Func<T1, T2, T3, T4, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> Zip<T1, T2, T3, T4, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, Func<T1, T2, T3, T4, ValueTask<TResult>> selector)
         {
             if (source1 == null)
                 throw new ArgumentNullException(nameof(source1));
@@ -312,7 +312,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> Zip<T1, T2, T3, T4, T5, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, Func<T1, T2, T3, T4, T5, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> Zip<T1, T2, T3, T4, T5, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, Func<T1, T2, T3, T4, T5, ValueTask<TResult>> selector)
         {
             if (source1 == null)
                 throw new ArgumentNullException(nameof(source1));
@@ -415,7 +415,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> Zip<T1, T2, T3, T4, T5, T6, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, Func<T1, T2, T3, T4, T5, T6, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> Zip<T1, T2, T3, T4, T5, T6, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, Func<T1, T2, T3, T4, T5, T6, ValueTask<TResult>> selector)
         {
             if (source1 == null)
                 throw new ArgumentNullException(nameof(source1));
@@ -527,7 +527,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> Zip<T1, T2, T3, T4, T5, T6, T7, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, Func<T1, T2, T3, T4, T5, T6, T7, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> Zip<T1, T2, T3, T4, T5, T6, T7, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, Func<T1, T2, T3, T4, T5, T6, T7, ValueTask<TResult>> selector)
         {
             if (source1 == null)
                 throw new ArgumentNullException(nameof(source1));
@@ -648,7 +648,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> Zip<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, Func<T1, T2, T3, T4, T5, T6, T7, T8, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> Zip<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, Func<T1, T2, T3, T4, T5, T6, T7, T8, ValueTask<TResult>> selector)
         {
             if (source1 == null)
                 throw new ArgumentNullException(nameof(source1));
@@ -778,7 +778,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, IAsyncObservable<T9> source9, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, IAsyncObservable<T9> source9, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, ValueTask<TResult>> selector)
         {
             if (source1 == null)
                 throw new ArgumentNullException(nameof(source1));
@@ -917,7 +917,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, IAsyncObservable<T9> source9, IAsyncObservable<T10> source10, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, IAsyncObservable<T9> source9, IAsyncObservable<T10> source10, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, ValueTask<TResult>> selector)
         {
             if (source1 == null)
                 throw new ArgumentNullException(nameof(source1));
@@ -1065,7 +1065,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, IAsyncObservable<T9> source9, IAsyncObservable<T10> source10, IAsyncObservable<T11> source11, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, IAsyncObservable<T9> source9, IAsyncObservable<T10> source10, IAsyncObservable<T11> source11, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, ValueTask<TResult>> selector)
         {
             if (source1 == null)
                 throw new ArgumentNullException(nameof(source1));
@@ -1222,7 +1222,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, IAsyncObservable<T9> source9, IAsyncObservable<T10> source10, IAsyncObservable<T11> source11, IAsyncObservable<T12> source12, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, IAsyncObservable<T9> source9, IAsyncObservable<T10> source10, IAsyncObservable<T11> source11, IAsyncObservable<T12> source12, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, ValueTask<TResult>> selector)
         {
             if (source1 == null)
                 throw new ArgumentNullException(nameof(source1));
@@ -1388,7 +1388,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, IAsyncObservable<T9> source9, IAsyncObservable<T10> source10, IAsyncObservable<T11> source11, IAsyncObservable<T12> source12, IAsyncObservable<T13> source13, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, IAsyncObservable<T9> source9, IAsyncObservable<T10> source10, IAsyncObservable<T11> source11, IAsyncObservable<T12> source12, IAsyncObservable<T13> source13, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, ValueTask<TResult>> selector)
         {
             if (source1 == null)
                 throw new ArgumentNullException(nameof(source1));
@@ -1563,7 +1563,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, IAsyncObservable<T9> source9, IAsyncObservable<T10> source10, IAsyncObservable<T11> source11, IAsyncObservable<T12> source12, IAsyncObservable<T13> source13, IAsyncObservable<T14> source14, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, IAsyncObservable<T9> source9, IAsyncObservable<T10> source10, IAsyncObservable<T11> source11, IAsyncObservable<T12> source12, IAsyncObservable<T13> source13, IAsyncObservable<T14> source14, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, ValueTask<TResult>> selector)
         {
             if (source1 == null)
                 throw new ArgumentNullException(nameof(source1));
@@ -1747,7 +1747,7 @@ namespace System.Reactive.Linq
             });
         }
 
-        public static IAsyncObservable<TResult> Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, IAsyncObservable<T9> source9, IAsyncObservable<T10> source10, IAsyncObservable<T11> source11, IAsyncObservable<T12> source12, IAsyncObservable<T13> source13, IAsyncObservable<T14> source14, IAsyncObservable<T15> source15, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(this IAsyncObservable<T1> source1, IAsyncObservable<T2> source2, IAsyncObservable<T3> source3, IAsyncObservable<T4> source4, IAsyncObservable<T5> source5, IAsyncObservable<T6> source6, IAsyncObservable<T7> source7, IAsyncObservable<T8> source8, IAsyncObservable<T9> source9, IAsyncObservable<T10> source10, IAsyncObservable<T11> source11, IAsyncObservable<T12> source12, IAsyncObservable<T13> source13, IAsyncObservable<T14> source14, IAsyncObservable<T15> source15, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, ValueTask<TResult>> selector)
         {
             if (source1 == null)
                 throw new ArgumentNullException(nameof(source1));
@@ -1903,10 +1903,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Zip<T1, T2, TResult>(observer, (x1, x2) => Task.FromResult(selector(x1, x2)));
+            return Zip<T1, T2, TResult>(observer, (x1, x2) => new ValueTask<TResult>(selector(x1, x2)));
         }
 
-        public static (IAsyncObserver<T1>, IAsyncObserver<T2>) Zip<T1, T2, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, Task<TResult>> selector)
+        public static (IAsyncObserver<T1>, IAsyncObserver<T2>) Zip<T1, T2, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -2093,10 +2093,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Zip<T1, T2, T3, TResult>(observer, (x1, x2, x3) => Task.FromResult(selector(x1, x2, x3)));
+            return Zip<T1, T2, T3, TResult>(observer, (x1, x2, x3) => new ValueTask<TResult>(selector(x1, x2, x3)));
         }
 
-        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>) Zip<T1, T2, T3, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, Task<TResult>> selector)
+        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>) Zip<T1, T2, T3, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -2287,10 +2287,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Zip<T1, T2, T3, T4, TResult>(observer, (x1, x2, x3, x4) => Task.FromResult(selector(x1, x2, x3, x4)));
+            return Zip<T1, T2, T3, T4, TResult>(observer, (x1, x2, x3, x4) => new ValueTask<TResult>(selector(x1, x2, x3, x4)));
         }
 
-        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>) Zip<T1, T2, T3, T4, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, Task<TResult>> selector)
+        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>) Zip<T1, T2, T3, T4, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -2485,10 +2485,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Zip<T1, T2, T3, T4, T5, TResult>(observer, (x1, x2, x3, x4, x5) => Task.FromResult(selector(x1, x2, x3, x4, x5)));
+            return Zip<T1, T2, T3, T4, T5, TResult>(observer, (x1, x2, x3, x4, x5) => new ValueTask<TResult>(selector(x1, x2, x3, x4, x5)));
         }
 
-        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>) Zip<T1, T2, T3, T4, T5, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, Task<TResult>> selector)
+        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>) Zip<T1, T2, T3, T4, T5, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -2687,10 +2687,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Zip<T1, T2, T3, T4, T5, T6, TResult>(observer, (x1, x2, x3, x4, x5, x6) => Task.FromResult(selector(x1, x2, x3, x4, x5, x6)));
+            return Zip<T1, T2, T3, T4, T5, T6, TResult>(observer, (x1, x2, x3, x4, x5, x6) => new ValueTask<TResult>(selector(x1, x2, x3, x4, x5, x6)));
         }
 
-        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>) Zip<T1, T2, T3, T4, T5, T6, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, Task<TResult>> selector)
+        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>) Zip<T1, T2, T3, T4, T5, T6, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -2893,10 +2893,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Zip<T1, T2, T3, T4, T5, T6, T7, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7) => Task.FromResult(selector(x1, x2, x3, x4, x5, x6, x7)));
+            return Zip<T1, T2, T3, T4, T5, T6, T7, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7) => new ValueTask<TResult>(selector(x1, x2, x3, x4, x5, x6, x7)));
         }
 
-        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>) Zip<T1, T2, T3, T4, T5, T6, T7, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, Task<TResult>> selector)
+        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>) Zip<T1, T2, T3, T4, T5, T6, T7, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -3103,10 +3103,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Zip<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8) => Task.FromResult(selector(x1, x2, x3, x4, x5, x6, x7, x8)));
+            return Zip<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8) => new ValueTask<TResult>(selector(x1, x2, x3, x4, x5, x6, x7, x8)));
         }
 
-        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>) Zip<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, Task<TResult>> selector)
+        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>) Zip<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -3317,10 +3317,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8, x9) => Task.FromResult(selector(x1, x2, x3, x4, x5, x6, x7, x8, x9)));
+            return Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8, x9) => new ValueTask<TResult>(selector(x1, x2, x3, x4, x5, x6, x7, x8, x9)));
         }
 
-        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>, IAsyncObserver<T9>) Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, Task<TResult>> selector)
+        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>, IAsyncObserver<T9>) Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -3535,10 +3535,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10) => Task.FromResult(selector(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10)));
+            return Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10) => new ValueTask<TResult>(selector(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10)));
         }
 
-        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>, IAsyncObserver<T9>, IAsyncObserver<T10>) Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Task<TResult>> selector)
+        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>, IAsyncObserver<T9>, IAsyncObserver<T10>) Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -3757,10 +3757,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11) => Task.FromResult(selector(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11)));
+            return Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11) => new ValueTask<TResult>(selector(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11)));
         }
 
-        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>, IAsyncObserver<T9>, IAsyncObserver<T10>, IAsyncObserver<T11>) Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, Task<TResult>> selector)
+        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>, IAsyncObserver<T9>, IAsyncObserver<T10>, IAsyncObserver<T11>) Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -3983,10 +3983,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12) => Task.FromResult(selector(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12)));
+            return Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12) => new ValueTask<TResult>(selector(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12)));
         }
 
-        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>, IAsyncObserver<T9>, IAsyncObserver<T10>, IAsyncObserver<T11>, IAsyncObserver<T12>) Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, Task<TResult>> selector)
+        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>, IAsyncObserver<T9>, IAsyncObserver<T10>, IAsyncObserver<T11>, IAsyncObserver<T12>) Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -4213,10 +4213,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13) => Task.FromResult(selector(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13)));
+            return Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13) => new ValueTask<TResult>(selector(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13)));
         }
 
-        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>, IAsyncObserver<T9>, IAsyncObserver<T10>, IAsyncObserver<T11>, IAsyncObserver<T12>, IAsyncObserver<T13>) Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, Task<TResult>> selector)
+        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>, IAsyncObserver<T9>, IAsyncObserver<T10>, IAsyncObserver<T11>, IAsyncObserver<T12>, IAsyncObserver<T13>) Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -4447,10 +4447,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14) => Task.FromResult(selector(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14)));
+            return Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14) => new ValueTask<TResult>(selector(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14)));
         }
 
-        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>, IAsyncObserver<T9>, IAsyncObserver<T10>, IAsyncObserver<T11>, IAsyncObserver<T12>, IAsyncObserver<T13>, IAsyncObserver<T14>) Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, Task<TResult>> selector)
+        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>, IAsyncObserver<T9>, IAsyncObserver<T10>, IAsyncObserver<T11>, IAsyncObserver<T12>, IAsyncObserver<T13>, IAsyncObserver<T14>) Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
@@ -4685,10 +4685,10 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) => Task.FromResult(selector(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15)));
+            return Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(observer, (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) => new ValueTask<TResult>(selector(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15)));
         }
 
-        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>, IAsyncObserver<T9>, IAsyncObserver<T10>, IAsyncObserver<T11>, IAsyncObserver<T12>, IAsyncObserver<T13>, IAsyncObserver<T14>, IAsyncObserver<T15>) Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, Task<TResult>> selector)
+        public static (IAsyncObserver<T1>, IAsyncObserver<T2>, IAsyncObserver<T3>, IAsyncObserver<T4>, IAsyncObserver<T5>, IAsyncObserver<T6>, IAsyncObserver<T7>, IAsyncObserver<T8>, IAsyncObserver<T9>, IAsyncObserver<T10>, IAsyncObserver<T11>, IAsyncObserver<T12>, IAsyncObserver<T13>, IAsyncObserver<T14>, IAsyncObserver<T15>) Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(IAsyncObserver<TResult> observer, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Zip.Generated.tt
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Zip.Generated.tt
@@ -94,7 +94,7 @@ for (var j = 1; j <= i; j++)
             });
         }
 
-        public static IAsyncObservable<TResult> Zip<<#=genPars#>>(this <#=args#>, Func<<#=genArgs#>, Task<TResult>> selector)
+        public static IAsyncObservable<TResult> Zip<<#=genPars#>>(this <#=args#>, Func<<#=genArgs#>, ValueTask<TResult>> selector)
         {
 <#
 for (var j = 1; j <= i; j++)
@@ -248,10 +248,10 @@ for (var j = 1; j <= i; j++)
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Zip<<#=genPars#>>(observer, (<#=string.Join(", ", Enumerable.Range(1, i).Select(j => "x" + j))#>) => Task.FromResult(selector(<#=string.Join(", ", Enumerable.Range(1, i).Select(j => "x" + j))#>)));
+            return Zip<<#=genPars#>>(observer, (<#=string.Join(", ", Enumerable.Range(1, i).Select(j => "x" + j))#>) => new ValueTask<TResult>(selector(<#=string.Join(", ", Enumerable.Range(1, i).Select(j => "x" + j))#>)));
         }
 
-        public static <#=res#> Zip<<#=genPars#>>(IAsyncObserver<TResult> observer, Func<<#=genArgs#>, Task<TResult>> selector)
+        public static <#=res#> Zip<<#=genPars#>>(IAsyncObserver<TResult> observer, Func<<#=genArgs#>, ValueTask<TResult>> selector)
         {
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));


### PR DESCRIPTION
Further alignment with operator surface in `System.Linq.Async`. Next steps are support for deep cancellation and disambiguation of overloads with the `Await` suffixes (for better or for worse, see discussion on `System.Linq.Async` about the ambiguities that arise if we don't follow this verbose naming pattern).