### PR TITLE
Enable #nullable for Group/Join family of operators.

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Internal/Grouping.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/Grouping.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT License.
+// See the LICENSE file in the project root for more information. 
+
+#nullable disable
+
+using System.Collections.Generic;
+using System.Reactive.Subjects;
+
+namespace System.Reactive
+{
+    internal sealed class Grouping<TKey, TElement> : Dictionary<TKey, Subject<TElement>>
+    {
+        public Grouping(IEqualityComparer<TKey> comparer)
+            : base(comparer)
+        {
+        }
+
+        public Grouping(int capacity, IEqualityComparer<TKey> comparer)
+            : base(capacity, comparer)
+        {
+        }
+    }
+}

--- a/Rx.NET/Source/src/System.Reactive/Internal/Map.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/Map.cs
@@ -1,0 +1,78 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace System.Reactive
+{
+    internal sealed class Map<TKey, TValue>
+    {
+        // Taken from ConcurrentDictionary in the BCL.
+
+        // The default concurrency level is DEFAULT_CONCURRENCY_MULTIPLIER * #CPUs. The higher the
+        // DEFAULT_CONCURRENCY_MULTIPLIER, the more concurrent writes can take place without interference
+        // and blocking, but also the more expensive operations that require all locks become (e.g. table
+        // resizing, ToArray, Count, etc). According to brief benchmarks that we ran, 4 seems like a good
+        // compromise.
+        private const int DefaultConcurrencyMultiplier = 4;
+
+        private static int DefaultConcurrencyLevel => DefaultConcurrencyMultiplier * Environment.ProcessorCount;
+
+        private readonly ConcurrentDictionary<TKey, TValue> _map;
+
+        public Map(int? capacity, IEqualityComparer<TKey> comparer)
+        {
+            if (capacity.HasValue)
+            {
+                _map = new ConcurrentDictionary<TKey, TValue>(DefaultConcurrencyLevel, capacity.Value, comparer);
+            }
+            else
+            {
+                _map = new ConcurrentDictionary<TKey, TValue>(comparer);
+            }
+        }
+
+        public TValue GetOrAdd(TKey key, Func<TValue> valueFactory, out bool added)
+        {
+            added = false;
+
+            TValue value;
+            var newValue = default(TValue);
+            var hasNewValue = false;
+            while (true)
+            {
+                if (_map.TryGetValue(key, out value))
+                {
+                    break;
+                }
+
+                if (!hasNewValue)
+                {
+                    newValue = valueFactory();
+                    hasNewValue = true;
+                }
+
+                if (_map.TryAdd(key, newValue))
+                {
+                    added = true;
+                    value = newValue;
+                    break;
+                }
+            }
+
+            return value;
+        }
+
+        public IEnumerable<TValue> Values => _map.Values.ToArray();
+
+        public bool Remove(TKey key)
+        {
+            return _map.TryRemove(key, out _);
+        }
+    }
+}

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/GroupBy.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/GroupBy.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Reactive.Disposables;
 using System.Reactive.Subjects;
@@ -35,10 +33,10 @@ namespace System.Reactive.Linq.ObservableImpl
         {
             private readonly Func<TSource, TKey> _keySelector;
             private readonly Func<TSource, TElement> _elementSelector;
-            private readonly Dictionary<TKey, Subject<TElement>> _map;
+            private readonly Grouping<TKey, TElement> _map;
 
-            private RefCountDisposable _refCountDisposable;
-            private Subject<TElement> _null;
+            private RefCountDisposable? _refCountDisposable;
+            private Subject<TElement>? _null;
 
             public _(GroupBy<TSource, TKey, TElement> parent, IObserver<IGroupedObservable<TKey, TElement>> observer)
                 : base(observer)
@@ -48,11 +46,11 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 if (parent._capacity.HasValue)
                 {
-                    _map = new Dictionary<TKey, Subject<TElement>>(parent._capacity.Value, parent._comparer);
+                    _map = new Grouping<TKey, TElement>(parent._capacity.Value, parent._comparer);
                 }
                 else
                 {
-                    _map = new Dictionary<TKey, Subject<TElement>>(parent._comparer);
+                    _map = new Grouping<TKey, TElement>(parent._comparer);
                 }
             }
 
@@ -79,7 +77,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
 
                 var fireNewMapEntry = false;
-                Subject<TElement> writer;
+                Subject<TElement>? writer;
                 try
                 {
                     //
@@ -128,7 +126,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 if (fireNewMapEntry)
                 {
-                    var group = new GroupedObservable<TKey, TElement>(key, writer, _refCountDisposable);
+                    var group = new GroupedObservable<TKey, TElement>(key, writer, _refCountDisposable!); // NB: _refCountDisposable is set in Run.
                     ForwardOnNext(group);
                 }
 

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/GroupByUntil.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/GroupByUntil.cs
@@ -2,11 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
-#nullable disable
-
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reactive.Disposables;
 using System.Reactive.Subjects;
 
@@ -47,7 +43,7 @@ namespace System.Reactive.Linq.ObservableImpl
             private readonly Func<TSource, TElement> _elementSelector;
             private readonly Func<IGroupedObservable<TKey, TElement>, IObservable<TDuration>> _durationSelector;
 
-            private ISubject<TElement> _null;
+            private ISubject<TElement>? _null;
 
             public _(GroupByUntil<TSource, TKey, TElement, TDuration> parent, IObserver<IGroupedObservable<TKey, TElement>> observer)
                 : base(observer)
@@ -210,7 +206,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (_key == null)
                     {
-                        ISubject<TElement> @null;
+                        ISubject<TElement>? @null;
 
                         lock (_parent._nullGate)
                         {
@@ -218,7 +214,7 @@ namespace System.Reactive.Linq.ObservableImpl
                             _parent._null = null;
                         }
 
-                        @null.OnCompleted();
+                        @null?.OnCompleted();
                     }
                     else
                     {
@@ -244,7 +240,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 //       using Subject<T>. It will transition into a terminal state, making one
                 //       of the two calls a no-op by swapping in a DoneObserver<T>.
                 //
-                ISubject<TElement> @null;
+                ISubject<TElement>? @null;
                 
                 lock (_nullGate)
                 {
@@ -271,7 +267,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 //       using Subject<T>. It will transition into a terminal state, making one
                 //       of the two calls a no-op by swapping in a DoneObserver<T>.
                 //
-                ISubject<TElement> @null;
+                ISubject<TElement>? @null;
 
                 lock (_nullGate)
                 {
@@ -290,72 +286,6 @@ namespace System.Reactive.Linq.ObservableImpl
                     ForwardOnError(exception);
                 }
             }
-        }
-    }
-
-    internal sealed class Map<TKey, TValue>
-    {
-        // Taken from ConcurrentDictionary in the BCL.
-
-        // The default concurrency level is DEFAULT_CONCURRENCY_MULTIPLIER * #CPUs. The higher the
-        // DEFAULT_CONCURRENCY_MULTIPLIER, the more concurrent writes can take place without interference
-        // and blocking, but also the more expensive operations that require all locks become (e.g. table
-        // resizing, ToArray, Count, etc). According to brief benchmarks that we ran, 4 seems like a good
-        // compromise.
-        private const int DefaultConcurrencyMultiplier = 4;
-
-        private static int DefaultConcurrencyLevel => DefaultConcurrencyMultiplier * Environment.ProcessorCount;
-
-        private readonly ConcurrentDictionary<TKey, TValue> _map;
-
-        public Map(int? capacity, IEqualityComparer<TKey> comparer)
-        {
-            if (capacity.HasValue)
-            {
-                _map = new ConcurrentDictionary<TKey, TValue>(DefaultConcurrencyLevel, capacity.Value, comparer);
-            }
-            else
-            {
-                _map = new ConcurrentDictionary<TKey, TValue>(comparer);
-            }
-        }
-
-        public TValue GetOrAdd(TKey key, Func<TValue> valueFactory, out bool added)
-        {
-            added = false;
-
-            TValue value;
-            var newValue = default(TValue);
-            var hasNewValue = false;
-            while (true)
-            {
-                if (_map.TryGetValue(key, out value))
-                {
-                    break;
-                }
-
-                if (!hasNewValue)
-                {
-                    newValue = valueFactory();
-                    hasNewValue = true;
-                }
-
-                if (_map.TryAdd(key, newValue))
-                {
-                    added = true;
-                    value = newValue;
-                    break;
-                }
-            }
-
-            return value;
-        }
-
-        public IEnumerable<TValue> Values => _map.Values.ToArray();
-
-        public bool Remove(TKey key)
-        {
-            return _map.TryRemove(key, out _);
         }
     }
 }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/GroupJoin.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/GroupJoin.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Reactive.Disposables;
 using System.Reactive.Subjects;

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Join.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Join.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Reactive.Disposables;
 


### PR DESCRIPTION
Moving a little back and forth on these operators by cornering the `notnull` constraint suppression to separate files (`Map.cs`, `Lookup.cs`, `Grouping.cs`). We can later consider to absorb the `null` handling for these operators within these helpers, therefore encapsulating the `null`-checking logic that guards against passing a `null` key value to the underlying `[Concurrent]Dictionary<,>` instance.