### PR TITLE
Remove some NET45 and NET46 #if checks.

### DIFF
--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Disposables/DisposableTests.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Disposables/DisposableTests.cs
@@ -506,7 +506,6 @@ namespace ReactiveTests.Tests
             Assert.False(enumerator.MoveNext());
         }
 
-#if NET45 || NET46 
         [Fact]
         public void CancellationDisposable_Ctor_Null()
         {
@@ -537,7 +536,7 @@ namespace ReactiveTests.Tests
             Assert.True(c.IsDisposed);
             Assert.True(c.Token.IsCancellationRequested);
         }
-#endif
+
         [Fact]
         public void ContextDisposable_CreateNullContext()
         {

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/RegressionTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/RegressionTest.cs
@@ -18,7 +18,6 @@ namespace ReactiveTests.Tests
 
     public class RegressionTest : ReactiveTest
     {
-#if NET45 || NET46
         [Fact]
         public void Bug_ConcurrentMerge()
         {
@@ -42,7 +41,6 @@ namespace ReactiveTests.Tests
 
             Assert.True(Enumerable.Range(0, reps).ToList().SequenceEqual(resultQueue.ToList()));
         }
-#endif
 
         [Fact]
         public void Bug_1283()


### PR DESCRIPTION
Remove unnecessary `#if` checks for types that are available across all target platforms currently.