### PR TITLE
Enable #nullable for some of the disposable types.

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Disposables/CancellationDisposable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/CancellationDisposable.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
-#nullable disable
-
 using System.Threading;
 
 namespace System.Reactive.Disposables

--- a/Rx.NET/Source/src/System.Reactive/Disposables/ContextDisposable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/ContextDisposable.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
-#nullable disable
-
 using System.Reactive.Concurrency;
 using System.Threading;
 

--- a/Rx.NET/Source/src/System.Reactive/Disposables/MultipleAssignmentDisposable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/MultipleAssignmentDisposable.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
-#nullable disable
-
-
 namespace System.Reactive.Disposables
 {
     /// <summary>
@@ -12,7 +9,7 @@ namespace System.Reactive.Disposables
     /// </summary>
     public sealed class MultipleAssignmentDisposable : ICancelable
     {
-        private IDisposable _current;
+        private IDisposable? _current;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MultipleAssignmentDisposable"/> class with no current underlying disposable.
@@ -30,7 +27,7 @@ namespace System.Reactive.Disposables
         /// Gets or sets the underlying disposable. After disposal, the result of getting this property is undefined.
         /// </summary>
         /// <remarks>If the <see cref="MultipleAssignmentDisposable"/> has already been disposed, assignment to this property causes immediate disposal of the given disposable object.</remarks>
-        public IDisposable Disposable
+        public IDisposable? Disposable
         {
             get => Disposables.Disposable.GetValueOrDefault(ref _current);
             set => Disposables.Disposable.TrySetMultiple(ref _current, value);

--- a/Rx.NET/Source/src/System.Reactive/Disposables/RefCountDisposable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/RefCountDisposable.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
-#nullable disable
-
 using System.Threading;
 
 namespace System.Reactive.Disposables
@@ -14,7 +12,9 @@ namespace System.Reactive.Disposables
     public sealed class RefCountDisposable : ICancelable
     {
         private readonly bool _throwWhenDisposed;
-        private IDisposable _disposable;
+
+        private IDisposable? _disposable;
+
         /// <summary>
         /// Holds the number of active child disposables and the
         /// indicator bit (31) if the main _disposable has been marked
@@ -167,7 +167,7 @@ namespace System.Reactive.Disposables
 
         private sealed class InnerDisposable : IDisposable
         {
-            private RefCountDisposable _parent;
+            private RefCountDisposable? _parent;
 
             public InnerDisposable(RefCountDisposable parent)
             {

--- a/Rx.NET/Source/src/System.Reactive/Disposables/ScheduledDisposable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/ScheduledDisposable.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
-#nullable disable
-
 using System.Reactive.Concurrency;
 
 namespace System.Reactive.Disposables

--- a/Rx.NET/Source/src/System.Reactive/Disposables/SerialDisposable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/SerialDisposable.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
-#nullable disable
-
-
 namespace System.Reactive.Disposables
 {
     /// <summary>
@@ -12,7 +9,7 @@ namespace System.Reactive.Disposables
     /// </summary>
     public sealed class SerialDisposable : ICancelable
     {
-        private IDisposable _current;
+        private IDisposable? _current;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="T:System.Reactive.Disposables.SerialDisposable"/> class.
@@ -30,7 +27,7 @@ namespace System.Reactive.Disposables
         /// Gets or sets the underlying disposable.
         /// </summary>
         /// <remarks>If the SerialDisposable has already been disposed, assignment to this property causes immediate disposal of the given disposable object. Assigning this property disposes the previous disposable object.</remarks>
-        public IDisposable Disposable
+        public IDisposable? Disposable
         {
             get => Disposables.Disposable.GetValue(ref _current);
             set => Disposables.Disposable.TrySetSerial(ref _current, value);

--- a/Rx.NET/Source/src/System.Reactive/Disposables/SingleAssignmentDisposable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/SingleAssignmentDisposable.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
-#nullable disable
-
-
 namespace System.Reactive.Disposables
 {
     /// <summary>
@@ -13,7 +10,7 @@ namespace System.Reactive.Disposables
     /// </summary>
     public sealed class SingleAssignmentDisposable : ICancelable
     {
-        private IDisposable _current;
+        private IDisposable? _current;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SingleAssignmentDisposable"/> class.
@@ -31,7 +28,7 @@ namespace System.Reactive.Disposables
         /// Gets or sets the underlying disposable. After disposal, the result of getting this property is undefined.
         /// </summary>
         /// <exception cref="InvalidOperationException">Thrown if the <see cref="SingleAssignmentDisposable"/> has already been assigned to.</exception>
-        public IDisposable Disposable
+        public IDisposable? Disposable
         {
             get => Disposables.Disposable.GetValueOrDefault(ref _current);
             set => Disposables.Disposable.SetSingle(ref _current, value);

--- a/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Api/ApiApprovalTests.Core.verified.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Api/ApiApprovalTests.Core.verified.cs
@@ -598,7 +598,7 @@ namespace System.Reactive.Disposables
     public sealed class MultipleAssignmentDisposable : System.IDisposable, System.Reactive.Disposables.ICancelable
     {
         public MultipleAssignmentDisposable() { }
-        public System.IDisposable Disposable { get; set; }
+        public System.IDisposable? Disposable { get; set; }
         public bool IsDisposed { get; }
         public void Dispose() { }
     }
@@ -621,14 +621,14 @@ namespace System.Reactive.Disposables
     public sealed class SerialDisposable : System.IDisposable, System.Reactive.Disposables.ICancelable
     {
         public SerialDisposable() { }
-        public System.IDisposable Disposable { get; set; }
+        public System.IDisposable? Disposable { get; set; }
         public bool IsDisposed { get; }
         public void Dispose() { }
     }
     public sealed class SingleAssignmentDisposable : System.IDisposable, System.Reactive.Disposables.ICancelable
     {
         public SingleAssignmentDisposable() { }
-        public System.IDisposable Disposable { get; set; }
+        public System.IDisposable? Disposable { get; set; }
         public bool IsDisposed { get; }
         public void Dispose() { }
     }


### PR DESCRIPTION
First few `#nullable` introductions for disposable types. Note that `Disposable` properties on 3 of these types are now marked as `?` because they can return `null`.

More to come for the composite variants of disposables. The rub with all of these (and the query operators after inlining disposable logic everywhere) is that all the helper methods use `ref` parameters and often need to change to `IDisposable?` to be callable, but then the call site does not have a guarantee about assignment. So, for now, we're stuck with these helpers remaining null-oblivious.