### PR TITLE
Address flaky UI framework tests

### DIFF
--- a/Rx.NET/Source/tests/Tests.System.Reactive/WinFormsTestUtils.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/WinFormsTestUtils.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT License.
+// See the LICENSE file in the project root for more information. 
+
+#if HAS_WINFORMS
+
+using System;
+using System.Threading;
+using System.Windows.Forms;
+
+namespace ReactiveTests.Tests
+{
+    internal static class WinFormsTestUtils
+    {
+        private static readonly Semaphore s_oneWinForms = new Semaphore(1, 1);
+
+        public static IDisposable RunTest(out Label label)
+        {
+            s_oneWinForms.WaitOne();
+
+            var loaded = new ManualResetEvent(false);
+            var lbl = default(Label);
+
+            var t = new Thread(() =>
+            {
+                lbl = new Label();
+                var frm = new Form { Controls = { lbl }, Width = 0, Height = 0, FormBorderStyle = FormBorderStyle.None, ShowInTaskbar = false };
+                frm.Load += (_, __) =>
+                {
+                    loaded.Set();
+                };
+                Application.Run(frm);
+            });
+            t.SetApartmentState(ApartmentState.STA);
+            t.Start();
+
+            loaded.WaitOne();
+
+            label = lbl;
+            return new RunWinFormsTest(label, t);
+        }
+
+        private sealed class RunWinFormsTest : IDisposable
+        {
+            private readonly Label _lbl;
+            private readonly Thread _t;
+
+            public RunWinFormsTest(Label lbl, Thread t)
+            {
+                _lbl = lbl;
+                _t = t;
+            }
+
+            public void Dispose()
+            {
+                _lbl.Invoke(new Action(() =>
+                {
+                    Application.Exit();
+                }));
+
+                _t.Join();
+
+                s_oneWinForms.Release();
+            }
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
These WinForms and WPF tests go all the way back to a private test infrastructure (prior to OSS) and later MsTest, and never were hardened against concurrent execution of test cases; they were always run sequentially. This has led to flakiness at some point later, maybe during the migration to Xunit, and it seems nobody ever addressed this.

This PR hardens things in a few ways:

* Ensure only one test for WinForms can run at a given point in time, to avoid multiple running UI threads. Same for WPF.
* Make tests hygienic, i.e. guarantee clean up of the thread they've spawn, and exiting the message loop (e.g. dispatcher).
* Avoid calling `Application.Exit` on a different thread.
* Simplify the way to write test code.

After this goes in, we can likely re-enable some tests that were disabled, possibly because folks observed flakiness (e.g. `ObserveOn` tests getting stuck indefinitely because another test case ran `Application.Exit` and killed the message loop from underneath the test).