### PR TITLE
Undo some code divergence.

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Subjects/Subject.cs
+++ b/Rx.NET/Source/src/System.Reactive/Subjects/Subject.cs
@@ -194,10 +194,7 @@ namespace System.Reactive.Subjects
                     break;
                 }
 
-                if (disposable == null)
-                {
-                    disposable = new SubjectDisposable(this, observer);
-                }
+                disposable ??= new SubjectDisposable(this, observer);
 
                 var n = observers.Length;
                 var b = new SubjectDisposable[n + 1];


### PR DESCRIPTION
A lot of logic in `Subject<T>` and `AsyncSubject<T>` is similar, so converge it again. This also saves on an allocation of a subscription object when trying to `Subscribe` to an already-completed `AsyncSubject<T>`. Furthermore, it uses `Array.IndexOf` rather than a manual loop, which has much better perf now (.NET Core optimizations).