### PR TITLE
Ensure all exception rethrows use EDI.

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Internal/ExceptionServices.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/ExceptionServices.cs
@@ -15,14 +15,6 @@ namespace System.Reactive
         [DoesNotReturn]
         public static void Throw(this Exception exception) => Services.Value.Rethrow(exception);
 
-        public static void ThrowIfNotNull(this Exception? exception)
-        {
-            if (exception != null)
-            {
-                Services.Value.Rethrow(exception);
-            }
-        }
-
         private static IExceptionServices Initialize()
         {
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/Rx.NET/Source/src/System.Reactive/Internal/PushPullAdapter.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/PushPullAdapter.cs
@@ -67,7 +67,7 @@ namespace System.Reactive
                 done = current.Kind != NotificationKind.OnNext;
             }
 
-            current.Exception.ThrowIfNotNull();
+            current.Exception?.Throw();
 
             return current.HasValue;
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/GetEnumerator.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/GetEnumerator.cs
@@ -70,7 +70,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 return true;
             }
 
-            _error.ThrowIfNotNull();
+            _error?.Throw();
 
             Debug.Assert(_done);
 

--- a/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Blocking.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Blocking.cs
@@ -78,7 +78,7 @@ namespace System.Reactive.Linq
                 consumer.Wait();
             }
 
-            consumer._error.ThrowIfNotNull();
+            consumer._error?.Throw();
 
             if (throwOnEmpty && !consumer._hasValue)
             {
@@ -101,7 +101,7 @@ namespace System.Reactive.Linq
                 sink.Wait();
             }
 
-            sink.Error.ThrowIfNotNull();
+            sink.Error?.Throw();
         }
 
         public virtual void ForEach<TSource>(IObservable<TSource> source, Action<TSource, int> onNext)
@@ -113,7 +113,7 @@ namespace System.Reactive.Linq
                 sink.Wait();
             }
 
-            sink.Error.ThrowIfNotNull();
+            sink.Error?.Throw();
         }
 
         #endregion
@@ -166,7 +166,7 @@ namespace System.Reactive.Linq
                 consumer.Wait();
             }
 
-            consumer._error.ThrowIfNotNull();
+            consumer._error?.Throw();
 
             if (throwOnEmpty && !consumer._hasValue)
             {
@@ -243,7 +243,7 @@ namespace System.Reactive.Linq
                 consumer.Wait();
             }
 
-            consumer._error.ThrowIfNotNull();
+            consumer._error?.Throw();
 
             if (consumer._hasMoreThanOneElement)
             {

--- a/Rx.NET/Source/src/System.Reactive/Runtime/CompilerServices/TaskObservableMethodBuilder.cs
+++ b/Rx.NET/Source/src/System.Reactive/Runtime/CompilerServices/TaskObservableMethodBuilder.cs
@@ -328,7 +328,7 @@ namespace System.Runtime.CompilerServices
                     return _subject.GetResult();
                 }
 
-                _exception.ThrowIfNotNull();
+                _exception?.Throw();
 
                 return _result!;
             }

--- a/Rx.NET/Source/src/System.Reactive/Subjects/AsyncSubject.cs
+++ b/Rx.NET/Source/src/System.Reactive/Subjects/AsyncSubject.cs
@@ -427,7 +427,7 @@ namespace System.Reactive.Subjects
                 e.Wait();
             }
 
-            _exception.ThrowIfNotNull();
+            _exception?.Throw();
 
             if (!_hasValue)
             {

--- a/Rx.NET/Source/src/System.Reactive/Subjects/BehaviorSubject.cs
+++ b/Rx.NET/Source/src/System.Reactive/Subjects/BehaviorSubject.cs
@@ -84,10 +84,7 @@ namespace System.Reactive.Subjects
                 {
                     CheckDisposed();
 
-                    if (_exception != null)
-                    {
-                        throw _exception;
-                    }
+                    _exception?.Throw();
 
                     return _value;
                 }
@@ -121,10 +118,7 @@ namespace System.Reactive.Subjects
                     return false;
                 }
 
-                if (_exception != null)
-                {
-                    throw _exception;
-                }
+                _exception?.Throw();
 
                 value = _value;
                 return true;


### PR DESCRIPTION
Code got into `BehaviorSubject<T>` that didn't leverage `IExceptionServices` to perform the rethrow. This mechanism was part of the `PlatformServices` separation and has also been used for hosting layers. Restore this for `BehaviorSubject<T>`.

Also simplifying all of the use sites of `ThrowIfNotNull` by using `?.` which works well with flow analysis and `#nullable` tracking (given the `DoesNotReturn` attribute on `Throw` and the lack of such an attribute that can make `ThrowIfNotNull` conditionally non-returning based on the nullability of the operand; `DoesNotReturnIf` only works with Boolean predicates).