### PR TITLE
Remove more dead code

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Internal/ExceptionHelper.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/ExceptionHelper.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
-using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 
 namespace System.Reactive
@@ -18,7 +18,7 @@ namespace System.Reactive
         /// The singleton instance of the exception indicating a terminal state,
         /// DO NOT LEAK or signal this via OnError!
         /// </summary>
-        public static Exception Terminated { get; } = new TerminatedException();
+        public static Exception Terminated { get; } = new EndOfStreamException("On[Error|Completed]");
 
         /// <summary>
         /// Tries to atomically set the Exception on the given field if it is
@@ -30,79 +30,6 @@ namespace System.Reactive
         public static bool TrySetException(ref Exception? field, Exception ex)
         {
             return Interlocked.CompareExchange(ref field, ex, null) == null;
-        }
-
-        /// <summary>
-        /// Atomically swaps in the Terminated exception into the field and
-        /// returns the previous exception in that field (which could be the
-        /// Terminated instance too).
-        /// </summary>
-        /// <param name="field">The target field to terminate.</param>
-        /// <returns>The previous exception in that field before the termination.</returns>
-        public static Exception Terminate(ref Exception field)
-        {
-            var current = Volatile.Read(ref field);
-            if (current != Terminated)
-            {
-                current = Interlocked.Exchange(ref field, Terminated);
-            }
-            return current;
-        }
-
-        /// <summary>
-        /// Atomically sets the field to the given new exception or combines
-        /// it with any pre-existing exception as a new AggregateException
-        /// unless the field contains the Terminated instance.
-        /// </summary>
-        /// <param name="field">The field to set or combine with.</param>
-        /// <param name="ex">The exception to combine with.</param>
-        /// <returns>True if successful, false if the field contains the Terminated instance.</returns>
-        /// <remarks>This type of atomic aggregation helps with operators that
-        /// want to delay all errors until all of their sources terminate in some way.</remarks>
-        public static bool TryAddException(ref Exception field, Exception ex)
-        {
-            for (; ; )
-            {
-                var current = Volatile.Read(ref field);
-                if (current == Terminated)
-                {
-                    return false;
-                }
-
-                Exception b;
-
-                if (current == null)
-                {
-                    b = ex;
-                }
-                else if (current is AggregateException a)
-                {
-                    var list = new List<Exception>(a.InnerExceptions)
-                    {
-                        ex
-                    };
-                    b = new AggregateException(list);
-                }
-                else
-                {
-                    b = new AggregateException(current, ex);
-                }
-
-                if (Interlocked.CompareExchange(ref field, b, current) == current)
-                {
-                    return true;
-                }
-            }
-        }
-
-        /// <summary>
-        /// The class indicating a terminal state as an Exception type.
-        /// </summary>
-        private sealed class TerminatedException : Exception
-        {
-            internal TerminatedException() : base("No further exceptions")
-            {
-            }
         }
     }
 }

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Internal/ExceptionHelperTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Internal/ExceptionHelperTest.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace ReactiveTests.Tests
 {
-
     public class ExceptionHelperTest
     {
         private Exception _errors;
@@ -34,106 +33,6 @@ namespace ReactiveTests.Tests
             Assert.False(ExceptionHelper.TrySetException(ref _errors, ex2));
 
             Assert.Equal(ex1, _errors);
-        }
-
-        [Fact]
-        public void ExceptionHelper_TrySetException_Terminate_Empty()
-        {
-            var ex = ExceptionHelper.Terminate(ref _errors);
-
-            Assert.Null(ex);
-            Assert.Equal(_errors, ExceptionHelper.Terminated);
-        }
-
-        [Fact]
-        public void ExceptionHelper_TrySetException_Terminate_Not_Empty()
-        {
-            var ex1 = new InvalidOperationException();
-            _errors = ex1;
-
-            var ex = ExceptionHelper.Terminate(ref _errors);
-
-            Assert.Equal(ex, ex1);
-            Assert.Equal(_errors, ExceptionHelper.Terminated);
-        }
-
-
-        [Fact]
-        public void ExceptionHelper_TrySetException_Terminate_Twice()
-        {
-            var ex1 = new InvalidOperationException();
-            _errors = ex1;
-
-            var ex = ExceptionHelper.Terminate(ref _errors);
-
-            Assert.Equal(ex, ex1);
-            Assert.Equal(_errors, ExceptionHelper.Terminated);
-
-            ex = ExceptionHelper.Terminate(ref _errors);
-
-            Assert.Equal(ex, ExceptionHelper.Terminated);
-            Assert.Equal(_errors, ExceptionHelper.Terminated);
-        }
-
-        [Fact]
-        public void ExceptionHelper_TryAddException_Empty()
-        {
-            var ex1 = new InvalidOperationException();
-
-            Assert.True(ExceptionHelper.TryAddException(ref _errors, ex1));
-
-            Assert.Equal(ex1, _errors);
-        }
-
-        [Fact]
-        public void ExceptionHelper_TryAddException_Not_Empty()
-        {
-            var ex1 = new InvalidOperationException();
-            _errors = ex1;
-
-            var ex2 = new NotImplementedException();
-
-            Assert.True(ExceptionHelper.TryAddException(ref _errors, ex2));
-
-            Assert.True(_errors is AggregateException);
-            var x = _errors as AggregateException;
-
-            Assert.Equal(2, x.InnerExceptions.Count);
-            Assert.True(x.InnerExceptions[0] is InvalidOperationException);
-            Assert.True(x.InnerExceptions[1] is NotImplementedException);
-        }
-
-        [Fact]
-        public void ExceptionHelper_TryAddException_Aggregated()
-        {
-            var ex1 = new InvalidOperationException();
-            var ex2 = new NotImplementedException();
-
-            _errors = new AggregateException(ex1, ex2);
-
-            var ex3 = new InvalidCastException();
-
-            Assert.True(ExceptionHelper.TryAddException(ref _errors, ex3));
-
-            Assert.True(_errors is AggregateException);
-            var x = _errors as AggregateException;
-
-            Assert.Equal(3, x.InnerExceptions.Count);
-            Assert.True(x.InnerExceptions[0] is InvalidOperationException);
-            Assert.True(x.InnerExceptions[1] is NotImplementedException);
-            Assert.True(x.InnerExceptions[2] is InvalidCastException);
-        }
-
-        [Fact]
-        public void ExceptionHelper_TryAddException_Terminated()
-        {
-            _errors = ExceptionHelper.Terminated;
-
-            var ex = new InvalidCastException();
-
-            Assert.False(ExceptionHelper.TryAddException(ref _errors, ex));
-
-            Assert.Equal(_errors, ExceptionHelper.Terminated);
         }
     }
 }


### PR DESCRIPTION
Remove some code that's no longer used, and simplify the exception singleton used. It doesn't need to have a unique type (and we never perform type checks); we should just never leak the instance. Also addresses a few warnings:

```
src\System.Reactive\Internal\ExceptionHelper.cs(101,30): warning CA1032: Add the following constructor to TerminatedException: public TerminatedException(string message)
src\System.Reactive\Internal\ExceptionHelper.cs(101,30): warning CA1032: Add the following constructor to TerminatedException: public TerminatedException(string message, Exception innerException)
src\System.Reactive\Internal\ExceptionHelper.cs(101,30): warning CA1064: Exceptions should be public
```