### PR TITLE
Remove two more uses of AsyncEnumerable.Create.

### DIFF
--- a/Ix.NET/Source/System.Interactive.Async/System/Linq/Operators/Amb.cs
+++ b/Ix.NET/Source/System.Interactive.Async/System/Linq/Operators/Amb.cs
@@ -160,9 +160,9 @@ namespace System.Linq
             if (sources == null)
                 throw Error.ArgumentNull(nameof(sources));
 
-            return AsyncEnumerable.Create(Core);
+            return Core(sources);
 
-            async IAsyncEnumerator<TSource> Core(CancellationToken cancellationToken)
+            static async IAsyncEnumerable<TSource> Core(IAsyncEnumerable<TSource>[] sources, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
             {
                 //
                 // REVIEW: See remarks on binary overload for changes compared to the original.


### PR DESCRIPTION
Removes the last two uses of `Create` in favor of using iterators with cancellation support. Avoids delegate and anonymous enumerable object allocation.