### PR TITLE
Suppress warnings in included Xunit source code

### DIFF
--- a/Rx.NET/Source/src/Microsoft.Reactive.Testing/Microsoft.Reactive.Testing.csproj
+++ b/Rx.NET/Source/src/Microsoft.Reactive.Testing/Microsoft.Reactive.Testing.csproj
@@ -7,6 +7,8 @@
     <DefineConstants>$(DefineConstants);PLATFORM_DOTNET;XUNIT_VISIBILITY_INTERNAL</DefineConstants>        
     <PackageTags>Rx;Reactive;Extensions;Observable;LINQ;Events</PackageTags>    
     <Description>Reactive Extensions (Rx) for .NET - Testing Library</Description>
+    <!-- NB: A lot of CA warnings are disabled because of the .cs files included from xunit.assert.source. -->
+    <NoWarn>$(NoWarn);CA1305;CA1307;CA1032;CA1064;CA1822;CA1812</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests.System.Reactive.csproj
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests.System.Reactive.csproj
@@ -9,7 +9,6 @@
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
-
   <ItemGroup>
     <Content Include="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
The `xunit.assert.source` NUGet package includes Xunit functionality as source code, which unfortunately has a bunch of code analysis warnings. Suppressing these warnings for the time being.