### PR TITLE
Non-empty stack traces for operator exceptions.

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Aggregate.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Aggregate.cs
@@ -62,7 +62,14 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (!_hasAccumulation)
                 {
-                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    try
+                    {
+                        throw new InvalidOperationException(Strings_Linq.NO_ELEMENTS);
+                    }
+                    catch (Exception e)
+                    {
+                        ForwardOnError(e);
+                    }
                 }
                 else
                 {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Average.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Average.cs
@@ -54,7 +54,14 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 else
                 {
-                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    try
+                    {
+                        throw new InvalidOperationException(Strings_Linq.NO_ELEMENTS);
+                    }
+                    catch (Exception e)
+                    {
+                        ForwardOnError(e);
+                    }
                 }
             }
         }
@@ -110,7 +117,14 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 else
                 {
-                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    try
+                    {
+                        throw new InvalidOperationException(Strings_Linq.NO_ELEMENTS);
+                    }
+                    catch (Exception e)
+                    {
+                        ForwardOnError(e);
+                    }
                 }
             }
         }
@@ -166,7 +180,14 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 else
                 {
-                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    try
+                    {
+                        throw new InvalidOperationException(Strings_Linq.NO_ELEMENTS);
+                    }
+                    catch (Exception e)
+                    {
+                        ForwardOnError(e);
+                    }
                 }
             }
         }
@@ -222,7 +243,14 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 else
                 {
-                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    try
+                    {
+                        throw new InvalidOperationException(Strings_Linq.NO_ELEMENTS);
+                    }
+                    catch (Exception e)
+                    {
+                        ForwardOnError(e);
+                    }
                 }
             }
         }
@@ -278,7 +306,14 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
                 else
                 {
-                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    try
+                    {
+                        throw new InvalidOperationException(Strings_Linq.NO_ELEMENTS);
+                    }
+                    catch (Exception e)
+                    {
+                        ForwardOnError(e);
+                    }
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/ElementAt.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/ElementAt.cs
@@ -44,7 +44,14 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (_i >= 0)
                 {
-                    ForwardOnError(new ArgumentOutOfRangeException("index"));
+                    try
+                    {
+                        throw new ArgumentOutOfRangeException("index");
+                    }
+                    catch (Exception e)
+                    {
+                        ForwardOnError(e);
+                    }
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/FirstAsync.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/FirstAsync.cs
@@ -39,7 +39,14 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (!_found)
                     {
-                        ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                        try
+                        {
+                            throw new InvalidOperationException(Strings_Linq.NO_ELEMENTS);
+                        }
+                        catch (Exception e)
+                        {
+                            ForwardOnError(e);
+                        }
                     }
                 }
             }
@@ -97,7 +104,14 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (!_found)
                     {
-                        ForwardOnError(new InvalidOperationException(Strings_Linq.NO_MATCHING_ELEMENTS));
+                        try
+                        {
+                            throw new InvalidOperationException(Strings_Linq.NO_MATCHING_ELEMENTS);
+                        }
+                        catch (Exception e)
+                        {
+                            ForwardOnError(e);
+                        }
                     }
                 }
             }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/LastAsync.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/LastAsync.cs
@@ -46,7 +46,14 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (!_seenValue)
                     {
-                        ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                        try
+                        {
+                            throw new InvalidOperationException(Strings_Linq.NO_ELEMENTS);
+                        }
+                        catch (Exception e)
+                        {
+                            ForwardOnError(e);
+                        }
                     }
                     else
                     {
@@ -118,7 +125,14 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (!_seenValue)
                     {
-                        ForwardOnError(new InvalidOperationException(Strings_Linq.NO_MATCHING_ELEMENTS));
+                        try
+                        {
+                            throw new InvalidOperationException(Strings_Linq.NO_MATCHING_ELEMENTS);
+                        }
+                        catch (Exception e)
+                        {
+                            ForwardOnError(e);
+                        }
                     }
                     else
                     {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Max.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Max.cs
@@ -73,7 +73,14 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (!_hasValue)
                 {
-                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    try
+                    {
+                        throw new InvalidOperationException(Strings_Linq.NO_ELEMENTS);
+                    }
+                    catch (Exception e)
+                    {
+                        ForwardOnError(e);
+                    }
                 }
                 else
                 {
@@ -177,7 +184,14 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (!_hasValue)
                 {
-                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    try
+                    {
+                        throw new InvalidOperationException(Strings_Linq.NO_ELEMENTS);
+                    }
+                    catch (Exception e)
+                    {
+                        ForwardOnError(e);
+                    }
                 }
                 else
                 {
@@ -231,7 +245,14 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (!_hasValue)
                 {
-                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    try
+                    {
+                        throw new InvalidOperationException(Strings_Linq.NO_ELEMENTS);
+                    }
+                    catch (Exception e)
+                    {
+                        ForwardOnError(e);
+                    }
                 }
                 else
                 {
@@ -285,7 +306,14 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (!_hasValue)
                 {
-                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    try
+                    {
+                        throw new InvalidOperationException(Strings_Linq.NO_ELEMENTS);
+                    }
+                    catch (Exception e)
+                    {
+                        ForwardOnError(e);
+                    }
                 }
                 else
                 {
@@ -339,7 +367,14 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (!_hasValue)
                 {
-                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    try
+                    {
+                        throw new InvalidOperationException(Strings_Linq.NO_ELEMENTS);
+                    }
+                    catch (Exception e)
+                    {
+                        ForwardOnError(e);
+                    }
                 }
                 else
                 {
@@ -393,7 +428,14 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (!_hasValue)
                 {
-                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    try
+                    {
+                        throw new InvalidOperationException(Strings_Linq.NO_ELEMENTS);
+                    }
+                    catch (Exception e)
+                    {
+                        ForwardOnError(e);
+                    }
                 }
                 else
                 {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Min.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Min.cs
@@ -78,7 +78,14 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (!_hasValue)
                 {
-                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    try
+                    {
+                        throw new InvalidOperationException(Strings_Linq.NO_ELEMENTS);
+                    }
+                    catch (Exception e)
+                    {
+                        ForwardOnError(e);
+                    }
                 }
                 else
                 {
@@ -177,7 +184,14 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (!_hasValue)
                 {
-                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    try
+                    {
+                        throw new InvalidOperationException(Strings_Linq.NO_ELEMENTS);
+                    }
+                    catch (Exception e)
+                    {
+                        ForwardOnError(e);
+                    }
                 }
                 else
                 {
@@ -231,7 +245,14 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (!_hasValue)
                 {
-                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    try
+                    {
+                        throw new InvalidOperationException(Strings_Linq.NO_ELEMENTS);
+                    }
+                    catch (Exception e)
+                    {
+                        ForwardOnError(e);
+                    }
                 }
                 else
                 {
@@ -285,7 +306,14 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (!_hasValue)
                 {
-                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    try
+                    {
+                        throw new InvalidOperationException(Strings_Linq.NO_ELEMENTS);
+                    }
+                    catch (Exception e)
+                    {
+                        ForwardOnError(e);
+                    }
                 }
                 else
                 {
@@ -339,7 +367,14 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (!_hasValue)
                 {
-                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    try
+                    {
+                        throw new InvalidOperationException(Strings_Linq.NO_ELEMENTS);
+                    }
+                    catch (Exception e)
+                    {
+                        ForwardOnError(e);
+                    }
                 }
                 else
                 {
@@ -393,7 +428,14 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (!_hasValue)
                 {
-                    ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    try
+                    {
+                        throw new InvalidOperationException(Strings_Linq.NO_ELEMENTS);
+                    }
+                    catch (Exception e)
+                    {
+                        ForwardOnError(e);
+                    }
                 }
                 else
                 {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/SingleAsync.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/SingleAsync.cs
@@ -33,7 +33,14 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (_seenValue)
                     {
-                        ForwardOnError(new InvalidOperationException(Strings_Linq.MORE_THAN_ONE_ELEMENT));
+                        try
+                        {
+                            throw new InvalidOperationException(Strings_Linq.MORE_THAN_ONE_ELEMENT);
+                        }
+                        catch (Exception e)
+                        {
+                            ForwardOnError(e);
+                        }
                         return;
                     }
 
@@ -45,7 +52,14 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (!_seenValue)
                     {
-                        ForwardOnError(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                        try
+                        {
+                            throw new InvalidOperationException(Strings_Linq.NO_ELEMENTS);
+                        }
+                        catch (Exception e)
+                        {
+                            ForwardOnError(e);
+                        }
                     }
                     else
                     {
@@ -101,7 +115,14 @@ namespace System.Reactive.Linq.ObservableImpl
                     {
                         if (_seenValue)
                         {
-                            ForwardOnError(new InvalidOperationException(Strings_Linq.MORE_THAN_ONE_MATCHING_ELEMENT));
+                            try
+                            {
+                                throw new InvalidOperationException(Strings_Linq.MORE_THAN_ONE_MATCHING_ELEMENT);
+                            }
+                            catch (Exception e)
+                            {
+                                ForwardOnError(e);
+                            }
                             return;
                         }
 
@@ -114,7 +135,14 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (!_seenValue)
                     {
-                        ForwardOnError(new InvalidOperationException(Strings_Linq.NO_MATCHING_ELEMENTS));
+                        try
+                        {
+                            throw new InvalidOperationException(Strings_Linq.NO_MATCHING_ELEMENTS);
+                        }
+                        catch (Exception e)
+                        {
+                            ForwardOnError(e);
+                        }
                     }
                     else
                     {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/SingleOrDefaultAsync.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/SingleOrDefaultAsync.cs
@@ -33,7 +33,14 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (_seenValue)
                     {
-                        ForwardOnError(new InvalidOperationException(Strings_Linq.MORE_THAN_ONE_ELEMENT));
+                        try
+                        {
+                            throw new InvalidOperationException(Strings_Linq.MORE_THAN_ONE_ELEMENT);
+                        }
+                        catch (Exception e)
+                        {
+                            ForwardOnError(e);
+                        }
                         return;
                     }
 
@@ -94,7 +101,14 @@ namespace System.Reactive.Linq.ObservableImpl
                     {
                         if (_seenValue)
                         {
-                            ForwardOnError(new InvalidOperationException(Strings_Linq.MORE_THAN_ONE_MATCHING_ELEMENT));
+                            try
+                            {
+                                throw new InvalidOperationException(Strings_Linq.MORE_THAN_ONE_MATCHING_ELEMENT);
+                            }
+                            catch (Exception e)
+                            {
+                                ForwardOnError(e);
+                            }
                             return;
                         }
 

--- a/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Blocking.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Blocking.cs
@@ -235,6 +235,7 @@ namespace System.Reactive.Linq
         {
             var value = default(TSource);
             var seenValue = false;
+            var moreThanOneElement = false;
             var ex = default(Exception);
 
             using (var evt = new WaitAndSetOnce())
@@ -247,7 +248,7 @@ namespace System.Reactive.Linq
                     {
                         if (seenValue)
                         {
-                            ex = new InvalidOperationException(Strings_Linq.MORE_THAN_ONE_ELEMENT);
+                            moreThanOneElement = true;
                             evt.Set();
                         }
 
@@ -269,6 +270,11 @@ namespace System.Reactive.Linq
             }
 
             ex.ThrowIfNotNull();
+
+            if (moreThanOneElement)
+            {
+                throw new InvalidOperationException(Strings_Linq.MORE_THAN_ONE_ELEMENT);
+            }
 
             if (throwOnEmpty && !seenValue)
             {

--- a/Rx.NET/Source/src/System.Reactive/Threading/Tasks/TaskObservableExtensions.cs
+++ b/Rx.NET/Source/src/System.Reactive/Threading/Tasks/TaskObservableExtensions.cs
@@ -470,7 +470,14 @@ namespace System.Reactive.Threading.Tasks
                 }
                 else
                 {
-                    _tcs.TrySetException(new InvalidOperationException(Strings_Linq.NO_ELEMENTS));
+                    try
+                    {
+                        throw new InvalidOperationException(Strings_Linq.NO_ELEMENTS);
+                    }
+                    catch (Exception e)
+                    {
+                        _tcs.TrySetException(e);
+                    }
                 }
 
                 _ctr.Dispose(); // no null-check needed (struct)


### PR DESCRIPTION
Improves https://github.com/dotnet/reactive/issues/1235 by ensuring there's a `StackTrace` for operators such as `SingleAsync` when propagating on `OnError` exception they've created themselves. Because there's no stack to unwind (`observer.OnError` goes "the other way"), the exception info is limited to the current frame (e.g. `OnCompleted` in `SingleAsync` noticing there was no element and thus propagating an `InvalidOperationException`). At the very least, it gives a clue about the operator that caused it. Further root cause analysis remains a debugging task (e.g. why the sequence produced no elements) but this can help to steer investigations.