### PR TITLE
Enable #nullable for disposable utils.

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Disposables/Disposable.Utils.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/Disposable.Utils.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
-#nullable disable
-
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 namespace System.Reactive.Disposables
@@ -21,7 +20,7 @@ namespace System.Reactive.Disposables
         /// Gets the value stored in <paramref name="fieldRef" /> or a null if
         /// <paramref name="fieldRef" /> was already disposed.
         /// </summary>
-        internal static IDisposable GetValue(ref IDisposable fieldRef)
+        internal static IDisposable? GetValue([NotNullIfNotNull("fieldRef")] /*in*/ ref IDisposable? fieldRef)
         {
             var current = Volatile.Read(ref fieldRef);
 
@@ -34,7 +33,8 @@ namespace System.Reactive.Disposables
         /// Gets the value stored in <paramref name="fieldRef" /> or a no-op-Disposable if
         /// <paramref name="fieldRef" /> was already disposed.
         /// </summary>
-        internal static IDisposable GetValueOrDefault(ref IDisposable fieldRef)
+        [return: NotNullIfNotNull("fieldRef")]
+        internal static IDisposable? GetValueOrDefault([NotNullIfNotNull("fieldRef")] /*in*/ ref IDisposable? fieldRef)
         {
             var current = Volatile.Read(ref fieldRef);
 
@@ -50,7 +50,7 @@ namespace System.Reactive.Disposables
         /// been assigned before.</returns>
         /// <returns>false if <paramref name="fieldRef" /> has been already disposed.</returns>
         /// <exception cref="InvalidOperationException"><paramref name="fieldRef" /> has already been assigned a value.</exception>
-        internal static bool SetSingle(ref IDisposable fieldRef, IDisposable value)
+        internal static bool SetSingle([NotNullIfNotNull("value")] ref IDisposable? fieldRef, IDisposable? value)
         {
             var result = TrySetSingle(ref fieldRef, value);
 
@@ -66,7 +66,7 @@ namespace System.Reactive.Disposables
         /// Tries to assign <paramref name="value" /> to <paramref name="fieldRef" />.
         /// </summary>
         /// <returns>A <see cref="TrySetSingleResult"/> value indicating the outcome of the operation.</returns>
-        internal static TrySetSingleResult TrySetSingle(ref IDisposable fieldRef, IDisposable value)
+        internal static TrySetSingleResult TrySetSingle([NotNullIfNotNull("value")] ref IDisposable? fieldRef, IDisposable? value)
         {
             var old = Interlocked.CompareExchange(ref fieldRef, value, null);
             if (old == null)
@@ -89,7 +89,7 @@ namespace System.Reactive.Disposables
         /// </summary>
         /// <returns>true if <paramref name="value" /> was successfully assigned to <paramref name="fieldRef" />.</returns>
         /// <returns>false <paramref name="fieldRef" /> has been disposed.</returns>
-        internal static bool TrySetMultiple(ref IDisposable fieldRef, IDisposable value)
+        internal static bool TrySetMultiple([NotNullIfNotNull("value")] ref IDisposable? fieldRef, IDisposable? value)
         {
             // Let's read the current value atomically (also prevents reordering).
             var old = Volatile.Read(ref fieldRef);
@@ -123,7 +123,7 @@ namespace System.Reactive.Disposables
         /// </summary>
         /// <returns>true if <paramref name="value" /> was successfully assigned to <paramref name="fieldRef" />.</returns>
         /// <returns>false <paramref name="fieldRef" /> has been disposed.</returns>
-        internal static bool TrySetSerial(ref IDisposable fieldRef, IDisposable value)
+        internal static bool TrySetSerial([NotNullIfNotNull("value")] ref IDisposable? fieldRef, IDisposable? value)
         {
             var copy = Volatile.Read(ref fieldRef);
             for (; ; )
@@ -150,7 +150,7 @@ namespace System.Reactive.Disposables
         /// </summary>
         /// <returns>true if <paramref name="fieldRef" /> has been disposed.</returns>
         /// <returns>false if <paramref name="fieldRef" /> has not been disposed.</returns>
-        internal static bool GetIsDisposed(ref IDisposable fieldRef)
+        internal static bool GetIsDisposed([NotNullIfNotNull("fieldRef")] /*in*/ ref IDisposable? fieldRef)
         {
             // We use a sentinel value to indicate we've been disposed. This sentinel never leaks
             // to the outside world (see the Disposable property getter), so no-one can ever assign
@@ -161,7 +161,7 @@ namespace System.Reactive.Disposables
         /// <summary>
         /// Disposes <paramref name="fieldRef" />. 
         /// </summary>
-        internal static void Dispose(ref IDisposable fieldRef)
+        internal static void Dispose([NotNullIfNotNull("fieldRef")] ref IDisposable? fieldRef)
         {
             var old = Interlocked.Exchange(ref fieldRef, BooleanDisposable.True);
 


### PR DESCRIPTION
One more bit of `#nullable` support. All of the helpers for `IDisposable` operations are rather gnarly given their excessive use of `ref` because of the underlying `Volatile` and `Interlocked` operations. Luckily we can flow nullable analysis through this using various attributes. In particular:

* read-only uses of `ref` (which could be `in` if the underlying APIs were to use `in`) can be annotated to ensure null-invariance;
* assignments through `ref` can be annotated to inherit their null-ness from the value being assigned.