### PR TITLE
Reduce default assignments.

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Concurrency/EventLoopScheduler.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/EventLoopScheduler.cs
@@ -297,7 +297,7 @@ namespace System.Reactive.Concurrency
             {
                 _evt.Wait();
 
-                var ready = default(ScheduledItem<TimeSpan>[]);
+                ScheduledItem<TimeSpan>[] ready = null;
 
                 lock (_gate)
                 {

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/HistoricalScheduler.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/HistoricalScheduler.cs
@@ -142,7 +142,7 @@ namespace System.Reactive.Concurrency
                 throw new ArgumentNullException(nameof(action));
             }
 
-            var si = default(ScheduledItem<DateTimeOffset, TState>);
+            ScheduledItem<DateTimeOffset, TState> si = null;
 
             var run = new Func<IScheduler, TState, IDisposable>((scheduler, state1) =>
             {

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/LocalScheduler.TimerQueue.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/LocalScheduler.TimerQueue.cs
@@ -207,7 +207,7 @@ namespace System.Reactive.Concurrency
         /// <returns>Empty disposable. Recursive work cancellation is wired through the original WorkItem.</returns>
         private IDisposable ExecuteNextShortTermWorkItem(IScheduler scheduler, IDisposable cancel)
         {
-            var next = default(WorkItem);
+            WorkItem next = null;
 
             lock (Gate)
             {

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/VirtualTimeScheduler.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/VirtualTimeScheduler.cs
@@ -422,7 +422,7 @@ namespace System.Reactive.Concurrency
                 throw new ArgumentNullException(nameof(action));
             }
 
-            var si = default(ScheduledItem<TAbsolute, TState>);
+            ScheduledItem<TAbsolute, TState> si = null;
 
             var run = new Func<IScheduler, TState, IDisposable>((scheduler, state1) =>
             {

--- a/Rx.NET/Source/src/System.Reactive/Disposables/CompositeDisposable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/CompositeDisposable.cs
@@ -106,10 +106,12 @@ namespace System.Reactive.Disposables
                 {
                     throw new ArgumentException(Strings_Core.DISPOSABLES_CANT_CONTAIN_NULL, nameof(disposables));
                 }
+
                 list.Add(d);
             }
 
             _disposables = list;
+
             // _count can be read by other threads and thus should be properly visible
             // also releases the _disposables contents so it becomes thread-safe
             Volatile.Write(ref _count, _disposables.Count);
@@ -137,6 +139,7 @@ namespace System.Reactive.Disposables
                 if (!_disposed)
                 {
                     _disposables.Add(item);
+
                     // If read atomically outside the lock, it should be written atomically inside
                     // the plain read on _count is fine here because manipulation always happens
                     // from inside a lock.
@@ -222,12 +225,14 @@ namespace System.Reactive.Disposables
         /// </summary>
         public void Dispose()
         {
-            var currentDisposables = default(List<IDisposable>);
+            List<IDisposable> currentDisposables = null;
+
             lock (_gate)
             {
                 if (!_disposed)
                 {
                     currentDisposables = _disposables;
+
                     // nulling out the reference is faster no risk to
                     // future Add/Remove because _disposed will be true
                     // and thus _disposables won't be touched again.
@@ -252,7 +257,8 @@ namespace System.Reactive.Disposables
         /// </summary>
         public void Clear()
         {
-            var previousDisposables = default(IDisposable[]);
+            IDisposable[] previousDisposables;
+
             lock (_gate)
             {
                 // disposed composites are always clear
@@ -294,6 +300,7 @@ namespace System.Reactive.Disposables
                 {
                     return false;
                 }
+
                 return _disposables.Contains(item);
             }
         }
@@ -331,7 +338,9 @@ namespace System.Reactive.Disposables
                     // to accommodate all _count disposables in this composite
                     throw new ArgumentOutOfRangeException(nameof(arrayIndex));
                 }
+                
                 var i = arrayIndex;
+                
                 foreach (var d in _disposables)
                 {
                     if (d != null)
@@ -359,6 +368,7 @@ namespace System.Reactive.Disposables
                 {
                     return EmptyEnumerator;
                 }
+
                 // the copy is unavoidable but the creation
                 // of an outer IEnumerable is avoidable
                 return new CompositeEnumerator(_disposables.ToArray());
@@ -418,10 +428,12 @@ namespace System.Reactive.Disposables
                 for (; ; )
                 {
                     var idx = ++_index;
+                    
                     if (idx >= disposables.Length)
                     {
                         return false;
                     }
+
                     // inlined that filter for null elements
                     if (disposables[idx] != null)
                     {

--- a/Rx.NET/Source/src/System.Reactive/EventPatternSourceBase.cs
+++ b/Rx.NET/Source/src/System.Reactive/EventPatternSourceBase.cs
@@ -142,7 +142,7 @@ namespace System.Reactive
                 throw new ArgumentNullException(nameof(handler));
             }
 
-            var d = default(IDisposable);
+            IDisposable d = null;
 
             lock (_subscriptions)
             {

--- a/Rx.NET/Source/src/System.Reactive/EventSource.cs
+++ b/Rx.NET/Source/src/System.Reactive/EventSource.cs
@@ -82,11 +82,12 @@ namespace System.Reactive
 
         private void Remove(Delegate handler)
         {
-            var d = default(IDisposable);
+            IDisposable d = null;
 
             lock (_subscriptions)
             {
                 var l = new Stack<IDisposable>();
+
                 if (_subscriptions.TryGetValue(handler, out l))
                 {
                     d = l.Pop();

--- a/Rx.NET/Source/src/System.Reactive/Internal/ReflectionUtils.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/ReflectionUtils.cs
@@ -25,7 +25,7 @@ namespace System.Reactive
 
         public static void GetEventMethods<TSender, TEventArgs>(Type targetType, object target, string eventName, out MethodInfo addMethod, out MethodInfo removeMethod, out Type delegateType, out bool isWinRT)
         {
-            var e = default(EventInfo);
+            EventInfo e;
 
             if (target == null)
             {

--- a/Rx.NET/Source/src/System.Reactive/Internal/SystemClock.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/SystemClock.cs
@@ -121,7 +121,7 @@ namespace System.Reactive.PlatformServices
             //
             lock (SystemClockChanged)
             {
-                var remove = default(HashSet<WeakReference<LocalScheduler>>);
+                HashSet<WeakReference<LocalScheduler>> remove = null;
 
                 foreach (var handler in SystemClockChanged)
                 {

--- a/Rx.NET/Source/src/System.Reactive/Joins/Plan.cs
+++ b/Rx.NET/Source/src/System.Reactive/Joins/Plan.cs
@@ -22,7 +22,8 @@ namespace System.Reactive.Joins
         internal static JoinObserver<TSource> CreateObserver<TSource>(
             Dictionary<object, IJoinObserver> externalSubscriptions, IObservable<TSource> observable, Action<Exception> onError)
         {
-            var observer = default(JoinObserver<TSource>);
+            JoinObserver<TSource> observer;
+
             if (!externalSubscriptions.TryGetValue(observable, out var nonGeneric))
             {
                 observer = new JoinObserver<TSource>(observable, onError);
@@ -32,6 +33,7 @@ namespace System.Reactive.Joins
             {
                 observer = (JoinObserver<TSource>)nonGeneric;
             }
+            
             return observer;
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/All.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/All.cs
@@ -31,7 +31,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public override void OnNext(TSource value)
             {
-                var res = false;
+                bool res;
                 try
                 {
                     res = _predicate(value);

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Any.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Any.cs
@@ -67,7 +67,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public override void OnNext(TSource value)
                 {
-                    var res = false;
+                    bool res;
                     try
                     {
                         res = _predicate(value);

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Buffer.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Buffer.cs
@@ -684,7 +684,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 private void CreateBufferClose()
                 {
-                    var bufferClose = default(IObservable<TBufferClosing>);
+                    IObservable<TBufferClosing> bufferClose;
                     try
                     {
                         bufferClose = _bufferClosingSelector();

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Catch.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Catch.cs
@@ -117,7 +117,7 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (!Volatile.Read(ref _once) && error is TException e)
                 {
-                    var result = default(IObservable<TSource>);
+                    IObservable<TSource> result;
                     try
                     {
                         result = _handler(e);

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Defer.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Defer.cs
@@ -32,7 +32,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public void Run()
             {
-                var result = default(IObservable<TValue>);
+                IObservable<TValue> result;
                 try
                 {
                     result = _observableFactory();

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Delay.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Delay.cs
@@ -624,7 +624,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public override void OnNext(TSource value)
                 {
-                    var delay = default(IObservable<TDelay>);
+                    IObservable<TDelay> delay;
                     try
                     {
                         delay = _delaySelector(value);

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Distinct.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Distinct.cs
@@ -38,7 +38,7 @@ namespace System.Reactive.Linq.ObservableImpl
             public override void OnNext(TSource value)
             {
                 TKey key;
-                var hasAdded = false;
+                bool hasAdded;
                 try
                 {
                     key = _keySelector(value);

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Empty.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Empty.cs
@@ -29,7 +29,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public void Run(IScheduler scheduler)
             {
-                SetUpstream(scheduler.ScheduleAction(this, target => target.OnCompleted()));
+                SetUpstream(scheduler.ScheduleAction(this, static target => target.OnCompleted()));
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/FirstAsync.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/FirstAsync.cs
@@ -80,7 +80,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public override void OnNext(TSource value)
                 {
-                    var b = false;
+                    bool b;
 
                     try
                     {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/FirstOrDefaultAsync.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/FirstOrDefaultAsync.cs
@@ -67,7 +67,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public override void OnNext(TSource value)
                 {
-                    var b = false;
+                    bool b;
 
                     try
                     {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/FromEvent.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/FromEvent.cs
@@ -208,7 +208,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         protected override IDisposable Run(IObserver<TArgs> observer)
         {
-            var connection = default(IDisposable);
+            IDisposable connection;
 
             lock (_gate)
             {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/FromEventPattern.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/FromEventPattern.cs
@@ -96,7 +96,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             protected override IDisposable AddHandler(Delegate handler)
             {
-                var removeHandler = default(Action);
+                Action removeHandler;
 
                 try
                 {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Generate.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Generate.cs
@@ -67,8 +67,9 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     while (!cancel.IsDisposed)
                     {
-                        var hasResult = false;
+                        bool hasResult;
                         var result = default(TResult);
+
                         try
                         {
                             if (_first)
@@ -111,8 +112,9 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 private void LoopRec(Action<_> recurse)
                 {
-                    var hasResult = false;
+                    bool hasResult;
                     var result = default(TResult);
+                    
                     try
                     {
                         if (_first)
@@ -212,12 +214,12 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 private IDisposable InvokeRec(IScheduler self, TState state)
                 {
-                    var time = default(DateTimeOffset);
-
                     if (_hasResult)
                     {
                         ForwardOnNext(_result);
                     }
+
+                    var time = default(DateTimeOffset);
 
                     try
                     {
@@ -289,7 +291,6 @@ namespace System.Reactive.Linq.ObservableImpl
                 private readonly Func<TState, TResult> _resultSelector;
                 private readonly Func<TState, TimeSpan> _timeSelector;
 
-
                 public _(Relative parent, IObserver<TResult> observer)
                     : base(observer)
                 {
@@ -322,12 +323,12 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 private IDisposable InvokeRec(IScheduler self, TState state)
                 {
-                    var time = default(TimeSpan);
-
                     if (_hasResult)
                     {
                         ForwardOnNext(_result);
                     }
+
+                    var time = default(TimeSpan);
 
                     try
                     {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/GroupByUntil.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/GroupByUntil.cs
@@ -86,7 +86,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
 
                 var fireNewMapEntry = false;
-                var writer = default(ISubject<TElement>);
+                ISubject<TElement> writer;
                 try
                 {
                     //
@@ -125,9 +125,9 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     var group = new GroupedObservable<TKey, TElement>(key, writer, _refCountDisposable);
 
-                    var duration = default(IObservable<TDuration>);
-
                     var durationGroup = new GroupedObservable<TKey, TElement>(key, writer);
+
+                    IObservable<TDuration> duration;
                     try
                     {
                         duration = _durationSelector(durationGroup);
@@ -208,7 +208,8 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (_key == null)
                     {
-                        var @null = default(ISubject<TElement>);
+                        ISubject<TElement> @null;
+
                         lock (_parent._nullGate)
                         {
                             @null = _parent._null;
@@ -241,7 +242,8 @@ namespace System.Reactive.Linq.ObservableImpl
                 //       using Subject<T>. It will transition into a terminal state, making one
                 //       of the two calls a no-op by swapping in a DoneObserver<T>.
                 //
-                var @null = default(ISubject<TElement>);
+                ISubject<TElement> @null;
+                
                 lock (_nullGate)
                 {
                     @null = _null;
@@ -267,7 +269,8 @@ namespace System.Reactive.Linq.ObservableImpl
                 //       using Subject<T>. It will transition into a terminal state, making one
                 //       of the two calls a no-op by swapping in a DoneObserver<T>.
                 //
-                var @null = default(ISubject<TElement>);
+                ISubject<TElement> @null;
+
                 lock (_nullGate)
                 {
                     @null = _null;

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/GroupJoin.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/GroupJoin.cs
@@ -95,8 +95,10 @@ namespace System.Reactive.Linq.ObservableImpl
                 public override void OnNext(TLeft value)
                 {
                     var s = new Subject<TRight>();
-                    var id = 0;
-                    var rightID = 0;
+
+                    int id;
+                    int rightID;
+
                     lock (_parent._gate)
                     {
                         id = _parent._leftID++;
@@ -108,7 +110,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                     // BREAKING CHANGE v2 > v1.x - Order of evaluation or the _leftDurationSelector and _resultSelector now consistent with Join.
 
-                    var duration = default(IObservable<TLeftDuration>);
+                    IObservable<TLeftDuration> duration;
                     try
                     {
                         duration = _parent._leftDurationSelector(value);
@@ -223,8 +225,9 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public override void OnNext(TRight value)
                 {
-                    var id = 0;
-                    var leftID = 0;
+                    int id;
+                    int leftID;
+
                     lock (_parent._gate)
                     {
                         id = _parent._rightID++;
@@ -232,7 +235,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         _parent._rightMap.Add(id, value);
                     }
 
-                    var duration = default(IObservable<TRightDuration>);
+                    IObservable<TRightDuration> duration;
                     try
                     {
                         duration = _parent._rightDurationSelector(value);

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Join.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Join.cs
@@ -91,8 +91,9 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public override void OnNext(TLeft value)
                 {
-                    var id = 0;
-                    var rightID = 0;
+                    int id;
+                    int rightID;
+
                     lock (_parent._gate)
                     {
                         id = _parent._leftID++;
@@ -101,7 +102,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
 
 
-                    var duration = default(IObservable<TLeftDuration>);
+                    IObservable<TLeftDuration> duration;
                     try
                     {
                         duration = _parent._leftDurationSelector(value);
@@ -216,8 +217,9 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public override void OnNext(TRight value)
                 {
-                    var id = 0;
-                    var leftID = 0;
+                    int id;
+                    int leftID;
+
                     lock (_parent._gate)
                     {
                         id = _parent._rightID++;
@@ -225,7 +227,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         _parent._rightMap.Add(id, value);
                     }
 
-                    var duration = default(IObservable<TRightDuration>);
+                    IObservable<TRightDuration> duration;
                     try
                     {
                         duration = _parent._rightDurationSelector(value);

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Latest.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Latest.cs
@@ -90,7 +90,8 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public override bool TryMoveNext(out TSource current)
             {
-                var kind = default(NotificationKind);
+                NotificationKind kind;
+
                 var value = default(TSource);
                 var error = default(Exception);
 

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Multicast.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Multicast.cs
@@ -35,8 +35,9 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public void Run(Multicast<TSource, TIntermediate, TResult> parent)
             {
-                var observable = default(IObservable<TResult>);
-                var connectable = default(IConnectableObservable<TIntermediate>);
+                IObservable<TResult> observable;
+                IConnectableObservable<TIntermediate> connectable;
+
                 try
                 {
                     var subject = parent._subjectSelector();
@@ -59,6 +60,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     Disposable.TryDispose(ref _connection);
                 }
+                
                 base.Dispose(disposing);
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/RefCount.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/RefCount.cs
@@ -55,8 +55,8 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public void Run()
                 {
-                    var doConnect = false;
-                    var conn = default(RefConnection);
+                    bool doConnect;
+                    RefConnection conn;
 
                     lock (_parent._gate)
                     {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/RepeatWhen.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/RepeatWhen.cs
@@ -27,11 +27,13 @@ namespace System.Reactive.Linq.ObservableImpl
             }
 
             var completeSignals = new Subject<object>();
-            var redo = default(IObservable<U>);
+
+            IObservable<U> redo;
 
             try
             {
                 redo = _handler(completeSignals);
+                
                 if (redo == null)
                 {
                     throw new NullReferenceException("The handler returned a null IObservable");

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/RetryWhen.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/RetryWhen.cs
@@ -28,7 +28,8 @@ namespace System.Reactive.Linq.ObservableImpl
             }
 
             var errorSignals = new Subject<Exception>();
-            var redo = default(IObservable<U>);
+            
+            IObservable<U> redo;
 
             try
             {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/SelectMany.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/SelectMany.cs
@@ -47,7 +47,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public override void OnNext(TSource value)
                 {
-                    var collection = default(IObservable<TCollection>);
+                    IObservable<TCollection> collection;
 
                     try
                     {
@@ -210,7 +210,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 public override void OnNext(TSource value)
                 {
                     var index = checked(_index++);
-                    var collection = default(IObservable<TCollection>);
+                    IObservable<TCollection> collection;
 
                     try
                     {
@@ -370,7 +370,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public override void OnNext(TSource value)
                 {
-                    var xs = default(IEnumerable<TCollection>);
+                    IEnumerable<TCollection> xs;
                     try
                     {
                         xs = _collectionSelector(value);
@@ -459,7 +459,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     var index = checked(_index++);
 
-                    var xs = default(IEnumerable<TCollection>);
+                    IEnumerable<TCollection> xs;
                     try
                     {
                         xs = _collectionSelector(value, index);
@@ -566,7 +566,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public override void OnNext(TSource value)
                 {
-                    var task = default(Task<TCollection>);
+                    Task<TCollection> task;
                     try
                     {
                         Interlocked.Increment(ref _count);
@@ -723,7 +723,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     var index = checked(_index++);
 
-                    var task = default(Task<TCollection>);
+                    Task<TCollection> task;
                     try
                     {
                         Interlocked.Increment(ref _count);
@@ -858,7 +858,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public override void OnNext(TSource value)
                 {
-                    var inner = default(IObservable<TResult>);
+                    IObservable<TResult> inner;
 
                     try
                     {
@@ -1007,7 +1007,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (_selectorOnError != null)
                     {
-                        var inner = default(IObservable<TResult>);
+                        IObservable<TResult> inner;
 
                         try
                         {
@@ -1036,7 +1036,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (_selectorOnCompleted != null)
                     {
-                        var inner = default(IObservable<TResult>);
+                        IObservable<TResult> inner;
 
                         try
                         {
@@ -1092,7 +1092,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public override void OnNext(TSource value)
                 {
-                    var inner = default(IObservable<TResult>);
+                    IObservable<TResult> inner;
 
                     try
                     {
@@ -1243,7 +1243,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (_selectorOnError != null)
                     {
-                        var inner = default(IObservable<TResult>);
+                        IObservable<TResult> inner;
 
                         try
                         {
@@ -1272,7 +1272,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (_selectorOnCompleted != null)
                     {
-                        var inner = default(IObservable<TResult>);
+                        IObservable<TResult> inner;
 
                         try
                         {
@@ -1322,7 +1322,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public override void OnNext(TSource value)
                 {
-                    var xs = default(IEnumerable<TResult>);
+                    IEnumerable<TResult> xs;
                     try
                     {
                         xs = _selector(value);
@@ -1405,7 +1405,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public override void OnNext(TSource value)
                 {
-                    var xs = default(IEnumerable<TResult>);
+                    IEnumerable<TResult> xs;
                     try
                     {
                         xs = _selector(value, checked(_index++));
@@ -1507,7 +1507,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public override void OnNext(TSource value)
                 {
-                    var task = default(Task<TResult>);
+                    Task<TResult> task;
                     try
                     {
                         Interlocked.Increment(ref _count);
@@ -1642,7 +1642,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public override void OnNext(TSource value)
                 {
-                    var task = default(Task<TResult>);
+                    Task<TResult> task;
                     try
                     {
                         Interlocked.Increment(ref _count);

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/SkipWhile.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/SkipWhile.cs
@@ -35,7 +35,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (_predicate != null)
                     {
-                        var shouldStart = default(bool);
+                        bool shouldStart;
                         try
                         {
                             shouldStart = !_predicate(value);
@@ -91,7 +91,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (_predicate != null)
                     {
-                        var shouldStart = default(bool);
+                        bool shouldStart;
                         try
                         {
                             shouldStart = !_predicate(value, checked(_index++));

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Switch.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Switch.cs
@@ -45,7 +45,8 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public override void OnNext(IObservable<TSource> value)
             {
-                var id = default(ulong);
+                ulong id;
+                
                 lock (_gate)
                 {
                     id = unchecked(++_latest);

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Throttle.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Throttle.cs
@@ -54,7 +54,8 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public override void OnNext(TSource value)
             {
-                var currentid = default(ulong);
+                ulong currentid;
+
                 lock (_gate)
                 {
                     _hasValue = true;
@@ -155,7 +156,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public override void OnNext(TSource value)
             {
-                var throttle = default(IObservable<TThrottle>);
+                IObservable<TThrottle> throttle;
                 try
                 {
                     throttle = _throttleSelector(value);
@@ -171,6 +172,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
 
                 ulong currentid;
+                
                 lock (_gate)
                 {
                     _hasValue = true;

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Timeout.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Timeout.cs
@@ -277,7 +277,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                         ForwardOnNext(value);
 
-                        var timeoutSource = default(IObservable<TTimeout>);
+                        IObservable<TTimeout> timeoutSource;
                         try
                         {
                             timeoutSource = _timeoutSelector(value);

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/ToObservable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/ToObservable.cs
@@ -149,7 +149,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public void Run(IEnumerable<TSource> source, ISchedulerLongRunning scheduler)
             {
-                var e = default(IEnumerator<TSource>);
+                IEnumerator<TSource> e;
                 try
                 {
                     e = source.GetEnumerator();

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Using.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Using.cs
@@ -33,7 +33,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public void Run(Using<TSource, TResource> parent)
             {
-                var source = default(IObservable<TSource>);
+                IObservable<TSource> source;
                 var disposable = Disposable.Empty;
                 try
                 {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Window.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Window.cs
@@ -427,7 +427,8 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 private void Tick(Subject<TSource> window)
                 {
-                    var newWindow = default(Subject<TSource>);
+                    Subject<TSource> newWindow;
+
                     lock (_gate)
                     {
                         if (window != _s)
@@ -448,7 +449,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public override void OnNext(TSource value)
                 {
-                    var newWindow = default(Subject<TSource>);
+                    Subject<TSource> newWindow = null;
 
                     lock (_gate)
                     {
@@ -546,7 +547,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 private void CreateWindowClose()
                 {
-                    var windowClose = default(IObservable<TWindowClosing>);
+                    IObservable<TWindowClosing> windowClose;
                     try
                     {
                         windowClose = _windowClosingSelector();

--- a/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguageEx.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguageEx.cs
@@ -131,7 +131,7 @@ namespace System.Reactive.Linq
                     {
                         m.Disposable = _scheduler.Schedule(self =>
                         {
-                            var work = default(IObservable<TSource>);
+                            IObservable<TSource> work;
 
                             lock (q)
                             {
@@ -156,7 +156,7 @@ namespace System.Reactive.Linq
                                         observer.OnNext(x);
                                     }
 
-                                    var result = default(IObservable<TSource>);
+                                    IObservable<TSource> result;
                                     try
                                     {
                                         result = _selector(x);
@@ -167,6 +167,8 @@ namespace System.Reactive.Linq
                                         {
                                             observer.OnError(exception);
                                         }
+
+                                        return;
                                     }
 
                                     lock (q)
@@ -450,7 +452,7 @@ namespace System.Reactive.Linq
         {
             return Observable.Defer(() =>
             {
-                var chain = default(ChainObservable<TSource>);
+                ChainObservable<TSource> chain = null;
 
                 return source
                     .Select(

--- a/Rx.NET/Source/src/System.Reactive/Notification.cs
+++ b/Rx.NET/Source/src/System.Reactive/Notification.cs
@@ -379,9 +379,7 @@ namespace System.Reactive
         /// <summary>
         /// Represents an OnCompleted notification to an observer.
         /// </summary>
-#if !NO_DEBUGGER_ATTRIBUTES
         [DebuggerDisplay("OnCompleted()")]
-#endif
 #if !NO_SERIALIZABLE
         [Serializable]
 #endif

--- a/Rx.NET/Source/src/System.Reactive/ObservableQuery.cs
+++ b/Rx.NET/Source/src/System.Reactive/ObservableQuery.cs
@@ -367,8 +367,10 @@ namespace System.Reactive
                 //
                 // Where to look for the matching operator?
                 //
-                var targetType = default(Type);
-                var methods = default(ILookup<string, MethodInfo>);
+                
+                Type targetType;
+                ILookup<string, MethodInfo> methods;
+
                 if (method.DeclaringType == typeof(Qbservable))
                 {
                     targetType = typeof(Observable);

--- a/Rx.NET/Source/src/System.Reactive/Subjects/BehaviorSubject.cs
+++ b/Rx.NET/Source/src/System.Reactive/Subjects/BehaviorSubject.cs
@@ -136,7 +136,8 @@ namespace System.Reactive.Subjects
         /// </summary>
         public override void OnCompleted()
         {
-            var os = default(IObserver<T>[]);
+            IObserver<T>[] os = null;
+
             lock (_gate)
             {
                 CheckDisposed();
@@ -170,7 +171,8 @@ namespace System.Reactive.Subjects
                 throw new ArgumentNullException(nameof(error));
             }
 
-            var os = default(IObserver<T>[]);
+            IObserver<T>[] os = null;
+
             lock (_gate)
             {
                 CheckDisposed();
@@ -199,7 +201,8 @@ namespace System.Reactive.Subjects
         /// <param name="value">The value to send to all observers.</param>
         public override void OnNext(T value)
         {
-            var os = default(IObserver<T>[]);
+            IObserver<T>[] os = null;
+
             lock (_gate)
             {
                 CheckDisposed();
@@ -237,7 +240,7 @@ namespace System.Reactive.Subjects
                 throw new ArgumentNullException(nameof(observer));
             }
 
-            var ex = default(Exception);
+            Exception ex;
 
             lock (_gate)
             {

--- a/Rx.NET/Source/src/System.Reactive/Subjects/ReplaySubject.cs
+++ b/Rx.NET/Source/src/System.Reactive/Subjects/ReplaySubject.cs
@@ -252,7 +252,8 @@ namespace System.Reactive.Subjects
 
             public override void OnNext(T value)
             {
-                var o = default(IScheduledObserver<T>[]);
+                IScheduledObserver<T>[] o = null;
+
                 lock (_gate)
                 {
                     CheckDisposed();
@@ -281,7 +282,8 @@ namespace System.Reactive.Subjects
 
             public override void OnError(Exception error)
             {
-                var o = default(IScheduledObserver<T>[]);
+                IScheduledObserver<T>[] o = null;
+
                 lock (_gate)
                 {
                     CheckDisposed();
@@ -313,7 +315,8 @@ namespace System.Reactive.Subjects
 
             public override void OnCompleted()
             {
-                var o = default(IScheduledObserver<T>[]);
+                IScheduledObserver<T>[] o = null;
+
                 lock (_gate)
                 {
                     CheckDisposed();


### PR DESCRIPTION
Reduce redundant assignments (often of the form `var x = default(T);`) and reduce the use of `default(T)` where `null` is more appropriate (to make searching for `null` a little easier when/if we embark on enabling C# 8.0 nullable reference types).