### PR TITLE
Make subject implementations a bit more alike.

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Subjects/AsyncSubject.cs
+++ b/Rx.NET/Source/src/System.Reactive/Subjects/AsyncSubject.cs
@@ -310,7 +310,7 @@ namespace System.Reactive.Subjects
         private sealed class AsyncSubjectDisposable : IDisposable
         {
             private AsyncSubject<T> _subject;
-            private IObserver<T>? _observer;
+            private volatile IObserver<T>? _observer;
 
             public AsyncSubjectDisposable(AsyncSubject<T> subject, IObserver<T> observer)
             {
@@ -318,7 +318,7 @@ namespace System.Reactive.Subjects
                 _observer = observer;
             }
 
-            public IObserver<T>? Observer => Volatile.Read(ref _observer);
+            public IObserver<T>? Observer => _observer;
 
             public void Dispose()
             {

--- a/Rx.NET/Source/src/System.Reactive/Subjects/Subject.cs
+++ b/Rx.NET/Source/src/System.Reactive/Subjects/Subject.cs
@@ -266,6 +266,8 @@ namespace System.Reactive.Subjects
                 _observer = observer;
             }
 
+            public IObserver<T>? Observer => _observer;
+
             public void Dispose()
             {
                 var observer = Interlocked.Exchange(ref _observer, null);
@@ -277,8 +279,6 @@ namespace System.Reactive.Subjects
                 _subject.Unsubscribe(this);
                 _subject = null!;
             }
-
-            public IObserver<T>? Observer => _observer;
         }
 
         #endregion


### PR DESCRIPTION
Minor changes to make the inner disposable object similar across all subject types. In particular, make the `Dispose` call `null` out the fields for the observer and the parent subject, in case someone keeps these objects alive. So, we no longer keep the subject or observer alive by just a disposable. (Note that `Subject<T>` already did this.)