### PR TITLE
Bump .NET Framework minimum version to v4.7.2.

### DIFF
--- a/Rx.NET/Source/Directory.build.targets
+++ b/Rx.NET/Source/Directory.build.targets
@@ -6,7 +6,7 @@
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
   </PropertyGroup>
     
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net46'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
     <DefineConstants>$(DefineConstants);HAS_WINFORMS;HAS_WPF;HAS_WINRT;HAS_DISPATCHER;HAS_REMOTING;DESKTOPCLR</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'uap10.0'">
@@ -28,7 +28,7 @@
     <DefineConstants>$(DefineConstants);HAS_WINRT;HAS_WINFORMS;HAS_WPF;HAS_DISPATCHER;DESKTOPCLR;WINDOWS;CSWINRT</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'uap10.0' or '$(TargetFramework)' == 'uap10.0.16299' or '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'uap10.0' or '$(TargetFramework)' == 'uap10.0.16299' or '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 

--- a/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/Benchmarks.System.Reactive.csproj
+++ b/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/Benchmarks.System.Reactive.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <Optimize>true</Optimize>
     <IsPackable>false</IsPackable>
     <Configurations>Current Sources;Rx.net 3.1.1;Rx.net 4.0</Configurations>

--- a/Rx.NET/Source/facades/GlobalAssemblyVersion.cs
+++ b/Rx.NET/Source/facades/GlobalAssemblyVersion.cs
@@ -18,7 +18,7 @@ using System.Reflection;
 [assembly: AssemblyVersion("3.0.4000.0")]
 #elif NETSTANDARD1_5 || NET462
 [assembly: AssemblyVersion("3.0.5000.0")]
-#elif NETSTANDARD1_6 || NETCOREAPP1_0 || NET463 || NETSTANDARD2_0
+#elif NETSTANDARD1_6 || NETCOREAPP1_0 || NET463 || NET472 || NETSTANDARD2_0
 [assembly: AssemblyVersion("3.0.6000.0")]
 #else // this is here to prevent the build system from complaining. It should never be hit
 [assembly: AssemblyVersion("invalid")]

--- a/Rx.NET/Source/facades/System.Reactive.Core/System.Reactive.Core.csproj
+++ b/Rx.NET/Source/facades/System.Reactive.Core/System.Reactive.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard2.0;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0;uap10.0.16299</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Rx.NET/Source/facades/System.Reactive.Experimental/System.Reactive.Experimental.csproj
+++ b/Rx.NET/Source/facades/System.Reactive.Experimental/System.Reactive.Experimental.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Rx.NET/Source/facades/System.Reactive.Interfaces/System.Reactive.Interfaces.csproj
+++ b/Rx.NET/Source/facades/System.Reactive.Interfaces/System.Reactive.Interfaces.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard2.0;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0;uap10.0.16299</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Rx.NET/Source/facades/System.Reactive.Linq/System.Reactive.Linq.csproj
+++ b/Rx.NET/Source/facades/System.Reactive.Linq/System.Reactive.Linq.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard2.0;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0;uap10.0.16299</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Rx.NET/Source/facades/System.Reactive.PlatformServices/System.Reactive.PlatformServices.csproj
+++ b/Rx.NET/Source/facades/System.Reactive.PlatformServices/System.Reactive.PlatformServices.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard2.0;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0;uap10.0.16299</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Rx.NET/Source/facades/System.Reactive.Providers/System.Reactive.Providers.csproj
+++ b/Rx.NET/Source/facades/System.Reactive.Providers/System.Reactive.Providers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard2.0;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0;uap10.0.16299</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Rx.NET/Source/facades/System.Reactive.Runtime.Remoting/System.Reactive.Runtime.Remoting.csproj
+++ b/Rx.NET/Source/facades/System.Reactive.Runtime.Remoting/System.Reactive.Runtime.Remoting.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Rx.NET/Source/facades/System.Reactive.Windows.Forms/System.Reactive.Windows.Forms.csproj
+++ b/Rx.NET/Source/facades/System.Reactive.Windows.Forms/System.Reactive.Windows.Forms.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Rx.NET/Source/facades/System.Reactive.Windows.Threading/System.Reactive.Windows.Threading.csproj
+++ b/Rx.NET/Source/facades/System.Reactive.Windows.Threading/System.Reactive.Windows.Threading.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks>net472;uap10.0.16299</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Rx.NET/Source/src/Microsoft.Reactive.Testing/Microsoft.Reactive.Testing.csproj
+++ b/Rx.NET/Source/src/Microsoft.Reactive.Testing/Microsoft.Reactive.Testing.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net46;uap10.0.16299;netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;uap10.0.16299;netstandard2.0;net5.0</TargetFrameworks>
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
     <Description>Reactive Extensions Testing Library containing interfaces and classes providing functionality to test applications and libraries built using Reactive Extensions.</Description>    
     <AssemblyTitle>Microsoft.Reactive.Testing - Testing Helper Library</AssemblyTitle>    

--- a/Rx.NET/Source/src/System.Reactive.Observable.Aliases/System.Reactive.Observable.Aliases.csproj
+++ b/Rx.NET/Source/src/System.Reactive.Observable.Aliases/System.Reactive.Observable.Aliases.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46;uap10.0.16299;net5.0</TargetFrameworks>    
+    <TargetFrameworks>netstandard2.0;net472;uap10.0.16299;net5.0</TargetFrameworks>    
     <Title>Reactive Extensions - Aliases</Title>    
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>    
     <PackageTags>Rx;Reactive;Extensions;Observable;LINQ;Events</PackageTags>

--- a/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
+++ b/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.0;net46;uap10.0.16299;net5.0;net5.0-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.0;net472;uap10.0.16299;net5.0;net5.0-windows10.0.19041</TargetFrameworks>
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
     <PackageTags>Rx;Reactive;Extensions;Observable;LINQ;Events</PackageTags>
     <Description>Reactive Extensions (Rx) for .NET</Description>
@@ -44,20 +44,19 @@
   </ItemGroup>
 
   <!-- Windows includes for Desktop and UWP -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' or $(TargetFramework.StartsWith('uap10.0')) or '$(TargetFramework)' == 'netcoreapp3.1' or $(TargetFramework.StartsWith('net5.0-windows'))">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' or $(TargetFramework.StartsWith('uap10.0')) or '$(TargetFramework)' == 'netcoreapp3.1' or $(TargetFramework.StartsWith('net5.0-windows'))">
     <Compile Include="Platforms\Windows\**\*.cs" />
     <EmbeddedResource Include="Platforms\Windows\**\*.resx" />
   </ItemGroup>
 
   <!-- Desktop -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46'">
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472'">
     <Reference Include="System.Windows" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netcoreapp3.1' or $(TargetFramework.StartsWith('net5.0-windows'))">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'netcoreapp3.1' or $(TargetFramework.StartsWith('net5.0-windows'))">
     <Compile Include="Platforms\Desktop\**\*.cs" />
   </ItemGroup>
 

--- a/Rx.NET/Source/tests/Directory.build.targets
+++ b/Rx.NET/Source/tests/Directory.build.targets
@@ -1,7 +1,7 @@
 <Project>  
   <Import Project="..\Directory.build.targets" />
   <PropertyGroup>
-    <DebugType Condition="'$(TargetFramework)' != 'net46'">portable</DebugType>
-    <DebugType Condition="'$(TargetFramework)' == 'net46'">full</DebugType>
+    <DebugType Condition="'$(TargetFramework)' != 'net472'">portable</DebugType>
+    <DebugType Condition="'$(TargetFramework)' == 'net472'">full</DebugType>
   </PropertyGroup>
 </Project>

--- a/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Api/ApiApprovalTests.Aliases.verified.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Api/ApiApprovalTests.Aliases.verified.cs
@@ -1,7 +1,7 @@
 [assembly: System.CLSCompliant(true)]
 [assembly: System.Resources.NeutralResourcesLanguage("en-US")]
 [assembly: System.Runtime.InteropServices.ComVisible(false)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.6", FrameworkDisplayName=".NET Framework 4.6")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.7.2", FrameworkDisplayName=".NET Framework 4.7.2")]
 namespace System.Reactive.Linq
 {
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Api/ApiApprovalTests.Core.verified.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Api/ApiApprovalTests.Core.verified.cs
@@ -3,7 +3,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Tests.System.Reactive, PublicKey=00240000048000009400000006020000002400005253413100040000010001008f5cff058631087031f8350f30a36fa078027e5df2316b564352dc9eb7af7ce856016d3c5e9d058036fe73bb5c83987bd3fc0793fbe25d633cc4f37c2bd5f1d717cd2a81661bec08f0971dc6078e17bde372b89005e7738a0ebd501b896ca3e8315270ff64df7809dd912c372df61785a5085b3553b7872e39b1b1cc0ff5a6bc")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Tests.System.Reactive.Uwp.DeviceRunner, PublicKey=00240000048000009400000006020000002400005253413100040000010001008f5cff058631087031f8350f30a36fa078027e5df2316b564352dc9eb7af7ce856016d3c5e9d058036fe73bb5c83987bd3fc0793fbe25d633cc4f37c2bd5f1d717cd2a81661bec08f0971dc6078e17bde372b89005e7738a0ebd501b896ca3e8315270ff64df7809dd912c372df61785a5085b3553b7872e39b1b1cc0ff5a6bc")]
 [assembly: System.Runtime.InteropServices.ComVisible(false)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.6", FrameworkDisplayName=".NET Framework 4.6")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.7.2", FrameworkDisplayName=".NET Framework 4.7.2")]
 namespace System
 {
     public static class ObservableExtensions

--- a/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Api/ApiApprovalTests.Testing.verified.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Api/ApiApprovalTests.Testing.verified.cs
@@ -1,6 +1,6 @@
 [assembly: System.CLSCompliant(true)]
 [assembly: System.Runtime.InteropServices.ComVisible(false)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.6", FrameworkDisplayName=".NET Framework 4.6")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.7.2", FrameworkDisplayName=".NET Framework 4.7.2")]
 namespace Microsoft.Reactive.Testing
 {
     public interface ITestableObservable<T> : System.IObservable<T>

--- a/Rx.NET/Source/tests/Tests.System.Reactive/DispatcherHelpers.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/DispatcherHelpers.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
-#if NETCOREAPP2_1 || NET46 || NETCOREAPP3_1 || CSWINRT
+#if NETCOREAPP2_1 || NET472 || NETCOREAPP3_1 || CSWINRT
 using System.Threading;
 #endif
 #if HAS_DISPATCHER

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests.System.Reactive.csproj
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests.System.Reactive.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net46;netcoreapp2.1;net5.0;net5.0-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;netcoreapp2.1;net5.0;net5.0-windows10.0.19041</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' or '$(TargetFramework)' == 'net46'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' or '$(TargetFramework)' == 'net472'">
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Concurrency/SchedulerTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Concurrency/SchedulerTest.cs
@@ -375,7 +375,7 @@ namespace ReactiveTests.Tests
         }
 #endif
 
-#if DESKTOPCLR && NET46
+#if DESKTOPCLR && NET472
         [Fact]
         public void Scheduler_Periodic_HostLifecycleManagement()
         {

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/FromEventPatternTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/FromEventPatternTest.cs
@@ -474,7 +474,7 @@ namespace ReactiveTests.Tests
             );
         }
 
-#if DESKTOPCLR && NET46
+#if DESKTOPCLR && NET472
         [Fact]
         public void FromEventPattern_Reflection_Instance_MissingAccessors()
         {


### PR DESCRIPTION
Upgrade to 4.7.2 as the minimum and remove `System.ValueTuple` package reference (see https://github.com/dotnet/reactive/issues/840).