### PR TITLE
Mark exception throwing helpers as DoesNotReturn.

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Internal/ExceptionServices.Default.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/ExceptionServices.Default.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.ExceptionServices;
 
 namespace System.Reactive.PlatformServices
@@ -13,6 +14,9 @@ namespace System.Reactive.PlatformServices
     //
     internal class DefaultExceptionServices/*Impl*/ : IExceptionServices
     {
+#pragma warning disable CS8763 // NB: On down-level platforms, Throw is not marked as DoesNotReturn.
+        [DoesNotReturn]
         public void Rethrow(Exception exception) => ExceptionDispatchInfo.Capture(exception).Throw();
+#pragma warning restore CS8763
     }
 }

--- a/Rx.NET/Source/src/System.Reactive/Internal/ExceptionServices.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/ExceptionServices.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information. 
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Reactive.PlatformServices;
 
 namespace System.Reactive
@@ -11,6 +12,7 @@ namespace System.Reactive
     {
         private static readonly Lazy<IExceptionServices> Services = new Lazy<IExceptionServices>(Initialize);
 
+        [DoesNotReturn]
         public static void Throw(this Exception exception) => Services.Value.Rethrow(exception);
 
         public static void ThrowIfNotNull(this Exception? exception)
@@ -46,6 +48,7 @@ namespace System.Reactive.PlatformServices
         /// Rethrows the specified exception.
         /// </summary>
         /// <param name="exception">Exception to rethrow.</param>
+        [DoesNotReturn]
         void Rethrow(Exception exception);
     }
 }

--- a/Rx.NET/Source/src/System.Reactive/Internal/ExceptionServicesImpl.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/ExceptionServicesImpl.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.ExceptionServices;
 
 namespace System.Reactive.PlatformServices
@@ -13,6 +14,9 @@ namespace System.Reactive.PlatformServices
     //
     internal class /*Default*/ExceptionServicesImpl : IExceptionServices
     {
+#pragma warning disable CS8763 // NB: On down-level platforms, Throw is not marked as DoesNotReturn.
+        [DoesNotReturn]
         public void Rethrow(Exception exception) => ExceptionDispatchInfo.Capture(exception).Throw();
+#pragma warning restore CS8763
     }
 }

--- a/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Api/ApiApprovalTests.Core.verified.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Api/ApiApprovalTests.Core.verified.cs
@@ -2408,6 +2408,7 @@ namespace System.Reactive.PlatformServices
     }
     public interface IExceptionServices
     {
+        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
         void Rethrow(System.Exception exception);
     }
     public interface IHostLifecycleNotifications


### PR DESCRIPTION
Helps with nullability tracking.