### PR TITLE
Enable #nullable for some more operators.

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/AppendPrepend.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/AppendPrepend.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
-#nullable disable
-
+using System.Diagnostics;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 
@@ -39,7 +38,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 var prev = new Node<TSource>(_value);
 
                 Node<TSource> appendNode;
-                Node<TSource> prependNode = null;
+                Node<TSource>? prependNode = null;
 
                 if (_append)
                 {
@@ -58,7 +57,7 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 var prev = new Node<TSource>(_value);
 
-                Node<TSource> appendNode = null;
+                Node<TSource>? appendNode = null;
                 Node<TSource> prependNode;
 
                 if (_append)
@@ -74,7 +73,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 return CreateAppendPrepend(prependNode, appendNode);
             }
 
-            private IAppendPrepend CreateAppendPrepend(Node<TSource> prepend, Node<TSource> append)
+            private IAppendPrepend CreateAppendPrepend(Node<TSource>? prepend, Node<TSource>? append)
             {
                 if (Scheduler is ISchedulerLongRunning longRunning)
                 {
@@ -106,7 +105,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 private readonly TSource _value;
                 private readonly IScheduler _scheduler;
                 private readonly bool _append;
-                private IDisposable _schedulerDisposable;
+                private IDisposable? _schedulerDisposable;
 
                 public _(SingleValue parent, IObserver<TSource> observer)
                     : base(observer)
@@ -165,12 +164,12 @@ namespace System.Reactive.Linq.ObservableImpl
         private sealed class Recursive : Producer<TSource, Recursive._>, IAppendPrepend
         {
             private readonly IObservable<TSource> _source;
-            private readonly Node<TSource> _appends;
-            private readonly Node<TSource> _prepends;
+            private readonly Node<TSource>? _appends;
+            private readonly Node<TSource>? _prepends;
 
             public IScheduler Scheduler { get; }
 
-            public Recursive(IObservable<TSource> source, Node<TSource> prepends, Node<TSource> appends, IScheduler scheduler)
+            public Recursive(IObservable<TSource> source, Node<TSource>? prepends, Node<TSource>? appends, IScheduler scheduler)
             {
                 _source = source;
                 _appends = appends;
@@ -201,11 +200,11 @@ namespace System.Reactive.Linq.ObservableImpl
             internal sealed class _ : IdentitySink<TSource>
             {
                 private readonly IObservable<TSource> _source;
-                private readonly Node<TSource> _appends;
+                private readonly Node<TSource>? _appends;
                 private readonly IScheduler _scheduler;
 
-                private Node<TSource> _currentPrependNode;
-                private TSource[] _appendArray;
+                private Node<TSource>? _currentPrependNode;
+                private TSource[]? _appendArray;
                 private int _currentAppendIndex;
                 private volatile bool _disposed;
 
@@ -230,7 +229,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         // We never allow the scheduled work to be cancelled. Instead, the _disposed flag
                         // is used to have PrependValues() bail out.
                         //
-                        _scheduler.Schedule(this, (innerScheduler, @this) => @this.PrependValues(innerScheduler));
+                        _scheduler.Schedule(this, static (innerScheduler, @this) => @this.PrependValues(innerScheduler));
                     }
                 }
 
@@ -243,11 +242,12 @@ namespace System.Reactive.Linq.ObservableImpl
                     else
                     {
                         _appendArray = _appends.ToReverseArray();
+
                         //
                         // We never allow the scheduled work to be cancelled. Instead, the _disposed flag
                         // is used to have `AppendValues` bail out.
                         //
-                        _scheduler.Schedule(this, (innerScheduler, @this) => @this.AppendValues(innerScheduler));
+                        _scheduler.Schedule(this, static (innerScheduler, @this) => @this.AppendValues(innerScheduler));
                     }
                 }
 
@@ -268,7 +268,9 @@ namespace System.Reactive.Linq.ObservableImpl
                         return Disposable.Empty;
                     }
 
-                    var current = _currentPrependNode.Value;
+                    Debug.Assert(_currentPrependNode != null);
+
+                    var current = _currentPrependNode!.Value;
                     ForwardOnNext(current);
 
                     _currentPrependNode = _currentPrependNode.Parent;
@@ -282,7 +284,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         // We never allow the scheduled work to be cancelled. Instead, the _disposed flag
                         // is used to have PrependValues() bail out.
                         //
-                        scheduler.Schedule(this, (innerScheduler, @this) => @this.PrependValues(innerScheduler));
+                        scheduler.Schedule(this, static (innerScheduler, @this) => @this.PrependValues(innerScheduler));
                     }
 
                     return Disposable.Empty;
@@ -295,7 +297,9 @@ namespace System.Reactive.Linq.ObservableImpl
                         return Disposable.Empty;
                     }
 
-                    var current = _appendArray[_currentAppendIndex];
+                    Debug.Assert(_appendArray != null);
+
+                    var current = _appendArray![_currentAppendIndex];
                     ForwardOnNext(current);
 
                     _currentAppendIndex++;
@@ -310,7 +314,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         // We never allow the scheduled work to be cancelled. Instead, the _disposed flag
                         // is used to have AppendValues() bail out.
                         //
-                        scheduler.Schedule(this, (innerScheduler, @this) => @this.AppendValues(innerScheduler));
+                        scheduler.Schedule(this, static (innerScheduler, @this) => @this.AppendValues(innerScheduler));
                     }
 
                     return Disposable.Empty;
@@ -321,13 +325,13 @@ namespace System.Reactive.Linq.ObservableImpl
         private sealed class LongRunning : Producer<TSource, LongRunning._>, IAppendPrepend
         {
             private readonly IObservable<TSource> _source;
-            private readonly Node<TSource> _appends;
-            private readonly Node<TSource> _prepends;
+            private readonly Node<TSource>? _appends;
+            private readonly Node<TSource>? _prepends;
             private readonly ISchedulerLongRunning _longRunningScheduler;
 
             public IScheduler Scheduler { get; }
 
-            public LongRunning(IObservable<TSource> source, Node<TSource> prepends, Node<TSource> appends, IScheduler scheduler, ISchedulerLongRunning longRunningScheduler)
+            public LongRunning(IObservable<TSource> source, Node<TSource>? prepends, Node<TSource>? appends, IScheduler scheduler, ISchedulerLongRunning longRunningScheduler)
             {
                 _source = source;
                 _appends = appends;
@@ -359,11 +363,11 @@ namespace System.Reactive.Linq.ObservableImpl
             internal sealed class _ : IdentitySink<TSource>
             {
                 private readonly IObservable<TSource> _source;
-                private readonly Node<TSource> _prepends; 
-                private readonly Node<TSource> _appends;
+                private readonly Node<TSource>? _prepends; 
+                private readonly Node<TSource>? _appends;
                 private readonly ISchedulerLongRunning _scheduler;
 
-                private IDisposable _schedulerDisposable;
+                private IDisposable? _schedulerDisposable;
 
                 public _(LongRunning parent, IObserver<TSource> observer)
                     : base(observer)
@@ -382,7 +386,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     else
                     {
-                        var disposable = _scheduler.ScheduleLongRunning(this, (@this, cancel) => @this.PrependValues(cancel));
+                        var disposable = _scheduler.ScheduleLongRunning(this, static (@this, cancel) => @this.PrependValues(cancel));
                         Disposable.TrySetSingle(ref _schedulerDisposable, disposable);
                     }
                 }
@@ -395,7 +399,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
                     else
                     {
-                        var disposable = _scheduler.ScheduleLongRunning(this, (@this, cancel) => @this.AppendValues(cancel));
+                        var disposable = _scheduler.ScheduleLongRunning(this, static (@this, cancel) => @this.AppendValues(cancel));
                         Disposable.TrySetSerial(ref _schedulerDisposable, disposable);
                     }
                 }
@@ -412,7 +416,9 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 private void PrependValues(ICancelable cancel)
                 {
-                    var current = _prepends;
+                    Debug.Assert(_prepends != null);
+
+                    var current = _prepends!;
 
                     while (!cancel.IsDisposed)
                     {
@@ -429,7 +435,9 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 private void AppendValues(ICancelable cancel)
                 {
-                    var array = _appends.ToReverseArray();
+                    Debug.Assert(_appends != null);
+
+                    var array = _appends!.ToReverseArray();
                     var i = 0;
 
                     while (!cancel.IsDisposed)
@@ -449,7 +457,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         private sealed class Node<T>
         {
-            public readonly Node<T> Parent;
+            public readonly Node<T>? Parent;
             public readonly T Value;
             public readonly int Count;
 
@@ -458,7 +466,7 @@ namespace System.Reactive.Linq.ObservableImpl
             {
             }
 
-            public Node(Node<T> parent, T value)
+            public Node(Node<T>? parent, T value)
             {
                 Parent = parent;
                 Value = value;
@@ -484,7 +492,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 var current = this;
                 for (var i = Count - 1; i >= 0; i--)
                 {
-                    array[i] = current.Value;
+                    array[i] = current!.Value; // NB: Count property ensures non-nullability.
                     current = current.Parent;
                 }
                 return array;

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Sample.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Sample.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
-#nullable disable
-
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 
@@ -33,11 +31,11 @@ namespace System.Reactive.Linq.ObservableImpl
             {
             }
 
-            private IDisposable _sourceDisposable;
-            private IDisposable _samplerDisposable;
+            private IDisposable? _sourceDisposable;
+            private IDisposable? _samplerDisposable;
 
             private bool _hasValue;
-            private TSource _value;
+            private TSource? _value;
             private bool _sourceAtEnd;
             private bool _samplerAtEnd;
 
@@ -55,6 +53,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     Disposable.Dispose(ref _sourceDisposable);
                     Disposable.Dispose(ref _samplerDisposable);
                 }
+
                 base.Dispose(disposing);
             }
 
@@ -108,7 +107,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         if (_parent._hasValue)
                         {
                             _parent._hasValue = false;
-                            _parent.ForwardOnNext(_parent._value);
+                            _parent.ForwardOnNext(_parent._value!);
                         }
 
                         if (_parent._sourceAtEnd)
@@ -136,7 +135,7 @@ namespace System.Reactive.Linq.ObservableImpl
                         if (_parent._hasValue)
                         {
                             _parent._hasValue = false;
-                            _parent.ForwardOnNext(_parent._value);
+                            _parent.ForwardOnNext(_parent._value!);
                         }
 
                         if (_parent._sourceAtEnd)
@@ -179,10 +178,10 @@ namespace System.Reactive.Linq.ObservableImpl
             {
             }
 
-            private IDisposable _sourceDisposable;
+            private IDisposable? _sourceDisposable;
 
             private bool _hasValue;
-            private TSource _value;
+            private TSource? _value;
             private bool _atEnd;
 
             public void Run(Sample<TSource> parent)
@@ -198,6 +197,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     Disposable.Dispose(ref _sourceDisposable);
                 }
+
                 base.Dispose(disposing);
             }
 
@@ -208,7 +208,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     if (_hasValue)
                     {
                         _hasValue = false;
-                        ForwardOnNext(_value);
+                        ForwardOnNext(_value!);
                     }
 
                     if (_atEnd)

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/SelectMany.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/SelectMany.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Reactive.Disposables;
 using System.Threading;
@@ -419,7 +417,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                             if (hasNext)
                             {
-                                ForwardOnNext(current);
+                                ForwardOnNext(current!);
                             }
                         }
                     }
@@ -510,7 +508,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                             if (hasNext)
                             {
-                                ForwardOnNext(current);
+                                ForwardOnNext(current!);
                             }
                         }
                     }
@@ -1373,7 +1371,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                             if (hasNext)
                             {
-                                ForwardOnNext(current);
+                                ForwardOnNext(current!);
                             }
                         }
                     }
@@ -1456,7 +1454,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                             if (hasNext)
                             {
-                                ForwardOnNext(current);
+                                ForwardOnNext(current!);
                             }
                         }
                     }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Switch.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Switch.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
-#nullable disable
-
 using System.Reactive.Disposables;
 
 namespace System.Reactive.Linq.ObservableImpl
@@ -30,7 +28,7 @@ namespace System.Reactive.Linq.ObservableImpl
             {
             }
 
-            private IDisposable _innerSerialDisposable;
+            private IDisposable? _innerSerialDisposable;
             private bool _isStopped;
             private ulong _latest;
             private bool _hasLatest;

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Throttle.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Throttle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
-#nullable disable
-
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 
@@ -28,6 +26,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         internal sealed class _ : IdentitySink<TSource>
         {
+            private readonly object _gate = new object();
             private readonly TimeSpan _dueTime;
             private readonly IScheduler _scheduler;
 
@@ -38,10 +37,9 @@ namespace System.Reactive.Linq.ObservableImpl
                 _scheduler = parent._scheduler;
             }
 
-            private readonly object _gate = new object();
-            private TSource _value;
+            private TSource? _value;
             private bool _hasValue;
-            private IDisposable _serialCancelable;
+            private IDisposable? _serialCancelable;
             private ulong _id;
 
             protected override void Dispose(bool disposing)
@@ -76,7 +74,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (_hasValue && _id == currentid)
                     {
-                        ForwardOnNext(_value);
+                        ForwardOnNext(_value!);
                     }
 
                     _hasValue = false;
@@ -104,7 +102,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (_hasValue)
                     {
-                        ForwardOnNext(_value);
+                        ForwardOnNext(_value!);
                     }
 
                     ForwardOnCompleted();
@@ -133,6 +131,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
         internal sealed class _ : IdentitySink<TSource>
         {
+            private readonly object _gate = new object();
             private readonly Func<TSource, IObservable<TThrottle>> _throttleSelector;
 
             public _(Throttle<TSource, TThrottle> parent, IObserver<TSource> observer)
@@ -141,10 +140,9 @@ namespace System.Reactive.Linq.ObservableImpl
                 _throttleSelector = parent._throttleSelector;
             }
 
-            private readonly object _gate = new object();
-            private TSource _value;
+            private TSource? _value;
             private bool _hasValue;
-            private IDisposable _serialCancelable;
+            private IDisposable? _serialCancelable;
             private ulong _id;
 
             protected override void Dispose(bool disposing)
@@ -153,6 +151,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     Disposable.Dispose(ref _serialCancelable);
                 }
+
                 base.Dispose(disposing);
             }
 
@@ -212,7 +211,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (_hasValue)
                     {
-                        ForwardOnNext(_value);
+                        ForwardOnNext(_value!);
                     }
 
                     ForwardOnCompleted();


### PR DESCRIPTION
Enabling for 8 more operators. Most notable suppressions with `!` are for the "if `hasValue` then use `value`" pattern.

Progress to 0 suppressions: `25/337` left