### PR TITLE
Remove traces of Silverlight in #if checks

### DIFF
--- a/Rx.NET/Source/tests/Tests.System.Reactive/DispatcherHelpers.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/DispatcherHelpers.cs
@@ -49,9 +49,7 @@ namespace ReactiveTests
 
         public void InvokeShutdown()
         {
-#if !USE_SL_DISPATCHER
             _dispatcher.InvokeShutdown();
-#endif
         }
 
         public static implicit operator Dispatcher(DispatcherWrapper wrapper)
@@ -59,13 +57,11 @@ namespace ReactiveTests
             return wrapper._dispatcher;
         }
 
-#if !USE_SL_DISPATCHER
         public event DispatcherUnhandledExceptionEventHandler UnhandledException
         {
             add { _dispatcher.UnhandledException += value; }
             remove { _dispatcher.UnhandledException -= value; }
         }
-#endif
 
         public void BeginInvoke(Action action)
         {

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ObserveOnTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ObserveOnTest.cs
@@ -44,18 +44,10 @@ namespace ReactiveTests.Tests
 #endif
 
 #if HAS_DISPATCHER
-#if USE_SL_DISPATCHER
-            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.ObserveOn<int>(default(IObservable<int>), new DispatcherScheduler(System.Windows.Deployment.Current.Dispatcher)));
-#else
             ReactiveAssert.Throws<ArgumentNullException>(() => Observable.ObserveOn<int>(default(IObservable<int>), new DispatcherScheduler(Dispatcher.CurrentDispatcher)));
-#endif
             ReactiveAssert.Throws<ArgumentNullException>(() => Observable.ObserveOn<int>(someObservable, default(DispatcherScheduler)));
 
-#if USE_SL_DISPATCHER
-            ReactiveAssert.Throws<ArgumentNullException>(() => DispatcherObservable.ObserveOn<int>(default(IObservable<int>), System.Windows.Deployment.Current.Dispatcher));
-#else
             ReactiveAssert.Throws<ArgumentNullException>(() => DispatcherObservable.ObserveOn<int>(default(IObservable<int>), Dispatcher.CurrentDispatcher));
-#endif
             ReactiveAssert.Throws<ArgumentNullException>(() => DispatcherObservable.ObserveOn<int>(someObservable, default(Dispatcher)));
             ReactiveAssert.Throws<ArgumentNullException>(() => DispatcherObservable.ObserveOnDispatcher<int>(default(IObservable<int>)));
 #endif

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/SubscribeOnTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/SubscribeOnTest.cs
@@ -42,18 +42,10 @@ namespace ReactiveTests.Tests
             ReactiveAssert.Throws<ArgumentNullException>(() => ControlObservable.SubscribeOn<int>(someObservable, default(Label)));
 #endif
 #if HAS_DISPATCHER
-#if USE_SL_DISPATCHER
-            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.SubscribeOn<int>(default(IObservable<int>), new DispatcherScheduler(System.Windows.Deployment.Current.Dispatcher)));
-#else
             ReactiveAssert.Throws<ArgumentNullException>(() => Observable.SubscribeOn<int>(default(IObservable<int>), new DispatcherScheduler(Dispatcher.CurrentDispatcher)));
-#endif
             ReactiveAssert.Throws<ArgumentNullException>(() => Observable.SubscribeOn<int>(someObservable, default(DispatcherScheduler)));
 
-#if USE_SL_DISPATCHER
-            ReactiveAssert.Throws<ArgumentNullException>(() => DispatcherObservable.SubscribeOn<int>(default(IObservable<int>), System.Windows.Deployment.Current.Dispatcher));
-#else
             ReactiveAssert.Throws<ArgumentNullException>(() => DispatcherObservable.SubscribeOn<int>(default(IObservable<int>), Dispatcher.CurrentDispatcher));
-#endif
             ReactiveAssert.Throws<ArgumentNullException>(() => DispatcherObservable.SubscribeOn<int>(someObservable, default(Dispatcher)));
             ReactiveAssert.Throws<ArgumentNullException>(() => DispatcherObservable.SubscribeOnDispatcher<int>(default(IObservable<int>)));
 #endif


### PR DESCRIPTION
Weed out more legacy stuff to get a clear picture of all the feature flags `#if` checks we have left in the code.