### PR TITLE
Clean up some disposable stuff.

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Concurrency/CatchScheduler.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/CatchScheduler.cs
@@ -114,7 +114,7 @@ namespace System.Reactive.Concurrency
 
                 public void Dispose()
                 {
-                    Disposable.TryDispose(ref _cancel);
+                    Disposable.Dispose(ref _cancel);
                 }
 
                 private (PeriodicallyScheduledWorkItem<TState> @this, TState state) Tick(TState state)
@@ -144,7 +144,7 @@ namespace System.Reactive.Concurrency
                             throw;
                         }
 
-                        Disposable.TryDispose(ref _cancel);
+                        Disposable.Dispose(ref _cancel);
                         return default;
                     }
                 }

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/ConcurrencyAbstractionLayerImpl.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/ConcurrencyAbstractionLayerImpl.cs
@@ -180,7 +180,7 @@ namespace System.Reactive.Concurrency
                 }
                 finally
                 {
-                    Disposable.TryDispose(ref timer._timer);
+                    Disposable.Dispose(ref timer._timer);
                 }
             }
 

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/DefaultScheduler.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/DefaultScheduler.cs
@@ -186,7 +186,7 @@ namespace System.Reactive.Concurrency
 
                 public void Dispose()
                 {
-                    Disposable.TryDispose(ref _cancel);
+                    Disposable.Dispose(ref _cancel);
                 }
 
                 public bool IsDisposed => Disposable.GetIsDisposed(ref _cancel);

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/EventLoopScheduler.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/EventLoopScheduler.cs
@@ -236,7 +236,7 @@ namespace System.Reactive.Concurrency
 
             public void Dispose()
             {
-                Disposable.TryDispose(ref _task);
+                Disposable.Dispose(ref _task);
                 _gate.Dispose();
             }
         }
@@ -265,7 +265,7 @@ namespace System.Reactive.Concurrency
                 if (!_disposed)
                 {
                     _disposed = true;
-                    Disposable.TryDispose(ref _nextTimer);
+                    Disposable.Dispose(ref _nextTimer);
                     _evt.Release();
                 }
             }

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/LocalScheduler.TimerQueue.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/LocalScheduler.TimerQueue.cs
@@ -461,7 +461,7 @@ namespace System.Reactive.Concurrency
 
             public int CompareTo(WorkItem? other) => Comparer<DateTimeOffset>.Default.Compare(DueTime, other!.DueTime);
 
-            public void Dispose() => Disposable.TryDispose(ref _disposable);
+            public void Dispose() => Disposable.Dispose(ref _disposable);
         }
 
         /// <summary>

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/ScheduledItem.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/ScheduledItem.cs
@@ -146,7 +146,7 @@ namespace System.Reactive.Concurrency
         /// <summary>
         /// Cancels the work item by disposing the resource returned by <see cref="InvokeCore"/> as soon as possible.
         /// </summary>
-        public void Cancel() => Disposable.TryDispose(ref _disposable);
+        public void Cancel() => Disposable.Dispose(ref _disposable);
 
         /// <summary>
         /// Gets whether the work item has received a cancellation request.

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/Scheduler.Async.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/Scheduler.Async.cs
@@ -38,7 +38,7 @@ namespace System.Reactive.Concurrency
             public void Dispose()
             {
                 _cts.Cancel();
-                Disposable.TryDispose(ref _run);
+                Disposable.Dispose(ref _run);
             }
         }
 

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/Scheduler.Services.Emulation.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/Scheduler.Services.Emulation.cs
@@ -383,7 +383,7 @@ namespace System.Reactive.Concurrency
 
             void IDisposable.Dispose()
             {
-                Disposable.TryDispose(ref _task);
+                Disposable.Dispose(ref _task);
                 Cancel();
             }
 

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/Synchronization.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/Synchronization.cs
@@ -64,7 +64,7 @@ namespace System.Reactive.Concurrency
 
                 public void Dispose()
                 {
-                    Disposable.TryDispose(ref _cancel);
+                    Disposable.Dispose(ref _cancel);
                 }
             }
 
@@ -138,7 +138,7 @@ namespace System.Reactive.Concurrency
 
                 public void Dispose()
                 {
-                    Disposable.TryDispose(ref _cancel);
+                    Disposable.Dispose(ref _cancel);
                 }
             }
 

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/TaskPoolScheduler.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/TaskPoolScheduler.cs
@@ -68,7 +68,7 @@ namespace System.Reactive.Concurrency
 
             public void Dispose()
             {
-                Disposable.TryDispose(ref _cancel);
+                Disposable.Dispose(ref _cancel);
             }
         }
 
@@ -107,7 +107,7 @@ namespace System.Reactive.Concurrency
 
             public void Dispose()
             {
-                Disposable.TryDispose(ref _cancel);
+                Disposable.Dispose(ref _cancel);
             }
         }
 
@@ -141,7 +141,7 @@ namespace System.Reactive.Concurrency
 
             public void Dispose()
             {
-                Disposable.TryDispose(ref _cancel);
+                Disposable.Dispose(ref _cancel);
             }
 
             public bool IsDisposed => Disposable.GetIsDisposed(ref _cancel);

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/UserWorkItem.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/UserWorkItem.cs
@@ -38,8 +38,8 @@ namespace System.Reactive.Concurrency
 
         public void Dispose()
         {
-            Disposable.TryDispose(ref _cancelQueueDisposable);
-            Disposable.TryDispose(ref _cancelRunDisposable);
+            Disposable.Dispose(ref _cancelQueueDisposable);
+            Disposable.Dispose(ref _cancelRunDisposable);
         }
     }
 }

--- a/Rx.NET/Source/src/System.Reactive/Disposables/AnonymousDisposable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/AnonymousDisposable.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
-#nullable disable
-
 using System.Threading;
 
 namespace System.Reactive.Disposables
@@ -13,7 +11,7 @@ namespace System.Reactive.Disposables
     /// </summary>
     internal sealed class AnonymousDisposable : ICancelable
     {
-        private volatile Action _dispose;
+        private volatile Action? _dispose;
 
         /// <summary>
         /// Constructs a new disposable with the given action used for disposal.
@@ -46,7 +44,7 @@ namespace System.Reactive.Disposables
     internal sealed class AnonymousDisposable<TState> : ICancelable
     {
         private TState _state;
-        private volatile Action<TState> _dispose;
+        private volatile Action<TState>? _dispose;
 
         /// <summary>
         /// Constructs a new disposable with the given action used for disposal.
@@ -72,7 +70,7 @@ namespace System.Reactive.Disposables
         public void Dispose()
         {
             Interlocked.Exchange(ref _dispose, null)?.Invoke(_state);
-            _state = default;
+            _state = default!;
         }
     }
 }

--- a/Rx.NET/Source/src/System.Reactive/Disposables/Disposable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/Disposable.cs
@@ -240,6 +240,19 @@ namespace System.Reactive.Disposables
             return true;
         }
 
+        /// <summary>
+        /// Disposes <paramref name="fieldRef" />. 
+        /// </summary>
+        internal static void Dispose(ref IDisposable fieldRef)
+        {
+            var old = Interlocked.Exchange(ref fieldRef, BooleanDisposable.True);
+
+            if (old != BooleanDisposable.True)
+            {
+                old?.Dispose();
+            }
+        }
+
         internal static bool TryRelease<TState>(ref IDisposable fieldRef, TState state, Action<IDisposable, TState> disposeAction)
         {
             var old = Interlocked.Exchange(ref fieldRef, BooleanDisposable.True);

--- a/Rx.NET/Source/src/System.Reactive/Disposables/MultipleAssignmentDisposable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/MultipleAssignmentDisposable.cs
@@ -41,7 +41,7 @@ namespace System.Reactive.Disposables
         /// </summary>
         public void Dispose()
         {
-            Disposables.Disposable.TryDispose(ref _current);
+            Disposables.Disposable.Dispose(ref _current);
         }
     }
 }

--- a/Rx.NET/Source/src/System.Reactive/Disposables/ScheduledDisposable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/ScheduledDisposable.cs
@@ -50,6 +50,6 @@ namespace System.Reactive.Disposables
         /// <summary>
         /// Disposes the wrapped disposable on the provided scheduler.
         /// </summary>
-        public void Dispose() => Scheduler.ScheduleAction(this, scheduler => Disposables.Disposable.TryDispose(ref scheduler._disposable));
+        public void Dispose() => Scheduler.ScheduleAction(this, scheduler => Disposables.Disposable.Dispose(ref scheduler._disposable));
     }
 }

--- a/Rx.NET/Source/src/System.Reactive/Disposables/SerialDisposable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/SerialDisposable.cs
@@ -41,7 +41,7 @@ namespace System.Reactive.Disposables
         /// </summary>
         public void Dispose()
         {
-            Disposables.Disposable.TryDispose(ref _current);
+            Disposables.Disposable.Dispose(ref _current);
         }
     }
 }

--- a/Rx.NET/Source/src/System.Reactive/Disposables/SingleAssignmentDisposable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/SingleAssignmentDisposable.cs
@@ -42,7 +42,7 @@ namespace System.Reactive.Disposables
         /// </summary>
         public void Dispose()
         {
-            Disposables.Disposable.TryDispose(ref _current);
+            Disposables.Disposable.Dispose(ref _current);
         }
     }
 }

--- a/Rx.NET/Source/src/System.Reactive/Disposables/StableCompositeDisposable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/StableCompositeDisposable.cs
@@ -105,8 +105,8 @@ namespace System.Reactive.Disposables
 
             public override void Dispose()
             {
-                Disposable.TryDispose(ref _disposable1);
-                Disposable.TryDispose(ref _disposable2);
+                Disposable.Dispose(ref _disposable1);
+                Disposable.Dispose(ref _disposable2);
             }
         }
 

--- a/Rx.NET/Source/src/System.Reactive/Internal/AutoDetachObserver.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/AutoDetachObserver.cs
@@ -100,7 +100,7 @@ namespace System.Reactive
 
             if (disposing)
             {
-                Disposable.TryDispose(ref _disposable);
+                Disposable.Dispose(ref _disposable);
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Internal/SafeObserver.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/SafeObserver.cs
@@ -88,7 +88,7 @@ namespace System.Reactive
         {
             if (disposing)
             {
-                Disposable.TryDispose(ref _disposable);
+                Disposable.Dispose(ref _disposable);
             }
         }
     }

--- a/Rx.NET/Source/src/System.Reactive/Internal/ScheduledObserver.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/ScheduledObserver.cs
@@ -317,7 +317,7 @@ namespace System.Reactive
 
             if (disposing)
             {
-                Disposable.TryDispose(ref _disposable);
+                Disposable.Dispose(ref _disposable);
             }
         }
     }
@@ -361,7 +361,7 @@ namespace System.Reactive
 
             if (disposing)
             {
-                Disposable.TryDispose(ref _run);
+                Disposable.Dispose(ref _run);
             }
         }
     }
@@ -423,7 +423,7 @@ namespace System.Reactive
             base.Dispose(disposing);
             if (disposing)
             {
-                Disposable.TryDispose(ref _task);
+                Disposable.Dispose(ref _task);
                 Clear(_queue);
             }
         }
@@ -689,7 +689,7 @@ namespace System.Reactive
                 Monitor.Pulse(_suspendGuard);
             }
             // Cancel the drain task handle.
-            Disposable.TryDispose(ref _drainTask);
+            Disposable.Dispose(ref _drainTask);
             base.Dispose(disposing);
         }
 

--- a/Rx.NET/Source/src/System.Reactive/Internal/Sink.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/Sink.cs
@@ -41,7 +41,7 @@ namespace System.Reactive
             //Sink is internal so this can pretty much be enforced.
             //_observer = NopObserver<TTarget>.Instance;
 
-            Disposable.TryDispose(ref _upstream);
+            Disposable.Dispose(ref _upstream);
         }
 
         public void ForwardOnNext(TTarget value)
@@ -68,7 +68,7 @@ namespace System.Reactive
 
         protected void DisposeUpstream()
         {
-            Disposable.TryDispose(ref _upstream);
+            Disposable.Dispose(ref _upstream);
         }
     }
 

--- a/Rx.NET/Source/src/System.Reactive/Internal/TailRecursiveSink.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/TailRecursiveSink.cs
@@ -60,7 +60,7 @@ namespace System.Reactive
                         enumerator.Dispose();
                     }
 
-                    Disposable.TryDispose(ref _currentSubscription);
+                    Disposable.Dispose(ref _currentSubscription);
                 }
                 else
                 {

--- a/Rx.NET/Source/src/System.Reactive/Joins/JoinObserver.cs
+++ b/Rx.NET/Source/src/System.Reactive/Joins/JoinObserver.cs
@@ -95,7 +95,7 @@ namespace System.Reactive.Joins
             {
                 if (disposing)
                 {
-                    Disposable.TryDispose(ref _subscription);
+                    Disposable.Dispose(ref _subscription);
                 }
 
                 _isDisposed = true;

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/AppendPrepend.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/AppendPrepend.cs
@@ -155,7 +155,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (disposing)
                     {
-                        Disposable.TryDispose(ref _schedulerDisposable);
+                        Disposable.Dispose(ref _schedulerDisposable);
                     }
                     base.Dispose(disposing);
                 }
@@ -404,7 +404,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (disposing)
                     {
-                        Disposable.TryDispose(ref _schedulerDisposable);
+                        Disposable.Dispose(ref _schedulerDisposable);
                     }
 
                     base.Dispose(disposing);

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Buffer.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Buffer.cs
@@ -301,7 +301,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (disposing)
                     {
-                        Disposable.TryDispose(ref _timerSerial);
+                        Disposable.Dispose(ref _timerSerial);
                     }
                     base.Dispose(disposing);
                 }
@@ -459,7 +459,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (disposing)
                     {
-                        Disposable.TryDispose(ref _periodicDisposable);
+                        Disposable.Dispose(ref _periodicDisposable);
                     }
                     base.Dispose(disposing);
                 }
@@ -552,7 +552,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (disposing)
                     {
-                        Disposable.TryDispose(ref _timerSerial);
+                        Disposable.Dispose(ref _timerSerial);
                     }
                     base.Dispose(disposing);
                 }
@@ -679,7 +679,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (disposing)
                     {
-                        Disposable.TryDispose(ref _bufferClosingSerialDisposable);
+                        Disposable.Dispose(ref _bufferClosingSerialDisposable);
                     }
                     base.Dispose(disposing);
                 }
@@ -811,7 +811,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (disposing)
                     {
-                        Disposable.TryDispose(ref _boundariesDisposable);
+                        Disposable.Dispose(ref _boundariesDisposable);
                     }
                     base.Dispose(disposing);
                 }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Catch.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Catch.cs
@@ -110,7 +110,7 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (disposing)
                 {
-                    Disposable.TryDispose(ref _subscription);
+                    Disposable.Dispose(ref _subscription);
                 }
                 base.Dispose(disposing);
             }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/CombineLatest.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/CombineLatest.cs
@@ -63,8 +63,8 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (disposing)
                 {
-                    Disposable.TryDispose(ref _firstDisposable);
-                    Disposable.TryDispose(ref _secondDisposable);
+                    Disposable.Dispose(ref _firstDisposable);
+                    Disposable.Dispose(ref _secondDisposable);
                 }
                 base.Dispose(disposing);
             }
@@ -134,7 +134,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         }
                         else
                         {
-                            Disposable.TryDispose(ref _parent._firstDisposable);
+                            Disposable.Dispose(ref _parent._firstDisposable);
                         }
                     }
                 }
@@ -205,7 +205,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         }
                         else
                         {
-                            Disposable.TryDispose(ref _parent._secondDisposable);
+                            Disposable.Dispose(ref _parent._secondDisposable);
                         }
                     }
                 }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/ConcatMany.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/ConcatMany.cs
@@ -62,7 +62,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             private void DisposeMain()
             {
-                Disposable.TryDispose(ref _upstream);
+                Disposable.Dispose(ref _upstream);
             }
 
             private bool IsDisposed()
@@ -204,7 +204,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public void Dispose()
                 {
-                    Disposable.TryDispose(ref Upstream);
+                    Disposable.Dispose(ref Upstream);
                 }
 
                 public void OnCompleted()

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Delay.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Delay.cs
@@ -75,7 +75,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                     if (disposing)
                     {
-                        Disposable.TryDispose(ref _cancelable);
+                        Disposable.Dispose(ref _cancelable);
                     }
                 }
 
@@ -280,7 +280,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                     if (disposing)
                     {
-                        Disposable.TryDispose(ref _cancelable);
+                        Disposable.Dispose(ref _cancelable);
                     }
                 }
 
@@ -616,7 +616,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (disposing)
                     {
-                        Disposable.TryDispose(ref _subscription);
+                        Disposable.Dispose(ref _subscription);
                         _delays.Dispose();
                     }
                     base.Dispose(disposing);
@@ -659,7 +659,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     lock (_gate)
                     {
                         _atEnd = true;
-                        Disposable.TryDispose(ref _subscription);
+                        Disposable.Dispose(ref _subscription);
 
                         CheckDone();
                     }
@@ -808,7 +808,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                     public void Dispose()
                     {
-                        Disposable.TryDispose(ref _subscription);
+                        Disposable.Dispose(ref _subscription);
                     }
                 }
             }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Generate.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Generate.cs
@@ -210,7 +210,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 protected override void Dispose(bool disposing)
                 {
-                    Disposable.TryDispose(ref _timerDisposable);
+                    Disposable.Dispose(ref _timerDisposable);
                     base.Dispose(disposing);
                 }
 
@@ -319,7 +319,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 protected override void Dispose(bool disposing)
                 {
-                    Disposable.TryDispose(ref _timerDisposable);
+                    Disposable.Dispose(ref _timerDisposable);
                     base.Dispose(disposing);
                 }
 

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/GetEnumerator.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/GetEnumerator.cs
@@ -47,14 +47,14 @@ namespace System.Reactive.Linq.ObservableImpl
         public void OnError(Exception error)
         {
             _error = error;
-            Disposable.TryDispose(ref _subscription);
+            Disposable.Dispose(ref _subscription);
             _gate.Release();
         }
 
         public void OnCompleted()
         {
             _done = true;
-            Disposable.TryDispose(ref _subscription);
+            Disposable.Dispose(ref _subscription);
             _gate.Release();
         }
 
@@ -86,7 +86,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         public void Dispose()
         {
-            Disposable.TryDispose(ref _subscription);
+            Disposable.Dispose(ref _subscription);
 
             _disposed = true;
             _gate.Release();

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Multicast.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Multicast.cs
@@ -60,7 +60,7 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (disposing)
                 {
-                    Disposable.TryDispose(ref _connection);
+                    Disposable.Dispose(ref _connection);
                 }
                 
                 base.Dispose(disposing);

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/PushToPullAdapter.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/PushToPullAdapter.cs
@@ -75,7 +75,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         public void Dispose()
         {
-            Disposable.TryDispose(ref _upstream);
+            Disposable.Dispose(ref _upstream);
         }
 
         public void SetUpstream(IDisposable d)

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Range.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Range.cs
@@ -50,7 +50,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 base.Dispose(disposing);
                 if (disposing)
                 {
-                    Disposable.TryDispose(ref _task);
+                    Disposable.Dispose(ref _task);
                 }
             }
 

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/RefCount.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/RefCount.cs
@@ -115,7 +115,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         }
 
                         // disconnect
-                        Disposable.TryDispose(ref targetConnection._disposable);
+                        Disposable.Dispose(ref targetConnection._disposable);
                     }
                 }
             }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Repeat.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Repeat.cs
@@ -49,7 +49,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     base.Dispose(disposing);
                     if (disposing)
                     {
-                        Disposable.TryDispose(ref _task);
+                        Disposable.Dispose(ref _task);
                     }
                 }
 
@@ -151,7 +151,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     base.Dispose(disposing);
                     if (disposing)
                     {
-                        Disposable.TryDispose(ref _task);
+                        Disposable.Dispose(ref _task);
                     }
                 }
 

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/RepeatWhen.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/RepeatWhen.cs
@@ -81,8 +81,8 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (disposing)
                 {
-                    Disposable.TryDispose(ref _upstream);
-                    Disposable.TryDispose(ref HandlerUpstream);
+                    Disposable.Dispose(ref _upstream);
+                    Disposable.Dispose(ref HandlerUpstream);
                 }
                 base.Dispose(disposing);
             }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/RetryWhen.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/RetryWhen.cs
@@ -80,8 +80,8 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (disposing)
                 {
-                    Disposable.TryDispose(ref _upstream);
-                    Disposable.TryDispose(ref HandlerUpstream);
+                    Disposable.Dispose(ref _upstream);
+                    Disposable.Dispose(ref HandlerUpstream);
                 }
                 base.Dispose(disposing);
             }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Sample.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Sample.cs
@@ -52,8 +52,8 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (disposing)
                 {
-                    Disposable.TryDispose(ref _sourceDisposable);
-                    Disposable.TryDispose(ref _samplerDisposable);
+                    Disposable.Dispose(ref _sourceDisposable);
+                    Disposable.Dispose(ref _samplerDisposable);
                 }
                 base.Dispose(disposing);
             }
@@ -87,7 +87,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     else
                     {
-                        Disposable.TryDispose(ref _sourceDisposable);
+                        Disposable.Dispose(ref _sourceDisposable);
                     }
                 }
             }
@@ -145,7 +145,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         }
                         else
                         {
-                            Disposable.TryDispose(ref _parent._samplerDisposable);
+                            Disposable.Dispose(ref _parent._samplerDisposable);
                         }
                     }
                 }
@@ -196,7 +196,7 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (disposing)
                 {
-                    Disposable.TryDispose(ref _sourceDisposable);
+                    Disposable.Dispose(ref _sourceDisposable);
                 }
                 base.Dispose(disposing);
             }
@@ -240,7 +240,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 lock (_gate)
                 {
                     _atEnd = true;
-                    Disposable.TryDispose(ref _sourceDisposable);
+                    Disposable.Dispose(ref _sourceDisposable);
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/SequenceEqual.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/SequenceEqual.cs
@@ -60,7 +60,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (disposing)
                     {
-                        Disposable.TryDispose(ref _second);
+                        Disposable.Dispose(ref _second);
                     }
                     base.Dispose(disposing);
                 }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Skip.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Skip.cs
@@ -119,7 +119,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (disposing)
                     {
-                        Disposable.TryDispose(ref _sourceDisposable);
+                        Disposable.Dispose(ref _sourceDisposable);
                     }
                     base.Dispose(disposing);
                 }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/SkipUntil.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/SkipUntil.cs
@@ -48,7 +48,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (!Disposable.GetIsDisposed(ref _otherDisposable))
                     {
-                        Disposable.TryDispose(ref _otherDisposable);
+                        Disposable.Dispose(ref _otherDisposable);
                     }
                 }
 
@@ -98,7 +98,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (!Disposable.GetIsDisposed(ref _parent._otherDisposable))
                     {
-                        Disposable.TryDispose(ref _parent._otherDisposable);
+                        Disposable.Dispose(ref _parent._otherDisposable);
                     }
                 }
 
@@ -178,7 +178,7 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (disposing)
                 {
-                    Disposable.TryDispose(ref _task);
+                    Disposable.Dispose(ref _task);
                 }
                 base.Dispose(disposing);
             }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Switch.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Switch.cs
@@ -39,7 +39,7 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (disposing)
                 {
-                    Disposable.TryDispose(ref _innerSerialDisposable);
+                    Disposable.Dispose(ref _innerSerialDisposable);
                 }
 
                 base.Dispose(disposing);

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Take.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Take.cs
@@ -128,7 +128,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (disposing)
                     {
-                        Disposable.TryDispose(ref _task);
+                        Disposable.Dispose(ref _task);
                     }
                     base.Dispose(disposing);
                 }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/TakeLast.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/TakeLast.cs
@@ -49,7 +49,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (disposing)
                     {
-                        Disposable.TryDispose(ref _loopDisposable);
+                        Disposable.Dispose(ref _loopDisposable);
                     }
 
                     base.Dispose(disposing);
@@ -165,7 +165,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (disposing)
                     {
-                        Disposable.TryDispose(ref _loopDisposable);
+                        Disposable.Dispose(ref _loopDisposable);
                     }
                     base.Dispose(disposing);
                 }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/TakeUntil.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/TakeUntil.cs
@@ -47,7 +47,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (!Disposable.GetIsDisposed(ref _otherDisposable))
                     {
-                        Disposable.TryDispose(ref _otherDisposable);
+                        Disposable.Dispose(ref _otherDisposable);
                     }
                 }
 
@@ -81,7 +81,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 public void OnCompleted()
                 {
                     // Completion doesn't mean termination in Rx.NET for this operator
-                    Disposable.TryDispose(ref _parent._otherDisposable);
+                    Disposable.Dispose(ref _parent._otherDisposable);
                 }
 
                 public void OnError(Exception error)
@@ -155,7 +155,7 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (disposing)
                 {
-                    Disposable.TryDispose(ref _timerDisposable);
+                    Disposable.Dispose(ref _timerDisposable);
                 }
                 base.Dispose(disposing);
             }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Throttle.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Throttle.cs
@@ -48,7 +48,7 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (disposing)
                 {
-                    Disposable.TryDispose(ref _serialCancelable);
+                    Disposable.Dispose(ref _serialCancelable);
                 }
 
                 base.Dispose(disposing);
@@ -85,7 +85,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public override void OnError(Exception error)
             {
-                Disposable.TryDispose(ref _serialCancelable);
+                Disposable.Dispose(ref _serialCancelable);
 
                 lock (_gate)
                 {
@@ -98,7 +98,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public override void OnCompleted()
             {
-                Disposable.TryDispose(ref _serialCancelable);
+                Disposable.Dispose(ref _serialCancelable);
 
                 lock (_gate)
                 {
@@ -151,7 +151,7 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (disposing)
                 {
-                    Disposable.TryDispose(ref _serialCancelable);
+                    Disposable.Dispose(ref _serialCancelable);
                 }
                 base.Dispose(disposing);
             }
@@ -193,7 +193,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public override void OnError(Exception error)
             {
-                Disposable.TryDispose(ref _serialCancelable);
+                Disposable.Dispose(ref _serialCancelable);
 
                 lock (_gate)
                 {
@@ -206,7 +206,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             public override void OnCompleted()
             {
-                Disposable.TryDispose(ref _serialCancelable);
+                Disposable.Dispose(ref _serialCancelable);
 
                 lock (_gate)
                 {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Timeout.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Timeout.cs
@@ -60,9 +60,9 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (disposing)
                     {
-                        Disposable.TryDispose(ref _mainDisposable);
-                        Disposable.TryDispose(ref _otherDisposable);
-                        Disposable.TryDispose(ref _timerDisposable);
+                        Disposable.Dispose(ref _mainDisposable);
+                        Disposable.Dispose(ref _otherDisposable);
+                        Disposable.Dispose(ref _timerDisposable);
                     }
                     base.Dispose(disposing);
                 }
@@ -82,7 +82,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (Volatile.Read(ref _index) == idx && Interlocked.CompareExchange(ref _index, long.MaxValue, idx) == idx)
                     {
-                        Disposable.TryDispose(ref _mainDisposable);
+                        Disposable.Dispose(ref _mainDisposable);
 
                         var d = _other.Subscribe(GetForwarder());
 
@@ -110,7 +110,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (Interlocked.Exchange(ref _index, long.MaxValue) != long.MaxValue)
                     {
-                        Disposable.TryDispose(ref _timerDisposable);
+                        Disposable.Dispose(ref _timerDisposable);
 
                         ForwardOnError(error);
                     }
@@ -120,7 +120,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (Interlocked.Exchange(ref _index, long.MaxValue) != long.MaxValue)
                     {
-                        Disposable.TryDispose(ref _timerDisposable);
+                        Disposable.Dispose(ref _timerDisposable);
 
                         ForwardOnCompleted();
                     }
@@ -170,7 +170,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (disposing)
                     {
-                        Disposable.TryDispose(ref _serialDisposable);
+                        Disposable.Dispose(ref _serialDisposable);
                     }
                     base.Dispose(disposing);
                 }
@@ -260,8 +260,8 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (disposing)
                 {
-                    Disposable.TryDispose(ref _sourceDisposable);
-                    Disposable.TryDispose(ref _timerDisposable);
+                    Disposable.Dispose(ref _sourceDisposable);
+                    Disposable.Dispose(ref _timerDisposable);
                 }
                 base.Dispose(disposing);
             }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Using.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Using.cs
@@ -65,7 +65,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 if (disposing)
                 {
-                    Disposable.TryDispose(ref _disposable);
+                    Disposable.Dispose(ref _disposable);
                 }
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/WithLatestFrom.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/WithLatestFrom.cs
@@ -59,7 +59,7 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 if (disposing)
                 {
-                    Disposable.TryDispose(ref _secondDisposable);
+                    Disposable.Dispose(ref _secondDisposable);
                 }
                 base.Dispose(disposing);
             }
@@ -136,7 +136,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public void OnCompleted()
                 {
-                    Disposable.TryDispose(ref _parent._secondDisposable);
+                    Disposable.Dispose(ref _parent._secondDisposable);
                 }
 
                 public void OnError(Exception error)

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Zip.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Zip.cs
@@ -69,8 +69,8 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (disposing)
                     {
-                        Disposable.TryDispose(ref _firstDisposable);
-                        Disposable.TryDispose(ref _secondDisposable);
+                        Disposable.Dispose(ref _firstDisposable);
+                        Disposable.Dispose(ref _secondDisposable);
 
                         // clearing the queue should happen under the lock
                         // as they are plain Queue<T>s, not concurrent queues.
@@ -154,7 +154,7 @@ namespace System.Reactive.Linq.ObservableImpl
                             }
                             else
                             {
-                                Disposable.TryDispose(ref _parent._firstDisposable);
+                                Disposable.Dispose(ref _parent._firstDisposable);
                             }
                         }
                     }
@@ -236,7 +236,7 @@ namespace System.Reactive.Linq.ObservableImpl
                             }
                             else
                             {
-                                Disposable.TryDispose(ref _parent._secondDisposable);
+                                Disposable.Dispose(ref _parent._secondDisposable);
                             }
                         }
                     }
@@ -631,7 +631,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     {
                         for (var i = 0; i < subscriptions.Length; i++)
                         {
-                            Disposable.TryDispose(ref subscriptions[i]);
+                            Disposable.Dispose(ref subscriptions[i]);
                         }
 
                         lock (_gate)
@@ -694,7 +694,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         var subscriptions = Volatile.Read(ref _subscriptions);
                         if (subscriptions != null && subscriptions != Array.Empty<IDisposable>())
                         {
-                            Disposable.TryDispose(ref subscriptions[index]);
+                            Disposable.Dispose(ref subscriptions[index]);
                         }
                     }
                 }

--- a/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Creation.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Creation.cs
@@ -150,7 +150,7 @@ namespace System.Reactive.Linq
 
                     public void Dispose()
                     {
-                        Disposable.TryDispose(ref _disposable);
+                        Disposable.Dispose(ref _disposable);
                     }
 
                     public void OnCompleted()

--- a/Rx.NET/Source/src/System.Reactive/Subjects/Subject.cs
+++ b/Rx.NET/Source/src/System.Reactive/Subjects/Subject.cs
@@ -61,7 +61,7 @@ namespace System.Reactive.Subjects
 
         #region IObserver<T> implementation
 
-        private void ThrowDisposed()
+        private static void ThrowDisposed()
         {
             throw new ObjectDisposedException(string.Empty);
         }

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Disposables/DisposableTests.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Disposables/DisposableTests.cs
@@ -893,7 +893,7 @@ namespace ReactiveTests.Tests
         {
             var field = default(IDisposable);
 
-            Disposable.TryDispose(ref field);
+            Disposable.Dispose(ref field);
 
             var count = 0;
 


### PR DESCRIPTION
Don't need `TryDispose` if we never check the `bool` result.