### PR TITLE
Avoid even more closures with an additional overload of AsyncObservable.Create

### DIFF
--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/AsyncObservable.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/AsyncObservable.cs
@@ -18,7 +18,7 @@ namespace System.Reactive.Linq
 
                 public AsyncObservableImpl(IAsyncObservable<TSource> source, Func<IAsyncObservable<TSource>, IAsyncObserver<TResult>, ValueTask<IAsyncDisposable>> subscribeAsync)
                 {
-                    _source = source;
+                    _source = source ?? throw new ArgumentNullException(nameof(source));
                     _subscribeAsync = subscribeAsync ?? throw new ArgumentNullException(nameof(subscribeAsync));
                 }
 
@@ -39,8 +39,8 @@ namespace System.Reactive.Linq
 
                 public AsyncObservableImpl(IAsyncObservable<TSource> source, TState state, Func<IAsyncObservable<TSource>, TState, IAsyncObserver<TResult>, ValueTask<IAsyncDisposable>> subscribeAsync)
                 {
-                    _source = source;
                     _state = state;
+                    _source = source ?? throw new ArgumentNullException(nameof(source));
                     _subscribeAsync = subscribeAsync ?? throw new ArgumentNullException(nameof(subscribeAsync));
                 }
 
@@ -55,23 +55,11 @@ namespace System.Reactive.Linq
 
             public static IAsyncObservable<TResult> From<TSource>(IAsyncObservable<TSource> source, Func<IAsyncObservable<TSource>, IAsyncObserver<TResult>, ValueTask<IAsyncDisposable>> subscribeAsync)
             {
-                if (source == null)
-                    throw new ArgumentNullException(nameof(source));
-
-                if (subscribeAsync == null)
-                    throw new ArgumentNullException(nameof(subscribeAsync));
-
                 return new AsyncObservableImpl<TSource>(source, subscribeAsync);
             }
 
             public static IAsyncObservable<TResult> From<TSource, TState>(IAsyncObservable<TSource> source, TState state, Func<IAsyncObservable<TSource>, TState, IAsyncObserver<TResult>, ValueTask<IAsyncDisposable>> subscribeAsync)
             {
-                if (source == null)
-                    throw new ArgumentNullException(nameof(source));
-
-                if (subscribeAsync == null)
-                    throw new ArgumentNullException(nameof(subscribeAsync));
-
                 return new AsyncObservableImpl<TSource, TState>(source, state, subscribeAsync);
             }
         }
@@ -86,12 +74,6 @@ namespace System.Reactive.Linq
 
         internal static IAsyncObservable<TResult> Create<TSource, TResult>(IAsyncObservable<TSource> source, Func<IAsyncObservable<TSource>, IAsyncObserver<TResult>, ValueTask<IAsyncDisposable>> subscribeAsync)
         {
-            if (source == null)
-                throw new ArgumentNullException(nameof(source));
-
-            if (subscribeAsync == null)
-                throw new ArgumentNullException(nameof(subscribeAsync));
-
             return CreateAsyncObservable<TResult>.From(source, subscribeAsync);
         }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/AsyncObservable.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/AsyncObservable.cs
@@ -9,7 +9,7 @@ namespace System.Reactive.Linq
 {
     public static partial class AsyncObservable
     {
-        internal static class Build<TResult>
+        internal static class CreateAsyncObservable<TResult>
         {
             private sealed class AsyncObservableImpl<TSource> : AsyncObservableBase<TResult>
             {
@@ -92,12 +92,12 @@ namespace System.Reactive.Linq
             if (subscribeAsync == null)
                 throw new ArgumentNullException(nameof(subscribeAsync));
 
-            return Build<TResult>.From(source, subscribeAsync);
+            return CreateAsyncObservable<TResult>.From(source, subscribeAsync);
         }
 
         internal static IAsyncObservable<TSource> Create<TSource, TState>(IAsyncObservable<TSource> source, TState state, Func<IAsyncObservable<TSource>, TState, IAsyncObserver<TSource>, ValueTask<IAsyncDisposable>> subscribeAsync)
         {
-            return Build<TSource>.From(source, state, subscribeAsync);
+            return CreateAsyncObservable<TSource>.From(source, state, subscribeAsync);
         }
 
         internal static IAsyncObservable<TSource> Create<TSource>(IAsyncObservable<TSource> source, Func<IAsyncObservable<TSource>, IAsyncObserver<TSource>, ValueTask<IAsyncDisposable>> subscribeAsync)

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Aggregate.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Aggregate.cs
@@ -15,10 +15,9 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 func,
-                default(TSource),
                 static (source, func, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, func)));
         }
 
@@ -29,10 +28,9 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 func,
-                default(TSource),
                 static (source, func, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, func)));
         }
 
@@ -43,10 +41,9 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Create(
+            return Build<TResult>.From(
                 source,
                 (seed, func),
-                default(TResult),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, state.seed, state.func)));
         }
 
@@ -57,10 +54,9 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Create(
+            return Build<TResult>.From(
                 source,
                 (seed, func),
-                default(TResult),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, state.seed, state.func)));
         }
 
@@ -73,10 +69,9 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Create(
+            return Build<TResult>.From(
                 source,
                 (seed, func, resultSelector),
-                default(TResult),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, state.seed, state.func, state.resultSelector)));
         }
 
@@ -89,10 +84,9 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Create(
+            return Build<TResult>.From(
                 source,
                 (seed, func, resultSelector),
-                default(TResult),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, state.seed, state.func, state.resultSelector)));
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Aggregate.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Aggregate.cs
@@ -15,7 +15,7 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 func,
                 static (source, func, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, func)));
@@ -28,7 +28,7 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 func,
                 static (source, func, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, func)));
@@ -41,7 +41,7 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Build<TResult>.From(
+            return CreateAsyncObservable<TResult>.From(
                 source,
                 (seed, func),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, state.seed, state.func)));
@@ -54,7 +54,7 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Build<TResult>.From(
+            return CreateAsyncObservable<TResult>.From(
                 source,
                 (seed, func),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, state.seed, state.func)));
@@ -69,7 +69,7 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Build<TResult>.From(
+            return CreateAsyncObservable<TResult>.From(
                 source,
                 (seed, func, resultSelector),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, state.seed, state.func, state.resultSelector)));
@@ -84,7 +84,7 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Build<TResult>.From(
+            return CreateAsyncObservable<TResult>.From(
                 source,
                 (seed, func, resultSelector),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, state.seed, state.func, state.resultSelector)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Aggregate.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Aggregate.cs
@@ -19,7 +19,7 @@ namespace System.Reactive.Linq
                 source,
                 func,
                 default(TSource),
-                (source, func, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, func)));
+                static (source, func, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, func)));
         }
 
         public static IAsyncObservable<TSource> Aggregate<TSource>(this IAsyncObservable<TSource> source, Func<TSource, TSource, ValueTask<TSource>> func)
@@ -33,7 +33,7 @@ namespace System.Reactive.Linq
                 source,
                 func,
                 default(TSource),
-                (source, func, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, func)));
+                static (source, func, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, func)));
         }
 
         public static IAsyncObservable<TResult> Aggregate<TSource, TResult>(this IAsyncObservable<TSource> source, TResult seed, Func<TResult, TSource, TResult> func)
@@ -47,7 +47,7 @@ namespace System.Reactive.Linq
                 source,
                 (seed, func),
                 default(TResult),
-                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, state.seed, state.func)));
+                static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, state.seed, state.func)));
         }
 
         public static IAsyncObservable<TResult> Aggregate<TSource, TResult>(this IAsyncObservable<TSource> source, TResult seed, Func<TResult, TSource, ValueTask<TResult>> func)
@@ -61,7 +61,7 @@ namespace System.Reactive.Linq
                 source,
                 (seed, func),
                 default(TResult),
-                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, state.seed, state.func)));
+                static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, state.seed, state.func)));
         }
 
         public static IAsyncObservable<TResult> Aggregate<TSource, TAccumulate, TResult>(this IAsyncObservable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, TAccumulate> func, Func<TAccumulate, TResult> resultSelector)
@@ -77,7 +77,7 @@ namespace System.Reactive.Linq
                 source,
                 (seed, func, resultSelector),
                 default(TResult),
-                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, state.seed, state.func, state.resultSelector)));
+                static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, state.seed, state.func, state.resultSelector)));
         }
 
         public static IAsyncObservable<TResult> Aggregate<TSource, TAccumulate, TResult>(this IAsyncObservable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, ValueTask<TAccumulate>> func, Func<TAccumulate, ValueTask<TResult>> resultSelector)
@@ -93,7 +93,7 @@ namespace System.Reactive.Linq
                 source,
                 (seed, func, resultSelector),
                 default(TResult),
-                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, state.seed, state.func, state.resultSelector)));
+                static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, state.seed, state.func, state.resultSelector)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Aggregate.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Aggregate.cs
@@ -15,7 +15,11 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, func)));
+            return Create(
+                source,
+                func,
+                default(TSource),
+                (source, func, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, func)));
         }
 
         public static IAsyncObservable<TSource> Aggregate<TSource>(this IAsyncObservable<TSource> source, Func<TSource, TSource, ValueTask<TSource>> func)
@@ -25,7 +29,11 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, func)));
+            return Create(
+                source,
+                func,
+                default(TSource),
+                (source, func, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, func)));
         }
 
         public static IAsyncObservable<TResult> Aggregate<TSource, TResult>(this IAsyncObservable<TSource> source, TResult seed, Func<TResult, TSource, TResult> func)
@@ -35,7 +43,11 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Create<TResult>(observer => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, seed, func)));
+            return Create(
+                source,
+                (seed, func),
+                default(TResult),
+                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, state.seed, state.func)));
         }
 
         public static IAsyncObservable<TResult> Aggregate<TSource, TResult>(this IAsyncObservable<TSource> source, TResult seed, Func<TResult, TSource, ValueTask<TResult>> func)
@@ -45,7 +57,11 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Create<TResult>(observer => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, seed, func)));
+            return Create(
+                source,
+                (seed, func),
+                default(TResult),
+                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, state.seed, state.func)));
         }
 
         public static IAsyncObservable<TResult> Aggregate<TSource, TAccumulate, TResult>(this IAsyncObservable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, TAccumulate> func, Func<TAccumulate, TResult> resultSelector)
@@ -57,7 +73,11 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Create<TResult>(observer => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, seed, func, resultSelector)));
+            return Create(
+                source,
+                (seed, func, resultSelector),
+                default(TResult),
+                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, state.seed, state.func, state.resultSelector)));
         }
 
         public static IAsyncObservable<TResult> Aggregate<TSource, TAccumulate, TResult>(this IAsyncObservable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, ValueTask<TAccumulate>> func, Func<TAccumulate, ValueTask<TResult>> resultSelector)
@@ -69,7 +89,11 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Create<TResult>(observer => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, seed, func, resultSelector)));
+            return Create(
+                source,
+                (seed, func, resultSelector),
+                default(TResult),
+                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Aggregate(observer, state.seed, state.func, state.resultSelector)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/All.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/All.cs
@@ -15,7 +15,11 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<bool>(observer => source.SubscribeSafeAsync(AsyncObserver.All(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                default(bool),
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.All(observer, predicate)));
         }
 
         public static IAsyncObservable<bool> All<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
@@ -25,7 +29,11 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<bool>(observer => source.SubscribeSafeAsync(AsyncObserver.All(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                default(bool),
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.All(observer, predicate)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/All.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/All.cs
@@ -15,7 +15,7 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Build<bool>.From(
+            return CreateAsyncObservable<bool>.From(
                 source,
                 predicate,
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.All(observer, predicate)));
@@ -28,7 +28,7 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Build<bool>.From(
+            return CreateAsyncObservable<bool>.From(
                 source,
                 predicate,
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.All(observer, predicate)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/All.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/All.cs
@@ -19,7 +19,7 @@ namespace System.Reactive.Linq
                 source,
                 predicate,
                 default(bool),
-                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.All(observer, predicate)));
+                static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.All(observer, predicate)));
         }
 
         public static IAsyncObservable<bool> All<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
@@ -33,7 +33,7 @@ namespace System.Reactive.Linq
                 source,
                 predicate,
                 default(bool),
-                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.All(observer, predicate)));
+                static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.All(observer, predicate)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/All.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/All.cs
@@ -15,10 +15,9 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(
+            return Build<bool>.From(
                 source,
                 predicate,
-                default(bool),
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.All(observer, predicate)));
         }
 
@@ -29,10 +28,9 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(
+            return Build<bool>.From(
                 source,
                 predicate,
-                default(bool),
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.All(observer, predicate)));
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Amb.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Amb.cs
@@ -19,7 +19,7 @@ namespace System.Reactive.Linq
             if (second == null)
                 throw new ArgumentNullException(nameof(second));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 first,
                 second,
                 static async (first, second, observer) =>

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Amb.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Amb.cs
@@ -19,10 +19,9 @@ namespace System.Reactive.Linq
             if (second == null)
                 throw new ArgumentNullException(nameof(second));
 
-            return Create(
+            return Build<TSource>.From(
                 first,
                 second,
-                default(TSource),
                 static async (first, second, observer) =>
                 {
                     var firstSubscription = new SingleAssignmentAsyncDisposable();

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Amb.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Amb.cs
@@ -23,7 +23,7 @@ namespace System.Reactive.Linq
                 first,
                 second,
                 default(TSource),
-                async (first, second, observer) =>
+                static async (first, second, observer) =>
                 {
                     var firstSubscription = new SingleAssignmentAsyncDisposable();
                     var secondSubscription = new SingleAssignmentAsyncDisposable();

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Amb.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Amb.cs
@@ -19,20 +19,24 @@ namespace System.Reactive.Linq
             if (second == null)
                 throw new ArgumentNullException(nameof(second));
 
-            return Create<TSource>(async observer =>
-            {
-                var firstSubscription = new SingleAssignmentAsyncDisposable();
-                var secondSubscription = new SingleAssignmentAsyncDisposable();
+            return Create(
+                first,
+                second,
+                default(TSource),
+                async (first, second, observer) =>
+                {
+                    var firstSubscription = new SingleAssignmentAsyncDisposable();
+                    var secondSubscription = new SingleAssignmentAsyncDisposable();
 
-                var (firstObserver, secondObserver) = AsyncObserver.Amb(observer, firstSubscription, secondSubscription);
+                    var (firstObserver, secondObserver) = AsyncObserver.Amb(observer, firstSubscription, secondSubscription);
 
-                var firstTask = first.SubscribeSafeAsync(firstObserver).AsTask().ContinueWith(d => firstSubscription.AssignAsync(d.Result).AsTask()).Unwrap();
-                var secondTask = second.SubscribeSafeAsync(secondObserver).AsTask().ContinueWith(d => secondSubscription.AssignAsync(d.Result).AsTask()).Unwrap();
+                    var firstTask = first.SubscribeSafeAsync(firstObserver).AsTask().ContinueWith(d => firstSubscription.AssignAsync(d.Result).AsTask()).Unwrap();
+                    var secondTask = second.SubscribeSafeAsync(secondObserver).AsTask().ContinueWith(d => secondSubscription.AssignAsync(d.Result).AsTask()).Unwrap();
 
-                await Task.WhenAll(firstTask, secondTask).ConfigureAwait(false);
+                    await Task.WhenAll(firstTask, secondTask).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(firstSubscription, secondSubscription);
-            });
+                    return StableCompositeAsyncDisposable.Create(firstSubscription, secondSubscription);
+                });
         }
 
         public static IAsyncObservable<TSource> Amb<TSource>(this IEnumerable<IAsyncObservable<TSource>> sources) => Amb(sources.ToArray());

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Any.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Any.cs
@@ -23,10 +23,9 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(
+            return Build<bool>.From(
                 source,
                 predicate,
-                default(bool),
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Any(observer, predicate)));
         }
 
@@ -37,10 +36,9 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(
+            return Build<bool>.From(
                 source,
                 predicate,
-                default(bool),
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Any(observer, predicate)));
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Any.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Any.cs
@@ -23,7 +23,7 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Build<bool>.From(
+            return CreateAsyncObservable<bool>.From(
                 source,
                 predicate,
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Any(observer, predicate)));
@@ -36,7 +36,7 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Build<bool>.From(
+            return CreateAsyncObservable<bool>.From(
                 source,
                 predicate,
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Any(observer, predicate)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Any.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Any.cs
@@ -27,7 +27,7 @@ namespace System.Reactive.Linq
                 source,
                 predicate,
                 default(bool),
-                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Any(observer, predicate)));
+                static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Any(observer, predicate)));
         }
 
         public static IAsyncObservable<bool> Any<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
@@ -41,7 +41,7 @@ namespace System.Reactive.Linq
                 source,
                 predicate,
                 default(bool),
-                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Any(observer, predicate)));
+                static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Any(observer, predicate)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Any.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Any.cs
@@ -23,7 +23,11 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<bool>(observer => source.SubscribeSafeAsync(AsyncObserver.Any(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                default(bool),
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Any(observer, predicate)));
         }
 
         public static IAsyncObservable<bool> Any<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
@@ -33,7 +37,11 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<bool>(observer => source.SubscribeSafeAsync(AsyncObserver.Any(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                default(bool),
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Any(observer, predicate)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Append.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Append.cs
@@ -15,10 +15,9 @@ namespace System.Reactive.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 value,
-                default(TSource),
                 static(source, value, observer) => source.SubscribeSafeAsync(AsyncObserver.Append(observer, value)));
         }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Append.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Append.cs
@@ -19,7 +19,7 @@ namespace System.Reactive.Linq
                 source,
                 value,
                 default(TSource),
-                (source, value, observer) => source.SubscribeSafeAsync(AsyncObserver.Append(observer, value)));
+                static(source, value, observer) => source.SubscribeSafeAsync(AsyncObserver.Append(observer, value)));
         }
 
         public static IAsyncObservable<TSource> Append<TSource>(this IAsyncObservable<TSource> source, TSource value, IAsyncScheduler scheduler)

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Append.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Append.cs
@@ -15,7 +15,11 @@ namespace System.Reactive.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.Append(observer, value)));
+            return Create(
+                source,
+                value,
+                default(TSource),
+                (source, value, observer) => source.SubscribeSafeAsync(AsyncObserver.Append(observer, value)));
         }
 
         public static IAsyncObservable<TSource> Append<TSource>(this IAsyncObservable<TSource> source, TSource value, IAsyncScheduler scheduler)
@@ -25,20 +29,23 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Create<TSource>(async observer =>
-            {
-                var d = new CompositeAsyncDisposable();
+            return Create(
+                source,
+                (value, scheduler),
+                async (source, state, observer) =>
+                {
+                    var d = new CompositeAsyncDisposable();
 
-                var (sink, disposable) = AsyncObserver.Append(observer, value, scheduler);
+                    var (sink, disposable) = AsyncObserver.Append(observer, state.value, state.scheduler);
 
-                await d.AddAsync(disposable).ConfigureAwait(false);
+                    await d.AddAsync(disposable).ConfigureAwait(false);
 
-                var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                await d.AddAsync(subscription).ConfigureAwait(false);
+                    await d.AddAsync(subscription).ConfigureAwait(false);
 
-                return d;
-            });
+                    return d;
+                });
         }
 
         public static IAsyncObservable<TSource> Append<TSource>(this IAsyncObservable<TSource> source, params TSource[] values)
@@ -48,7 +55,10 @@ namespace System.Reactive.Linq
             if (values == null)
                 throw new ArgumentNullException(nameof(values));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.Append(observer, values)));
+            return Create(
+                source,
+                values,
+                (source, values, observer) => source.SubscribeSafeAsync(AsyncObserver.Append(observer, values)));
         }
 
         public static IAsyncObservable<TSource> Append<TSource>(this IAsyncObservable<TSource> source, IAsyncScheduler scheduler, params TSource[] values)
@@ -60,20 +70,23 @@ namespace System.Reactive.Linq
             if (values == null)
                 throw new ArgumentNullException(nameof(values));
 
-            return Create<TSource>(async observer =>
-            {
-                var d = new CompositeAsyncDisposable();
+            return Create(
+                source,
+                (scheduler, values),
+                async (source, state, observer) =>
+                {
+                    var d = new CompositeAsyncDisposable();
 
-                var (sink, disposable) = AsyncObserver.Append(observer, scheduler, values);
+                    var (sink, disposable) = AsyncObserver.Append(observer, state.scheduler, state.values);
 
-                await d.AddAsync(disposable).ConfigureAwait(false);
+                    await d.AddAsync(disposable).ConfigureAwait(false);
 
-                var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                await d.AddAsync(subscription).ConfigureAwait(false);
+                    await d.AddAsync(subscription).ConfigureAwait(false);
 
-                return d;
-            });
+                    return d;
+                });
         }
 
         public static IAsyncObservable<TSource> Append<TSource>(this IAsyncObservable<TSource> source, IEnumerable<TSource> values)
@@ -83,7 +96,10 @@ namespace System.Reactive.Linq
             if (values == null)
                 throw new ArgumentNullException(nameof(values));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.Append(observer, values)));
+            return Create(
+                source,
+                values,
+                (source, values, observer) => source.SubscribeSafeAsync(AsyncObserver.Append(observer, values)));
         }
 
         public static IAsyncObservable<TSource> Append<TSource>(this IAsyncObservable<TSource> source, IAsyncScheduler scheduler, IEnumerable<TSource> values)
@@ -95,20 +111,23 @@ namespace System.Reactive.Linq
             if (values == null)
                 throw new ArgumentNullException(nameof(values));
 
-            return Create<TSource>(async observer =>
-            {
-                var d = new CompositeAsyncDisposable();
+            return Create(
+                source,
+                (scheduler, values),
+                async (source, state, observer) =>
+                {
+                    var d = new CompositeAsyncDisposable();
 
-                var (sink, disposable) = AsyncObserver.Append(observer, scheduler, values);
+                    var (sink, disposable) = AsyncObserver.Append(observer, state.scheduler, state.values);
 
-                await d.AddAsync(disposable).ConfigureAwait(false);
+                    await d.AddAsync(disposable).ConfigureAwait(false);
 
-                var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                await d.AddAsync(subscription).ConfigureAwait(false);
+                    await d.AddAsync(subscription).ConfigureAwait(false);
 
-                return d;
-            });
+                    return d;
+                });
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Append.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Append.cs
@@ -15,7 +15,7 @@ namespace System.Reactive.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 value,
                 static(source, value, observer) => source.SubscribeSafeAsync(AsyncObserver.Append(observer, value)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Average.Generated.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Average.Generated.cs
@@ -23,7 +23,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Double>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageInt32(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Double),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Double> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int32>> selector)
@@ -33,7 +37,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Double>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageInt32(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Double),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Double?> Average(this IAsyncObservable<Int32?> source)
@@ -51,7 +59,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Double?>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageNullableInt32(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Double?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Double?> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int32?>> selector)
@@ -61,7 +73,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Double?>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageNullableInt32(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Double?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Double> Average(this IAsyncObservable<Int64> source)
@@ -79,7 +95,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Double>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageInt64(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Double),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Double> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int64>> selector)
@@ -89,7 +109,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Double>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageInt64(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Double),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Double?> Average(this IAsyncObservable<Int64?> source)
@@ -107,7 +131,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Double?>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageNullableInt64(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Double?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Double?> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int64?>> selector)
@@ -117,7 +145,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Double?>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageNullableInt64(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Double?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Single> Average(this IAsyncObservable<Single> source)
@@ -135,7 +167,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Single>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageSingle(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Single),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Single> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Single>> selector)
@@ -145,7 +181,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Single>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageSingle(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Single),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Single?> Average(this IAsyncObservable<Single?> source)
@@ -163,7 +203,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Single?>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageNullableSingle(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Single?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Single?> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Single?>> selector)
@@ -173,7 +217,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Single?>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageNullableSingle(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Single?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Double> Average(this IAsyncObservable<Double> source)
@@ -191,7 +239,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Double>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageDouble(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Double),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Double> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Double>> selector)
@@ -201,7 +253,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Double>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageDouble(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Double),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Double?> Average(this IAsyncObservable<Double?> source)
@@ -219,7 +275,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Double?>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageNullableDouble(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Double?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Double?> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Double?>> selector)
@@ -229,7 +289,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Double?>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageNullableDouble(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Double?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal> Average(this IAsyncObservable<Decimal> source)
@@ -247,7 +311,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Decimal>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageDecimal(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Decimal),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageDecimal(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Decimal>> selector)
@@ -257,7 +325,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Decimal>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageDecimal(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Decimal),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageDecimal(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal?> Average(this IAsyncObservable<Decimal?> source)
@@ -275,7 +347,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Decimal?>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageNullableDecimal(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Decimal?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableDecimal(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal?> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Decimal?>> selector)
@@ -285,7 +361,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Decimal?>(observer => source.SubscribeSafeAsync(AsyncObserver.AverageNullableDecimal(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Decimal?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableDecimal(observer, selector)));
         }
 
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Average.Generated.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Average.Generated.cs
@@ -23,7 +23,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Double>.From(
+            return CreateAsyncObservable<Double>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageInt32(observer, selector)));
@@ -36,7 +36,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Double>.From(
+            return CreateAsyncObservable<Double>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageInt32(observer, selector)));
@@ -57,7 +57,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Double?>.From(
+            return CreateAsyncObservable<Double?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableInt32(observer, selector)));
@@ -70,7 +70,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Double?>.From(
+            return CreateAsyncObservable<Double?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableInt32(observer, selector)));
@@ -91,7 +91,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Double>.From(
+            return CreateAsyncObservable<Double>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageInt64(observer, selector)));
@@ -104,7 +104,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Double>.From(
+            return CreateAsyncObservable<Double>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageInt64(observer, selector)));
@@ -125,7 +125,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Double?>.From(
+            return CreateAsyncObservable<Double?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableInt64(observer, selector)));
@@ -138,7 +138,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Double?>.From(
+            return CreateAsyncObservable<Double?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableInt64(observer, selector)));
@@ -159,7 +159,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Single>.From(
+            return CreateAsyncObservable<Single>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageSingle(observer, selector)));
@@ -172,7 +172,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Single>.From(
+            return CreateAsyncObservable<Single>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageSingle(observer, selector)));
@@ -193,7 +193,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Single?>.From(
+            return CreateAsyncObservable<Single?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableSingle(observer, selector)));
@@ -206,7 +206,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Single?>.From(
+            return CreateAsyncObservable<Single?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableSingle(observer, selector)));
@@ -227,7 +227,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Double>.From(
+            return CreateAsyncObservable<Double>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageDouble(observer, selector)));
@@ -240,7 +240,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Double>.From(
+            return CreateAsyncObservable<Double>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageDouble(observer, selector)));
@@ -261,7 +261,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Double?>.From(
+            return CreateAsyncObservable<Double?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableDouble(observer, selector)));
@@ -274,7 +274,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Double?>.From(
+            return CreateAsyncObservable<Double?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableDouble(observer, selector)));
@@ -295,7 +295,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Decimal>.From(
+            return CreateAsyncObservable<Decimal>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageDecimal(observer, selector)));
@@ -308,7 +308,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Decimal>.From(
+            return CreateAsyncObservable<Decimal>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageDecimal(observer, selector)));
@@ -329,7 +329,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Decimal?>.From(
+            return CreateAsyncObservable<Decimal?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableDecimal(observer, selector)));
@@ -342,7 +342,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Decimal?>.From(
+            return CreateAsyncObservable<Decimal?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableDecimal(observer, selector)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Average.Generated.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Average.Generated.cs
@@ -23,10 +23,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Double>.From(
                 source,
                 selector,
-                default(Double),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageInt32(observer, selector)));
         }
 
@@ -37,10 +36,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Double>.From(
                 source,
                 selector,
-                default(Double),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageInt32(observer, selector)));
         }
 
@@ -59,10 +57,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Double?>.From(
                 source,
                 selector,
-                default(Double?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableInt32(observer, selector)));
         }
 
@@ -73,10 +70,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Double?>.From(
                 source,
                 selector,
-                default(Double?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableInt32(observer, selector)));
         }
 
@@ -95,10 +91,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Double>.From(
                 source,
                 selector,
-                default(Double),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageInt64(observer, selector)));
         }
 
@@ -109,10 +104,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Double>.From(
                 source,
                 selector,
-                default(Double),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageInt64(observer, selector)));
         }
 
@@ -131,10 +125,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Double?>.From(
                 source,
                 selector,
-                default(Double?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableInt64(observer, selector)));
         }
 
@@ -145,10 +138,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Double?>.From(
                 source,
                 selector,
-                default(Double?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableInt64(observer, selector)));
         }
 
@@ -167,10 +159,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Single>.From(
                 source,
                 selector,
-                default(Single),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageSingle(observer, selector)));
         }
 
@@ -181,10 +172,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Single>.From(
                 source,
                 selector,
-                default(Single),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageSingle(observer, selector)));
         }
 
@@ -203,10 +193,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Single?>.From(
                 source,
                 selector,
-                default(Single?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableSingle(observer, selector)));
         }
 
@@ -217,10 +206,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Single?>.From(
                 source,
                 selector,
-                default(Single?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableSingle(observer, selector)));
         }
 
@@ -239,10 +227,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Double>.From(
                 source,
                 selector,
-                default(Double),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageDouble(observer, selector)));
         }
 
@@ -253,10 +240,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Double>.From(
                 source,
                 selector,
-                default(Double),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageDouble(observer, selector)));
         }
 
@@ -275,10 +261,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Double?>.From(
                 source,
                 selector,
-                default(Double?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableDouble(observer, selector)));
         }
 
@@ -289,10 +274,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Double?>.From(
                 source,
                 selector,
-                default(Double?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableDouble(observer, selector)));
         }
 
@@ -311,10 +295,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Decimal>.From(
                 source,
                 selector,
-                default(Decimal),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageDecimal(observer, selector)));
         }
 
@@ -325,10 +308,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Decimal>.From(
                 source,
                 selector,
-                default(Decimal),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageDecimal(observer, selector)));
         }
 
@@ -347,10 +329,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Decimal?>.From(
                 source,
                 selector,
-                default(Decimal?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableDecimal(observer, selector)));
         }
 
@@ -361,10 +342,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Decimal?>.From(
                 source,
                 selector,
-                default(Decimal?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableDecimal(observer, selector)));
         }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Average.Generated.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Average.Generated.cs
@@ -27,7 +27,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Double),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageInt32(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Double> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int32>> selector)
@@ -41,7 +41,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Double),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageInt32(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Double?> Average(this IAsyncObservable<Int32?> source)
@@ -63,7 +63,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Double?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableInt32(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Double?> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int32?>> selector)
@@ -77,7 +77,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Double?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableInt32(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Double> Average(this IAsyncObservable<Int64> source)
@@ -99,7 +99,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Double),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageInt64(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Double> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int64>> selector)
@@ -113,7 +113,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Double),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageInt64(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Double?> Average(this IAsyncObservable<Int64?> source)
@@ -135,7 +135,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Double?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableInt64(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Double?> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int64?>> selector)
@@ -149,7 +149,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Double?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableInt64(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Single> Average(this IAsyncObservable<Single> source)
@@ -171,7 +171,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Single),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageSingle(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Single> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Single>> selector)
@@ -185,7 +185,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Single),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageSingle(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Single?> Average(this IAsyncObservable<Single?> source)
@@ -207,7 +207,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Single?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableSingle(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Single?> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Single?>> selector)
@@ -221,7 +221,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Single?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableSingle(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Double> Average(this IAsyncObservable<Double> source)
@@ -243,7 +243,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Double),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageDouble(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Double> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Double>> selector)
@@ -257,7 +257,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Double),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageDouble(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Double?> Average(this IAsyncObservable<Double?> source)
@@ -279,7 +279,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Double?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableDouble(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Double?> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Double?>> selector)
@@ -293,7 +293,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Double?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableDouble(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal> Average(this IAsyncObservable<Decimal> source)
@@ -315,7 +315,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Decimal),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageDecimal(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageDecimal(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Decimal>> selector)
@@ -329,7 +329,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Decimal),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageDecimal(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageDecimal(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal?> Average(this IAsyncObservable<Decimal?> source)
@@ -351,7 +351,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Decimal?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableDecimal(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableDecimal(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal?> Average<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Decimal?>> selector)
@@ -365,7 +365,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Decimal?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableDecimal(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.AverageNullableDecimal(observer, selector)));
         }
 
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Average.Generated.tt
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Average.Generated.tt
@@ -53,7 +53,11 @@ foreach (var t in types)
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<<#=targetTypeName#>>(observer => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(<#=targetTypeName#>),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
         }
 
         public static IAsyncObservable<<#=targetTypeName#>> <#=name#><TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<<#=sourceTypeName#>>> selector)
@@ -63,7 +67,11 @@ foreach (var t in types)
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<<#=targetTypeName#>>(observer => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(<#=targetTypeName#>),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
         }
 
 <#

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Average.Generated.tt
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Average.Generated.tt
@@ -53,10 +53,9 @@ foreach (var t in types)
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<<#=targetTypeName#>>.From(
                 source,
                 selector,
-                default(<#=targetTypeName#>),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
         }
 
@@ -67,10 +66,9 @@ foreach (var t in types)
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<<#=targetTypeName#>>.From(
                 source,
                 selector,
-                default(<#=targetTypeName#>),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
         }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Average.Generated.tt
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Average.Generated.tt
@@ -57,7 +57,7 @@ foreach (var t in types)
                 source,
                 selector,
                 default(<#=targetTypeName#>),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
         }
 
         public static IAsyncObservable<<#=targetTypeName#>> <#=name#><TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<<#=sourceTypeName#>>> selector)
@@ -71,7 +71,7 @@ foreach (var t in types)
                 source,
                 selector,
                 default(<#=targetTypeName#>),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
         }
 
 <#

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Buffer.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Buffer.cs
@@ -23,7 +23,7 @@ namespace System.Reactive.Linq
                 source,
                 count,
                 default(IList<TSource>),
-                (source, count, observer) => source.SubscribeSafeAsync(AsyncObserver.Buffer(observer, count)));
+                static (source, count, observer) => source.SubscribeSafeAsync(AsyncObserver.Buffer(observer, count)));
         }
 
         public static IAsyncObservable<IList<TSource>> Buffer<TSource>(this IAsyncObservable<TSource> source, int count, int skip)
@@ -39,7 +39,7 @@ namespace System.Reactive.Linq
                 source,
                 (count, skip),
                 default(IList<TSource>),
-                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Buffer(observer, state.count, state.skip)));
+                static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Buffer(observer, state.count, state.skip)));
         }
 
         public static IAsyncObservable<IList<TSource>> Buffer<TSource>(this IAsyncObservable<TSource> source, TimeSpan timeSpan)
@@ -53,7 +53,7 @@ namespace System.Reactive.Linq
                 source,
                 timeSpan,
                 default(IList<TSource>),
-                async (source, timeSpan, observer) =>
+                static async (source, timeSpan, observer) =>
                 {
                     var (sink, timer) = await AsyncObserver.Buffer(observer, timeSpan).ConfigureAwait(false);
 
@@ -76,7 +76,7 @@ namespace System.Reactive.Linq
                 source,
                 (timeSpan, scheduler),
                 default(IList<TSource>),
-                async (source, state, observer) =>
+                static async (source, state, observer) =>
                 {
                     var (sink, timer) = await AsyncObserver.Buffer(observer, state.timeSpan, state.scheduler).ConfigureAwait(false);
 
@@ -99,7 +99,7 @@ namespace System.Reactive.Linq
                 source,
                 (timeSpan, timeShift),
                 default(IList<TSource>),
-                async (source, state, observer) =>
+                static async (source, state, observer) =>
                 {
                     var (sink, timer) = await AsyncObserver.Buffer(observer, state.timeSpan, state.timeShift).ConfigureAwait(false);
 
@@ -124,7 +124,7 @@ namespace System.Reactive.Linq
                 source,
                 (timeSpan, timeShift, scheduler),
                 default(IList<TSource>),
-                async (source, state, observer) =>
+                static async (source, state, observer) =>
                 {
                     var (sink, timer) = await AsyncObserver.Buffer(observer, state.timeSpan, state.timeShift, state.scheduler).ConfigureAwait(false);
 
@@ -147,7 +147,7 @@ namespace System.Reactive.Linq
                 source,
                 (timeSpan, count),
                 default(IList<TSource>),
-                async (source, state, observer) =>
+                static async (source, state, observer) =>
                 {
                     var (sink, timer) = await AsyncObserver.Buffer(observer, state.timeSpan, state.count).ConfigureAwait(false);
 
@@ -172,7 +172,7 @@ namespace System.Reactive.Linq
                 source,
                 (timeSpan, count, scheduler),
                 default(IList<TSource>),
-                async (source, state, observer) =>
+                static async (source, state, observer) =>
                 {
                     var (sink, timer) = await AsyncObserver.Buffer(observer, state.timeSpan, state.count, state.scheduler).ConfigureAwait(false);
 
@@ -193,7 +193,7 @@ namespace System.Reactive.Linq
                 source,
                 bufferBoundaries,
                 default(IList<TSource>),
-                async (source, bufferBoundaries, observer) =>
+                static async (source, bufferBoundaries, observer) =>
                 {
                     var (sourceObserver, boundariesObserver) = AsyncObserver.Buffer<TSource, TBufferBoundary>(observer);
 
@@ -217,7 +217,7 @@ namespace System.Reactive.Linq
                 source,
                 bufferClosingSelector,
                 default(IList<TSource>),
-                async (source, bufferClosingSelector, observer) =>
+                static async (source, bufferClosingSelector, observer) =>
                 {
                     var (sourceObserver, closingDisposable) = await AsyncObserver.Buffer<TSource, TBufferClosing>(observer, bufferClosingSelector).ConfigureAwait(false);
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Buffer.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Buffer.cs
@@ -19,10 +19,9 @@ namespace System.Reactive.Linq
             if (count <= 0)
                 throw new ArgumentNullException(nameof(count));
 
-            return Create(
+            return Build<IList<TSource>>.From(
                 source,
                 count,
-                default(IList<TSource>),
                 static (source, count, observer) => source.SubscribeSafeAsync(AsyncObserver.Buffer(observer, count)));
         }
 
@@ -35,10 +34,9 @@ namespace System.Reactive.Linq
             if (skip <= 0)
                 throw new ArgumentNullException(nameof(skip));
 
-            return Create(
+            return Build<IList<TSource>>.From(
                 source,
                 (count, skip),
-                default(IList<TSource>),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Buffer(observer, state.count, state.skip)));
         }
 
@@ -49,10 +47,9 @@ namespace System.Reactive.Linq
             if (timeSpan < TimeSpan.Zero)
                 throw new ArgumentNullException(nameof(timeSpan));
 
-            return Create(
+            return Build<IList<TSource>>.From(
                 source,
                 timeSpan,
-                default(IList<TSource>),
                 static async (source, timeSpan, observer) =>
                 {
                     var (sink, timer) = await AsyncObserver.Buffer(observer, timeSpan).ConfigureAwait(false);
@@ -72,10 +69,9 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Create(
+            return Build<IList<TSource>>.From(
                 source,
                 (timeSpan, scheduler),
-                default(IList<TSource>),
                 static async (source, state, observer) =>
                 {
                     var (sink, timer) = await AsyncObserver.Buffer(observer, state.timeSpan, state.scheduler).ConfigureAwait(false);
@@ -95,10 +91,9 @@ namespace System.Reactive.Linq
             if (timeShift < TimeSpan.Zero)
                 throw new ArgumentNullException(nameof(timeShift));
 
-            return Create(
+            return Build<IList<TSource>>.From(
                 source,
                 (timeSpan, timeShift),
-                default(IList<TSource>),
                 static async (source, state, observer) =>
                 {
                     var (sink, timer) = await AsyncObserver.Buffer(observer, state.timeSpan, state.timeShift).ConfigureAwait(false);
@@ -120,10 +115,9 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Create(
+            return Build<IList<TSource>>.From(
                 source,
                 (timeSpan, timeShift, scheduler),
-                default(IList<TSource>),
                 static async (source, state, observer) =>
                 {
                     var (sink, timer) = await AsyncObserver.Buffer(observer, state.timeSpan, state.timeShift, state.scheduler).ConfigureAwait(false);
@@ -143,10 +137,9 @@ namespace System.Reactive.Linq
             if (count <= 0)
                 throw new ArgumentNullException(nameof(count));
 
-            return Create(
+            return Build<IList<TSource>>.From(
                 source,
                 (timeSpan, count),
-                default(IList<TSource>),
                 static async (source, state, observer) =>
                 {
                     var (sink, timer) = await AsyncObserver.Buffer(observer, state.timeSpan, state.count).ConfigureAwait(false);
@@ -168,10 +161,9 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Create(
+            return Build<IList<TSource>>.From(
                 source,
                 (timeSpan, count, scheduler),
-                default(IList<TSource>),
                 static async (source, state, observer) =>
                 {
                     var (sink, timer) = await AsyncObserver.Buffer(observer, state.timeSpan, state.count, state.scheduler).ConfigureAwait(false);
@@ -189,10 +181,9 @@ namespace System.Reactive.Linq
             if (bufferBoundaries == null)
                 throw new ArgumentNullException(nameof(bufferBoundaries));
 
-            return Create(
+            return Build<IList<TSource>>.From(
                 source,
                 bufferBoundaries,
-                default(IList<TSource>),
                 static async (source, bufferBoundaries, observer) =>
                 {
                     var (sourceObserver, boundariesObserver) = AsyncObserver.Buffer<TSource, TBufferBoundary>(observer);
@@ -213,10 +204,9 @@ namespace System.Reactive.Linq
             if (bufferClosingSelector == null)
                 throw new ArgumentNullException(nameof(bufferClosingSelector));
 
-            return Create(
+            return Build<IList<TSource>>.From(
                 source,
                 bufferClosingSelector,
-                default(IList<TSource>),
                 static async (source, bufferClosingSelector, observer) =>
                 {
                     var (sourceObserver, closingDisposable) = await AsyncObserver.Buffer<TSource, TBufferClosing>(observer, bufferClosingSelector).ConfigureAwait(false);

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Buffer.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Buffer.cs
@@ -19,7 +19,7 @@ namespace System.Reactive.Linq
             if (count <= 0)
                 throw new ArgumentNullException(nameof(count));
 
-            return Build<IList<TSource>>.From(
+            return CreateAsyncObservable<IList<TSource>>.From(
                 source,
                 count,
                 static (source, count, observer) => source.SubscribeSafeAsync(AsyncObserver.Buffer(observer, count)));
@@ -34,7 +34,7 @@ namespace System.Reactive.Linq
             if (skip <= 0)
                 throw new ArgumentNullException(nameof(skip));
 
-            return Build<IList<TSource>>.From(
+            return CreateAsyncObservable<IList<TSource>>.From(
                 source,
                 (count, skip),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Buffer(observer, state.count, state.skip)));
@@ -47,7 +47,7 @@ namespace System.Reactive.Linq
             if (timeSpan < TimeSpan.Zero)
                 throw new ArgumentNullException(nameof(timeSpan));
 
-            return Build<IList<TSource>>.From(
+            return CreateAsyncObservable<IList<TSource>>.From(
                 source,
                 timeSpan,
                 static async (source, timeSpan, observer) =>
@@ -69,7 +69,7 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Build<IList<TSource>>.From(
+            return CreateAsyncObservable<IList<TSource>>.From(
                 source,
                 (timeSpan, scheduler),
                 static async (source, state, observer) =>
@@ -91,7 +91,7 @@ namespace System.Reactive.Linq
             if (timeShift < TimeSpan.Zero)
                 throw new ArgumentNullException(nameof(timeShift));
 
-            return Build<IList<TSource>>.From(
+            return CreateAsyncObservable<IList<TSource>>.From(
                 source,
                 (timeSpan, timeShift),
                 static async (source, state, observer) =>
@@ -115,7 +115,7 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Build<IList<TSource>>.From(
+            return CreateAsyncObservable<IList<TSource>>.From(
                 source,
                 (timeSpan, timeShift, scheduler),
                 static async (source, state, observer) =>
@@ -137,7 +137,7 @@ namespace System.Reactive.Linq
             if (count <= 0)
                 throw new ArgumentNullException(nameof(count));
 
-            return Build<IList<TSource>>.From(
+            return CreateAsyncObservable<IList<TSource>>.From(
                 source,
                 (timeSpan, count),
                 static async (source, state, observer) =>
@@ -161,7 +161,7 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Build<IList<TSource>>.From(
+            return CreateAsyncObservable<IList<TSource>>.From(
                 source,
                 (timeSpan, count, scheduler),
                 static async (source, state, observer) =>
@@ -181,7 +181,7 @@ namespace System.Reactive.Linq
             if (bufferBoundaries == null)
                 throw new ArgumentNullException(nameof(bufferBoundaries));
 
-            return Build<IList<TSource>>.From(
+            return CreateAsyncObservable<IList<TSource>>.From(
                 source,
                 bufferBoundaries,
                 static async (source, bufferBoundaries, observer) =>
@@ -204,7 +204,7 @@ namespace System.Reactive.Linq
             if (bufferClosingSelector == null)
                 throw new ArgumentNullException(nameof(bufferClosingSelector));
 
-            return Build<IList<TSource>>.From(
+            return CreateAsyncObservable<IList<TSource>>.From(
                 source,
                 bufferClosingSelector,
                 static async (source, bufferClosingSelector, observer) =>

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Buffer.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Buffer.cs
@@ -19,7 +19,11 @@ namespace System.Reactive.Linq
             if (count <= 0)
                 throw new ArgumentNullException(nameof(count));
 
-            return Create<IList<TSource>>(observer => source.SubscribeSafeAsync(AsyncObserver.Buffer(observer, count)));
+            return Create(
+                source,
+                count,
+                default(IList<TSource>),
+                (source, count, observer) => source.SubscribeSafeAsync(AsyncObserver.Buffer(observer, count)));
         }
 
         public static IAsyncObservable<IList<TSource>> Buffer<TSource>(this IAsyncObservable<TSource> source, int count, int skip)
@@ -31,7 +35,11 @@ namespace System.Reactive.Linq
             if (skip <= 0)
                 throw new ArgumentNullException(nameof(skip));
 
-            return Create<IList<TSource>>(observer => source.SubscribeSafeAsync(AsyncObserver.Buffer(observer, count, skip)));
+            return Create(
+                source,
+                (count, skip),
+                default(IList<TSource>),
+                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Buffer(observer, state.count, state.skip)));
         }
 
         public static IAsyncObservable<IList<TSource>> Buffer<TSource>(this IAsyncObservable<TSource> source, TimeSpan timeSpan)
@@ -41,14 +49,18 @@ namespace System.Reactive.Linq
             if (timeSpan < TimeSpan.Zero)
                 throw new ArgumentNullException(nameof(timeSpan));
 
-            return Create<IList<TSource>>(async observer =>
-            {
-                var (sink, timer) = await AsyncObserver.Buffer(observer, timeSpan).ConfigureAwait(false);
+            return Create(
+                source,
+                timeSpan,
+                default(IList<TSource>),
+                async (source, timeSpan, observer) =>
+                {
+                    var (sink, timer) = await AsyncObserver.Buffer(observer, timeSpan).ConfigureAwait(false);
 
-                var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, timer);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, timer);
+                });
         }
 
         public static IAsyncObservable<IList<TSource>> Buffer<TSource>(this IAsyncObservable<TSource> source, TimeSpan timeSpan, IAsyncScheduler scheduler)
@@ -60,14 +72,18 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Create<IList<TSource>>(async observer =>
-            {
-                var (sink, timer) = await AsyncObserver.Buffer(observer, timeSpan, scheduler).ConfigureAwait(false);
+            return Create(
+                source,
+                (timeSpan, scheduler),
+                default(IList<TSource>),
+                async (source, state, observer) =>
+                {
+                    var (sink, timer) = await AsyncObserver.Buffer(observer, state.timeSpan, state.scheduler).ConfigureAwait(false);
 
-                var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, timer);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, timer);
+                });
         }
 
         public static IAsyncObservable<IList<TSource>> Buffer<TSource>(this IAsyncObservable<TSource> source, TimeSpan timeSpan, TimeSpan timeShift)
@@ -79,14 +95,18 @@ namespace System.Reactive.Linq
             if (timeShift < TimeSpan.Zero)
                 throw new ArgumentNullException(nameof(timeShift));
 
-            return Create<IList<TSource>>(async observer =>
-            {
-                var (sink, timer) = await AsyncObserver.Buffer(observer, timeSpan, timeShift).ConfigureAwait(false);
+            return Create(
+                source,
+                (timeSpan, timeShift),
+                default(IList<TSource>),
+                async (source, state, observer) =>
+                {
+                    var (sink, timer) = await AsyncObserver.Buffer(observer, state.timeSpan, state.timeShift).ConfigureAwait(false);
 
-                var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, timer);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, timer);
+                });
         }
 
         public static IAsyncObservable<IList<TSource>> Buffer<TSource>(this IAsyncObservable<TSource> source, TimeSpan timeSpan, TimeSpan timeShift, IAsyncScheduler scheduler)
@@ -100,14 +120,18 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Create<IList<TSource>>(async observer =>
-            {
-                var (sink, timer) = await AsyncObserver.Buffer(observer, timeSpan, timeShift, scheduler).ConfigureAwait(false);
+            return Create(
+                source,
+                (timeSpan, timeShift, scheduler),
+                default(IList<TSource>),
+                async (source, state, observer) =>
+                {
+                    var (sink, timer) = await AsyncObserver.Buffer(observer, state.timeSpan, state.timeShift, state.scheduler).ConfigureAwait(false);
 
-                var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, timer);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, timer);
+                });
         }
 
         public static IAsyncObservable<IList<TSource>> Buffer<TSource>(this IAsyncObservable<TSource> source, TimeSpan timeSpan, int count)
@@ -119,14 +143,18 @@ namespace System.Reactive.Linq
             if (count <= 0)
                 throw new ArgumentNullException(nameof(count));
 
-            return Create<IList<TSource>>(async observer =>
-            {
-                var (sink, timer) = await AsyncObserver.Buffer(observer, timeSpan, count).ConfigureAwait(false);
+            return Create(
+                source,
+                (timeSpan, count),
+                default(IList<TSource>),
+                async (source, state, observer) =>
+                {
+                    var (sink, timer) = await AsyncObserver.Buffer(observer, state.timeSpan, state.count).ConfigureAwait(false);
 
-                var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, timer);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, timer);
+                });
         }
 
         public static IAsyncObservable<IList<TSource>> Buffer<TSource>(this IAsyncObservable<TSource> source, TimeSpan timeSpan, int count, IAsyncScheduler scheduler)
@@ -140,14 +168,18 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Create<IList<TSource>>(async observer =>
-            {
-                var (sink, timer) = await AsyncObserver.Buffer(observer, timeSpan, count, scheduler).ConfigureAwait(false);
+            return Create(
+                source,
+                (timeSpan, count, scheduler),
+                default(IList<TSource>),
+                async (source, state, observer) =>
+                {
+                    var (sink, timer) = await AsyncObserver.Buffer(observer, state.timeSpan, state.count, state.scheduler).ConfigureAwait(false);
 
-                var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, timer);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, timer);
+                });
         }
 
         public static IAsyncObservable<IList<TSource>> Buffer<TSource, TBufferBoundary>(this IAsyncObservable<TSource> source, IAsyncObservable<TBufferBoundary> bufferBoundaries)
@@ -157,15 +189,19 @@ namespace System.Reactive.Linq
             if (bufferBoundaries == null)
                 throw new ArgumentNullException(nameof(bufferBoundaries));
 
-            return Create<IList<TSource>>(async observer =>
-            {
-                var (sourceObserver, boundariesObserver) = AsyncObserver.Buffer<TSource, TBufferBoundary>(observer);
+            return Create(
+                source,
+                bufferBoundaries,
+                default(IList<TSource>),
+                async (source, bufferBoundaries, observer) =>
+                {
+                    var (sourceObserver, boundariesObserver) = AsyncObserver.Buffer<TSource, TBufferBoundary>(observer);
 
-                var sourceSubscription = await source.SubscribeSafeAsync(sourceObserver).ConfigureAwait(false);
-                var boundariesSubscription = await bufferBoundaries.SubscribeSafeAsync(boundariesObserver).ConfigureAwait(false);
+                    var sourceSubscription = await source.SubscribeSafeAsync(sourceObserver).ConfigureAwait(false);
+                    var boundariesSubscription = await bufferBoundaries.SubscribeSafeAsync(boundariesObserver).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(sourceSubscription, boundariesSubscription);
-            });
+                    return StableCompositeAsyncDisposable.Create(sourceSubscription, boundariesSubscription);
+                });
         }
 
         // REVIEW: This overload is inherited from Rx but arguably a bit esoteric as it doesn't provide context to the closing selector.
@@ -177,14 +213,18 @@ namespace System.Reactive.Linq
             if (bufferClosingSelector == null)
                 throw new ArgumentNullException(nameof(bufferClosingSelector));
 
-            return Create<IList<TSource>>(async observer =>
-            {
-                var (sourceObserver, closingDisposable) = await AsyncObserver.Buffer<TSource, TBufferClosing>(observer, bufferClosingSelector).ConfigureAwait(false);
+            return Create(
+                source,
+                bufferClosingSelector,
+                default(IList<TSource>),
+                async (source, bufferClosingSelector, observer) =>
+                {
+                    var (sourceObserver, closingDisposable) = await AsyncObserver.Buffer<TSource, TBufferClosing>(observer, bufferClosingSelector).ConfigureAwait(false);
 
-                var sourceSubscription = await source.SubscribeSafeAsync(sourceObserver).ConfigureAwait(false);
+                    var sourceSubscription = await source.SubscribeSafeAsync(sourceObserver).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(sourceSubscription, closingDisposable);
-            });
+                    return StableCompositeAsyncDisposable.Create(sourceSubscription, closingDisposable);
+                });
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Catch.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Catch.cs
@@ -20,14 +20,17 @@ namespace System.Reactive.Linq
             if (handler == null)
                 throw new ArgumentNullException(nameof(handler));
 
-            return Create<TSource>(async observer =>
-            {
-                var (sink, inner) = AsyncObserver.Catch(observer, handler);
+            return Create(
+                source,
+                handler,
+                async (source, handler, observer) =>
+                {
+                    var (sink, inner) = AsyncObserver.Catch(observer, handler);
 
-                var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, inner);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, inner);
+                });
         }
 
         public static IAsyncObservable<TSource> Catch<TSource, TException>(this IAsyncObservable<TSource> source, Func<TException, ValueTask<IAsyncObservable<TSource>>> handler)
@@ -38,14 +41,17 @@ namespace System.Reactive.Linq
             if (handler == null)
                 throw new ArgumentNullException(nameof(handler));
 
-            return Create<TSource>(async observer =>
-            {
-                var (sink, inner) = AsyncObserver.Catch(observer, handler);
+            return Create(
+                source,
+                handler,
+                async (source, handler, observer) =>
+                {
+                    var (sink, inner) = AsyncObserver.Catch(observer, handler);
 
-                var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, inner);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, inner);
+                });
         }
 
         public static IAsyncObservable<TSource> Catch<TSource>(this IAsyncObservable<TSource> first, IAsyncObservable<TSource> second)
@@ -55,14 +61,17 @@ namespace System.Reactive.Linq
             if (second == null)
                 throw new ArgumentNullException(nameof(second));
 
-            return Create<TSource>(async observer =>
-            {
-                var (sink, inner) = AsyncObserver.Catch(observer, second);
+            return Create(
+                first,
+                second,
+                async (first, second, observer) =>
+                {
+                    var (sink, inner) = AsyncObserver.Catch(observer, second);
 
-                var subscription = await first.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await first.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, inner);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, inner);
+                });
         }
 
         public static IAsyncObservable<TSource> Catch<TSource>(params IAsyncObservable<TSource>[] sources) => Catch((IEnumerable<IAsyncObservable<TSource>>)sources);

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Concat.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Concat.cs
@@ -19,14 +19,17 @@ namespace System.Reactive.Linq
             if (second == null)
                 throw new ArgumentNullException(nameof(second));
 
-            return Create<TSource>(async observer =>
-            {
-                var (sink, inner) = AsyncObserver.Concat(observer, second);
+            return Create(
+                first,
+                second,
+                async (first, second, observer) =>
+                {
+                    var (sink, inner) = AsyncObserver.Concat(observer, second);
 
-                var subscription = await first.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await first.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, inner);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, inner);
+                });
         }
 
         public static IAsyncObservable<TSource> Concat<TSource>(params IAsyncObservable<TSource>[] sources) => Concat((IEnumerable<IAsyncObservable<TSource>>)sources);

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Contains.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Contains.cs
@@ -17,7 +17,7 @@ namespace System.Reactive.Linq
                 source,
                 element,
                 default(bool),
-                (source, element, observer) => source.SubscribeSafeAsync(AsyncObserver.Contains(observer, element)));
+                static (source, element, observer) => source.SubscribeSafeAsync(AsyncObserver.Contains(observer, element)));
         }
 
         public static IAsyncObservable<bool> Contains<TSource>(this IAsyncObservable<TSource> source, TSource element, IEqualityComparer<TSource> comparer)
@@ -31,7 +31,7 @@ namespace System.Reactive.Linq
                 source,
                 (element, comparer),
                 default(bool),
-                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Contains(observer, state.element, state.comparer)));
+                static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Contains(observer, state.element, state.comparer)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Contains.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Contains.cs
@@ -13,10 +13,9 @@ namespace System.Reactive.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return Create(
+            return Build<bool>.From(
                 source,
                 element,
-                default(bool),
                 static (source, element, observer) => source.SubscribeSafeAsync(AsyncObserver.Contains(observer, element)));
         }
 
@@ -27,10 +26,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build<bool>.From(
                 source,
                 (element, comparer),
-                default(bool),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Contains(observer, state.element, state.comparer)));
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Contains.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Contains.cs
@@ -13,7 +13,7 @@ namespace System.Reactive.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return Build<bool>.From(
+            return CreateAsyncObservable<bool>.From(
                 source,
                 element,
                 static (source, element, observer) => source.SubscribeSafeAsync(AsyncObserver.Contains(observer, element)));
@@ -26,7 +26,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build<bool>.From(
+            return CreateAsyncObservable<bool>.From(
                 source,
                 (element, comparer),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Contains(observer, state.element, state.comparer)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Contains.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Contains.cs
@@ -13,7 +13,11 @@ namespace System.Reactive.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return Create<bool>(observer => source.SubscribeSafeAsync(AsyncObserver.Contains(observer, element)));
+            return Create(
+                source,
+                element,
+                default(bool),
+                (source, element, observer) => source.SubscribeSafeAsync(AsyncObserver.Contains(observer, element)));
         }
 
         public static IAsyncObservable<bool> Contains<TSource>(this IAsyncObservable<TSource> source, TSource element, IEqualityComparer<TSource> comparer)
@@ -23,7 +27,11 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<bool>(observer => source.SubscribeSafeAsync(AsyncObserver.Contains(observer, element, comparer)));
+            return Create(
+                source,
+                (element, comparer),
+                default(bool),
+                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Contains(observer, state.element, state.comparer)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Count.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Count.cs
@@ -23,7 +23,7 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Build<int>.From(
+            return CreateAsyncObservable<int>.From(
                 source,
                 predicate,
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Count(observer, predicate)));
@@ -36,7 +36,7 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Build<int>.From(
+            return CreateAsyncObservable<int>.From(
                 source,
                 predicate,
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Count(observer, predicate)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Count.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Count.cs
@@ -23,10 +23,9 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(
+            return Build<int>.From(
                 source,
                 predicate,
-                default(int),
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Count(observer, predicate)));
         }
 
@@ -37,10 +36,9 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(
+            return Build<int>.From(
                 source,
                 predicate,
-                default(int),
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Count(observer, predicate)));
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Count.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Count.cs
@@ -23,7 +23,11 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<int>(observer => source.SubscribeSafeAsync(AsyncObserver.Count(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                default(int),
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Count(observer, predicate)));
         }
 
         public static IAsyncObservable<int> Count<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
@@ -33,7 +37,11 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<int>(observer => source.SubscribeSafeAsync(AsyncObserver.Count(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                default(int),
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Count(observer, predicate)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Count.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Count.cs
@@ -27,7 +27,7 @@ namespace System.Reactive.Linq
                 source,
                 predicate,
                 default(int),
-                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Count(observer, predicate)));
+                static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Count(observer, predicate)));
         }
 
         public static IAsyncObservable<int> Count<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
@@ -41,7 +41,7 @@ namespace System.Reactive.Linq
                 source,
                 predicate,
                 default(int),
-                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Count(observer, predicate)));
+                static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Count(observer, predicate)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/DefaultIfEmpty.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/DefaultIfEmpty.cs
@@ -19,7 +19,10 @@ namespace System.Reactive.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.DefaultIfEmpty(observer, defaultValue)));
+            return Create(
+                source,
+                defaultValue,
+                (source, defaultValue, observer) => source.SubscribeSafeAsync(AsyncObserver.DefaultIfEmpty(observer, defaultValue)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Delay.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Delay.cs
@@ -19,14 +19,17 @@ namespace System.Reactive.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return Create<TSource>(async observer =>
-            {
-                var (sink, drain) = await AsyncObserver.Delay(observer, dueTime).ConfigureAwait(false);
+            return Create(
+                source,
+                dueTime,
+                async (source, dueTime, observer) =>
+                {
+                    var (sink, drain) = await AsyncObserver.Delay(observer, dueTime).ConfigureAwait(false);
 
-                var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, drain);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, drain);
+                });
         }
 
         public static IAsyncObservable<TSource> Delay<TSource>(this IAsyncObservable<TSource> source, TimeSpan dueTime, IAsyncScheduler scheduler)
@@ -36,14 +39,17 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Create<TSource>(async observer =>
-            {
-                var (sink, drain) = await AsyncObserver.Delay(observer, dueTime, scheduler).ConfigureAwait(false);
+            return Create(
+                source,
+                (dueTime, scheduler),
+                async (source, state, observer) =>
+                {
+                    var (sink, drain) = await AsyncObserver.Delay(observer, state.dueTime, state.scheduler).ConfigureAwait(false);
 
-                var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, drain);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, drain);
+                });
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/DelaySubscription.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/DelaySubscription.cs
@@ -24,20 +24,23 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Create<TSource>(async observer =>
-            {
-                var d = new CompositeAsyncDisposable();
-
-                var task = await scheduler.ScheduleAsync(async ct =>
+            return Create(
+                source,
+                (dueTime, scheduler),
+                async (source, state, observer) =>
                 {
-                    var inner = await source.SubscribeSafeAsync(observer).ConfigureAwait(false);
-                    await d.AddAsync(inner).ConfigureAwait(false);
-                }, dueTime).ConfigureAwait(false);
+                    var d = new CompositeAsyncDisposable();
 
-                await d.AddAsync(task).ConfigureAwait(false);
+                    var task = await state.scheduler.ScheduleAsync(async ct =>
+                    {
+                        var inner = await source.SubscribeSafeAsync(observer).ConfigureAwait(false);
+                        await d.AddAsync(inner).ConfigureAwait(false);
+                    }, state.dueTime).ConfigureAwait(false);
 
-                return d;
-            });
+                    await d.AddAsync(task).ConfigureAwait(false);
+
+                    return d;
+                });
         }
 
         public static IAsyncObservable<TSource> DelaySubscription<TSource>(this IAsyncObservable<TSource> source, DateTimeOffset dueTime)
@@ -55,20 +58,23 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Create<TSource>(async observer =>
-            {
-                var d = new CompositeAsyncDisposable();
-
-                var task = await scheduler.ScheduleAsync(async ct =>
+            return Create(
+                source,
+                (dueTime, scheduler),
+                async (source, state, observer) =>
                 {
-                    var inner = await source.SubscribeSafeAsync(observer).ConfigureAwait(false);
-                    await d.AddAsync(inner).ConfigureAwait(false);
-                }, dueTime).ConfigureAwait(false);
+                    var d = new CompositeAsyncDisposable();
 
-                await d.AddAsync(task).ConfigureAwait(false);
+                    var task = await state.scheduler.ScheduleAsync(async ct =>
+                    {
+                        var inner = await source.SubscribeSafeAsync(observer).ConfigureAwait(false);
+                        await d.AddAsync(inner).ConfigureAwait(false);
+                    }, state.dueTime).ConfigureAwait(false);
 
-                return d;
-            });
+                    await d.AddAsync(task).ConfigureAwait(false);
+
+                    return d;
+                });
         }
     }
 }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Distinct.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Distinct.cs
@@ -23,7 +23,10 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.Distinct(observer, comparer)));
+            return Create(
+                source,
+                comparer,
+                (source, comparer, observer) => source.SubscribeSafeAsync(AsyncObserver.Distinct(observer, comparer)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/DistinctUntilChanged.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/DistinctUntilChanged.cs
@@ -24,7 +24,10 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.DistinctUntilChanged(observer, comparer)));
+            return Create(
+                source,
+                comparer,
+                (source, comparer, observer) => source.SubscribeSafeAsync(AsyncObserver.DistinctUntilChanged(observer, comparer)));
         }
 
         public static IAsyncObservable<TSource> DistinctUntilChanged<TSource, TKey>(IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector)
@@ -34,7 +37,10 @@ namespace System.Reactive.Linq
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.DistinctUntilChanged(observer, keySelector)));
+            return Create(
+                source,
+                keySelector,
+                (source, keySelector, observer) => source.SubscribeSafeAsync(AsyncObserver.DistinctUntilChanged(observer, keySelector)));
         }
 
         public static IAsyncObservable<TSource> DistinctUntilChanged<TSource, TKey>(IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector)
@@ -44,7 +50,10 @@ namespace System.Reactive.Linq
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.DistinctUntilChanged(observer, keySelector)));
+            return Create(
+                source,
+                keySelector,
+                (source, keySelector, observer) => source.SubscribeSafeAsync(AsyncObserver.DistinctUntilChanged(observer, keySelector)));
         }
 
         public static IAsyncObservable<TSource> DistinctUntilChanged<TSource, TKey>(IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
@@ -56,7 +65,10 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.DistinctUntilChanged(observer, keySelector, comparer)));
+            return Create(
+                source,
+                (keySelector, comparer),
+                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.DistinctUntilChanged(observer, state.keySelector, state.comparer)));
         }
 
         public static IAsyncObservable<TSource> DistinctUntilChanged<TSource, TKey>(IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, IEqualityComparer<TKey> comparer)
@@ -68,7 +80,10 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.DistinctUntilChanged(observer, keySelector, comparer)));
+            return Create(
+                source,
+                (keySelector, comparer),
+                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.DistinctUntilChanged(observer, state.keySelector, state.comparer)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Do.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Do.cs
@@ -15,7 +15,10 @@ namespace System.Reactive.Linq
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
 
-            return Create<TSource>(target => source.SubscribeSafeAsync(AsyncObserver.Do(target, observer)));
+            return Create(
+                source,
+                observer,
+                (source, observer, target) => source.SubscribeSafeAsync(AsyncObserver.Do(target, observer)));
         }
 
         public static IAsyncObservable<TSource> Do<TSource>(this IAsyncObservable<TSource> source, Action<TSource> onNext)
@@ -25,7 +28,10 @@ namespace System.Reactive.Linq
             if (onNext == null)
                 throw new ArgumentNullException(nameof(onNext));
 
-            return Create<TSource>(target => source.SubscribeSafeAsync(AsyncObserver.Do(target, onNext)));
+            return Create(
+                source,
+                onNext,
+                (source, onNext, target) => source.SubscribeSafeAsync(AsyncObserver.Do(target, onNext)));
         }
 
         public static IAsyncObservable<TSource> Do<TSource>(this IAsyncObservable<TSource> source, Action<Exception> onError)
@@ -35,7 +41,10 @@ namespace System.Reactive.Linq
             if (onError == null)
                 throw new ArgumentNullException(nameof(onError));
 
-            return Create<TSource>(target => source.SubscribeSafeAsync(AsyncObserver.Do(target, onError)));
+            return Create(
+                source,
+                onError,
+                (source, onError, target) => source.SubscribeSafeAsync(AsyncObserver.Do(target, onError)));
         }
 
         public static IAsyncObservable<TSource> Do<TSource>(this IAsyncObservable<TSource> source, Action onCompleted)
@@ -45,7 +54,10 @@ namespace System.Reactive.Linq
             if (onCompleted == null)
                 throw new ArgumentNullException(nameof(onCompleted));
 
-            return Create<TSource>(target => source.SubscribeSafeAsync(AsyncObserver.Do(target, onCompleted)));
+            return Create(
+                source,
+                onCompleted,
+                (source, onCompleted, target) => source.SubscribeSafeAsync(AsyncObserver.Do(target, onCompleted)));
         }
 
         public static IAsyncObservable<TSource> Do<TSource>(this IAsyncObservable<TSource> source, Action<TSource> onNext, Action<Exception> onError, Action onCompleted)
@@ -59,7 +71,10 @@ namespace System.Reactive.Linq
             if (onCompleted == null)
                 throw new ArgumentNullException(nameof(onCompleted));
 
-            return Create<TSource>(target => source.SubscribeSafeAsync(AsyncObserver.Do(target, onNext, onError, onCompleted)));
+            return Create(
+                source,
+                (onNext, onError, onCompleted),
+                (source, state, target) => source.SubscribeSafeAsync(AsyncObserver.Do(target, state.onNext, state.onError, state.onCompleted)));
         }
 
         public static IAsyncObservable<TSource> Do<TSource>(this IAsyncObservable<TSource> source, IAsyncObserver<TSource> observer)
@@ -69,7 +84,10 @@ namespace System.Reactive.Linq
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
 
-            return Create<TSource>(target => source.SubscribeSafeAsync(AsyncObserver.Do(target, observer)));
+            return Create(
+                source,
+                observer,
+                (source, observer, target) => source.SubscribeSafeAsync(AsyncObserver.Do(target, observer)));
         }
 
         public static IAsyncObservable<TSource> Do<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask> onNext)
@@ -79,7 +97,10 @@ namespace System.Reactive.Linq
             if (onNext == null)
                 throw new ArgumentNullException(nameof(onNext));
 
-            return Create<TSource>(target => source.SubscribeSafeAsync(AsyncObserver.Do(target, onNext)));
+            return Create(
+                source,
+                onNext,
+                (source, onNext, target) => source.SubscribeSafeAsync(AsyncObserver.Do(target, onNext)));
         }
 
         public static IAsyncObservable<TSource> Do<TSource>(this IAsyncObservable<TSource> source, Func<Exception, ValueTask> onError)
@@ -89,7 +110,10 @@ namespace System.Reactive.Linq
             if (onError == null)
                 throw new ArgumentNullException(nameof(onError));
 
-            return Create<TSource>(target => source.SubscribeSafeAsync(AsyncObserver.Do(target, onError)));
+            return Create(
+                source,
+                onError,
+                (source, onError, target) => source.SubscribeSafeAsync(AsyncObserver.Do(target, onError)));
         }
 
         public static IAsyncObservable<TSource> Do<TSource>(this IAsyncObservable<TSource> source, Func<ValueTask> onCompleted)
@@ -99,7 +123,10 @@ namespace System.Reactive.Linq
             if (onCompleted == null)
                 throw new ArgumentNullException(nameof(onCompleted));
 
-            return Create<TSource>(target => source.SubscribeSafeAsync(AsyncObserver.Do(target, onCompleted)));
+            return Create(
+                source,
+                onCompleted,
+                (source, onCompleted, target) => source.SubscribeSafeAsync(AsyncObserver.Do(target, onCompleted)));
         }
 
         public static IAsyncObservable<TSource> Do<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask> onNext, Func<Exception, ValueTask> onError, Func<ValueTask> onCompleted)
@@ -113,7 +140,10 @@ namespace System.Reactive.Linq
             if (onCompleted == null)
                 throw new ArgumentNullException(nameof(onCompleted));
 
-            return Create<TSource>(target => source.SubscribeSafeAsync(AsyncObserver.Do(target, onNext, onError, onCompleted)));
+            return Create(
+                source,
+                (onNext, onError, onCompleted),
+                (source, state, target) => source.SubscribeSafeAsync(AsyncObserver.Do(target, state.onNext, state.onError, state.onCompleted)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/DoWhile.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/DoWhile.cs
@@ -18,55 +18,58 @@ namespace System.Reactive.Linq
             if (condition == null)
                 throw new ArgumentNullException(nameof(condition));
 
-            return Create<TSource>(async observer =>
-            {
-                var subscription = new SerialAsyncDisposable();
-
-                var o = default(IAsyncObserver<TSource>);
-
-                o = AsyncObserver.CreateUnsafe<TSource>(
-                        observer.OnNextAsync,
-                        observer.OnErrorAsync,
-                        MoveNext
-                    );
-
-                async Task Subscribe()
+            return Create(
+                source,
+                condition,
+                async (source, condition, observer) =>
                 {
-                    var sad = new SingleAssignmentAsyncDisposable();
-                    await subscription.AssignAsync(sad).ConfigureAwait(false);
+                    var subscription = new SerialAsyncDisposable();
 
-                    var d = await source.SubscribeSafeAsync(o).ConfigureAwait(false);
-                    await sad.AssignAsync(d).ConfigureAwait(false);
-                }
+                    var o = default(IAsyncObserver<TSource>);
 
-                async ValueTask MoveNext()
-                {
-                    var b = default(bool);
+                    o = AsyncObserver.CreateUnsafe<TSource>(
+                            observer.OnNextAsync,
+                            observer.OnErrorAsync,
+                            MoveNext
+                        );
 
-                    try
+                    async Task Subscribe()
                     {
-                        b = condition();
-                    }
-                    catch (Exception ex)
-                    {
-                        await observer.OnErrorAsync(ex).ConfigureAwait(false);
-                        return;
+                        var sad = new SingleAssignmentAsyncDisposable();
+                        await subscription.AssignAsync(sad).ConfigureAwait(false);
+
+                        var d = await source.SubscribeSafeAsync(o).ConfigureAwait(false);
+                        await sad.AssignAsync(d).ConfigureAwait(false);
                     }
 
-                    if (b)
+                    async ValueTask MoveNext()
                     {
-                        await Subscribe().ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        await observer.OnCompletedAsync().ConfigureAwait(false);
-                    }
-                }
+                        var b = default(bool);
 
-                await Subscribe().ConfigureAwait(false);
+                        try
+                        {
+                            b = condition();
+                        }
+                        catch (Exception ex)
+                        {
+                            await observer.OnErrorAsync(ex).ConfigureAwait(false);
+                            return;
+                        }
 
-                return subscription;
-            });
+                        if (b)
+                        {
+                            await Subscribe().ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            await observer.OnCompletedAsync().ConfigureAwait(false);
+                        }
+                    }
+
+                    await Subscribe().ConfigureAwait(false);
+
+                    return subscription;
+                });
         }
 
         public static IAsyncObservable<TSource> DoWhile<TSource>(IAsyncObservable<TSource> source, Func<ValueTask<bool>> condition)
@@ -76,55 +79,58 @@ namespace System.Reactive.Linq
             if (condition == null)
                 throw new ArgumentNullException(nameof(condition));
 
-            return Create<TSource>(async observer =>
-            {
-                var subscription = new SerialAsyncDisposable();
-
-                var o = default(IAsyncObserver<TSource>);
-
-                o = AsyncObserver.CreateUnsafe<TSource>(
-                        observer.OnNextAsync,
-                        observer.OnErrorAsync,
-                        MoveNext
-                    );
-
-                async Task Subscribe()
+            return Create(
+                source,
+                condition,
+                async (source, condition, observer) =>
                 {
-                    var sad = new SingleAssignmentAsyncDisposable();
-                    await subscription.AssignAsync(sad).ConfigureAwait(false);
+                    var subscription = new SerialAsyncDisposable();
 
-                    var d = await source.SubscribeSafeAsync(o).ConfigureAwait(false);
-                    await sad.AssignAsync(d).ConfigureAwait(false);
-                }
+                    var o = default(IAsyncObserver<TSource>);
 
-                async ValueTask MoveNext()
-                {
-                    var b = default(bool);
+                    o = AsyncObserver.CreateUnsafe<TSource>(
+                            observer.OnNextAsync,
+                            observer.OnErrorAsync,
+                            MoveNext
+                        );
 
-                    try
+                    async Task Subscribe()
                     {
-                        b = await condition().ConfigureAwait(false);
-                    }
-                    catch (Exception ex)
-                    {
-                        await observer.OnErrorAsync(ex).ConfigureAwait(false);
-                        return;
+                        var sad = new SingleAssignmentAsyncDisposable();
+                        await subscription.AssignAsync(sad).ConfigureAwait(false);
+
+                        var d = await source.SubscribeSafeAsync(o).ConfigureAwait(false);
+                        await sad.AssignAsync(d).ConfigureAwait(false);
                     }
 
-                    if (b)
+                    async ValueTask MoveNext()
                     {
-                        await Subscribe().ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        await observer.OnCompletedAsync().ConfigureAwait(false);
-                    }
-                }
+                        var b = default(bool);
 
-                await Subscribe().ConfigureAwait(false);
+                        try
+                        {
+                            b = await condition().ConfigureAwait(false);
+                        }
+                        catch (Exception ex)
+                        {
+                            await observer.OnErrorAsync(ex).ConfigureAwait(false);
+                            return;
+                        }
 
-                return subscription;
-            });
+                        if (b)
+                        {
+                            await Subscribe().ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            await observer.OnCompletedAsync().ConfigureAwait(false);
+                        }
+                    }
+
+                    await Subscribe().ConfigureAwait(false);
+
+                    return subscription;
+                });
         }
     }
 }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ElementAt.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ElementAt.cs
@@ -15,7 +15,10 @@ namespace System.Reactive.Linq
             if (index < 0)
                 throw new ArgumentOutOfRangeException(nameof(index));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.ElementAt(observer, index)));
+            return Create(
+                source,
+                index,
+                (source, index, observer) => source.SubscribeSafeAsync(AsyncObserver.ElementAt(observer, index)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ElementAtOrDefault.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ElementAtOrDefault.cs
@@ -13,7 +13,10 @@ namespace System.Reactive.Linq
             if (index < 0)
                 throw new ArgumentOutOfRangeException(nameof(index));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.ElementAtOrDefault(observer, index)));
+            return Create(
+                source,
+                index,
+                (source, index, observer) => source.SubscribeSafeAsync(AsyncObserver.ElementAtOrDefault(observer, index)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Finally.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Finally.cs
@@ -16,22 +16,25 @@ namespace System.Reactive.Linq
             if (finallyAction == null)
                 throw new ArgumentNullException(nameof(finallyAction));
 
-            return Create<TSource>(async observer =>
-            {
-                var subscription = await source.SubscribeSafeAsync(observer).ConfigureAwait(false);
-
-                return AsyncDisposable.Create(async () =>
+            return Create(
+                source,
+                finallyAction,
+                async (source, finallyAction, observer) =>
                 {
-                    try
+                    var subscription = await source.SubscribeSafeAsync(observer).ConfigureAwait(false);
+
+                    return AsyncDisposable.Create(async () =>
                     {
-                        await subscription.DisposeAsync().ConfigureAwait(false);
-                    }
-                    finally
-                    {
-                        finallyAction();
-                    }
+                        try
+                        {
+                            await subscription.DisposeAsync().ConfigureAwait(false);
+                        }
+                        finally
+                        {
+                            finallyAction();
+                        }
+                    });
                 });
-            });
         }
 
         public static IAsyncObservable<TSource> Finally<TSource>(this IAsyncObservable<TSource> source, Func<Task> finallyAction)
@@ -41,22 +44,25 @@ namespace System.Reactive.Linq
             if (finallyAction == null)
                 throw new ArgumentNullException(nameof(finallyAction));
 
-            return Create<TSource>(async observer =>
-            {
-                var subscription = await source.SubscribeSafeAsync(observer).ConfigureAwait(false);
-
-                return AsyncDisposable.Create(async () =>
+            return Create(
+                source,
+                finallyAction,
+                async (source, finallyAction, observer) =>
                 {
-                    try
+                    var subscription = await source.SubscribeSafeAsync(observer).ConfigureAwait(false);
+
+                    return AsyncDisposable.Create(async () =>
                     {
-                        await subscription.DisposeAsync().ConfigureAwait(false);
-                    }
-                    finally
-                    {
-                        await finallyAction().ConfigureAwait(false);
-                    }
+                        try
+                        {
+                            await subscription.DisposeAsync().ConfigureAwait(false);
+                        }
+                        finally
+                        {
+                            await finallyAction().ConfigureAwait(false);
+                        }
+                    });
                 });
-            });
         }
     }
 }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/First.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/First.cs
@@ -27,7 +27,10 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.First(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.First(observer, predicate)));
         }
 
         public static IAsyncObservable<TSource> First<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
@@ -37,7 +40,10 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.First(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.First(observer, predicate)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/FirstOrDefault.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/FirstOrDefault.cs
@@ -27,7 +27,10 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.FirstOrDefault(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.FirstOrDefault(observer, predicate)));
         }
 
         public static IAsyncObservable<TSource> FirstOrDefault<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
@@ -37,7 +40,10 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.FirstOrDefault(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.FirstOrDefault(observer, predicate)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/GroupBy.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/GroupBy.cs
@@ -18,10 +18,9 @@ namespace System.Reactive.Linq
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 keySelector,
-                default(IGroupedAsyncObservable<TKey, TSource>),
                 static (source, keySelector, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector)));
         }
 
@@ -34,10 +33,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 (keySelector, comparer),
-                default(IGroupedAsyncObservable<TKey, TSource>),
                 static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.comparer)));
         }
 
@@ -50,10 +48,9 @@ namespace System.Reactive.Linq
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 (keySelector, capacity),
-                default(IGroupedAsyncObservable<TKey, TSource>),
                 static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.capacity)));
         }
 
@@ -68,10 +65,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 (keySelector, capacity, comparer),
-                default(IGroupedAsyncObservable<TKey, TSource>),
                 static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.capacity, state.comparer)));
         }
 
@@ -84,10 +80,9 @@ namespace System.Reactive.Linq
             if (elementSelector == null)
                 throw new ArgumentNullException(nameof(elementSelector));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector),
-                default(IGroupedAsyncObservable<TKey, TElement>),
                 static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector)));
         }
 
@@ -102,10 +97,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector, comparer),
-                default(IGroupedAsyncObservable<TKey, TElement>),
                 static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.comparer)));
         }
 
@@ -120,10 +114,9 @@ namespace System.Reactive.Linq
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector, capacity),
-                default(IGroupedAsyncObservable<TKey, TElement>),
                 static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.capacity)));
         }
 
@@ -140,10 +133,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector, capacity, comparer),
-                default(IGroupedAsyncObservable<TKey, TElement>),
                 static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.capacity, state.comparer)));
         }
 
@@ -154,10 +146,9 @@ namespace System.Reactive.Linq
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 keySelector,
-                default(IGroupedAsyncObservable<TKey, TSource>),
                 static (source, keySelector, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector)));
         }
 
@@ -170,10 +161,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 (keySelector, comparer),
-                default(IGroupedAsyncObservable<TKey, TSource>),
                 static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.comparer)));
         }
 
@@ -186,10 +176,9 @@ namespace System.Reactive.Linq
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 (keySelector, capacity),
-                default(IGroupedAsyncObservable<TKey, TSource>),
                 static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.capacity)));
         }
 
@@ -204,10 +193,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 (keySelector, capacity, comparer),
-                default(IGroupedAsyncObservable<TKey, TSource>),
                 static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.capacity, state.comparer)));
         }
 
@@ -220,10 +208,9 @@ namespace System.Reactive.Linq
             if (elementSelector == null)
                 throw new ArgumentNullException(nameof(elementSelector));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector),
-                default(IGroupedAsyncObservable<TKey, TElement>),
                 static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector)));
         }
 
@@ -238,10 +225,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector, comparer),
-                default(IGroupedAsyncObservable<TKey, TElement>),
                 static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.comparer)));
         }
 
@@ -256,10 +242,9 @@ namespace System.Reactive.Linq
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector, capacity),
-                default(IGroupedAsyncObservable<TKey, TElement>),
                 static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.capacity)));
         }
 
@@ -276,10 +261,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build< IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector, capacity, comparer),
-                default(IGroupedAsyncObservable<TKey, TElement>),
                 static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.capacity, state.comparer)));
         }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/GroupBy.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/GroupBy.cs
@@ -22,7 +22,7 @@ namespace System.Reactive.Linq
                 source,
                 keySelector,
                 default(IGroupedAsyncObservable<TKey, TSource>),
-                (source, keySelector, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector)));
+                static (source, keySelector, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupBy<TSource, TKey>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
@@ -38,7 +38,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, comparer),
                 default(IGroupedAsyncObservable<TKey, TSource>),
-                (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.comparer)));
+                static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.comparer)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupBy<TSource, TKey>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, int capacity)
@@ -54,7 +54,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, capacity),
                 default(IGroupedAsyncObservable<TKey, TSource>),
-                (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.capacity)));
+                static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.capacity)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupBy<TSource, TKey>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, int capacity, IEqualityComparer<TKey> comparer)
@@ -72,7 +72,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, capacity, comparer),
                 default(IGroupedAsyncObservable<TKey, TSource>),
-                (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.capacity, state.comparer)));
+                static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.capacity, state.comparer)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
@@ -88,7 +88,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, elementSelector),
                 default(IGroupedAsyncObservable<TKey, TElement>),
-                (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector)));
+                static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
@@ -106,7 +106,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, elementSelector, comparer),
                 default(IGroupedAsyncObservable<TKey, TElement>),
-                (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.comparer)));
+                static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.comparer)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, int capacity)
@@ -124,7 +124,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, elementSelector, capacity),
                 default(IGroupedAsyncObservable<TKey, TElement>),
-                (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.capacity)));
+                static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.capacity)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, int capacity, IEqualityComparer<TKey> comparer)
@@ -144,7 +144,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, elementSelector, capacity, comparer),
                 default(IGroupedAsyncObservable<TKey, TElement>),
-                (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.capacity, state.comparer)));
+                static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.capacity, state.comparer)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupBy<TSource, TKey>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector)
@@ -158,7 +158,7 @@ namespace System.Reactive.Linq
                 source,
                 keySelector,
                 default(IGroupedAsyncObservable<TKey, TSource>),
-                (source, keySelector, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector)));
+                static (source, keySelector, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupBy<TSource, TKey>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, IEqualityComparer<TKey> comparer)
@@ -174,7 +174,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, comparer),
                 default(IGroupedAsyncObservable<TKey, TSource>),
-                (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.comparer)));
+                static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.comparer)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupBy<TSource, TKey>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, int capacity)
@@ -190,7 +190,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, capacity),
                 default(IGroupedAsyncObservable<TKey, TSource>),
-                (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.capacity)));
+                static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.capacity)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupBy<TSource, TKey>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, int capacity, IEqualityComparer<TKey> comparer)
@@ -208,7 +208,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, capacity, comparer),
                 default(IGroupedAsyncObservable<TKey, TSource>),
-                (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.capacity, state.comparer)));
+                static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.capacity, state.comparer)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector)
@@ -224,7 +224,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, elementSelector),
                 default(IGroupedAsyncObservable<TKey, TElement>),
-                (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector)));
+                static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, IEqualityComparer<TKey> comparer)
@@ -242,7 +242,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, elementSelector, comparer),
                 default(IGroupedAsyncObservable<TKey, TElement>),
-                (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.comparer)));
+                static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.comparer)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, int capacity)
@@ -260,7 +260,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, elementSelector, capacity),
                 default(IGroupedAsyncObservable<TKey, TElement>),
-                (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.capacity)));
+                static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.capacity)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, int capacity, IEqualityComparer<TKey> comparer)
@@ -280,7 +280,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, elementSelector, capacity, comparer),
                 default(IGroupedAsyncObservable<TKey, TElement>),
-                (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.capacity, state.comparer)));
+                static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.capacity, state.comparer)));
         }
 
         private static async ValueTask<IAsyncDisposable> GroupByCore<TSource, TKey, TElement>(IAsyncObservable<TSource> source, IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, Func<IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>>, IAsyncDisposable, (IAsyncObserver<TSource>, IAsyncDisposable)> createObserver)

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/GroupBy.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/GroupBy.cs
@@ -18,7 +18,11 @@ namespace System.Reactive.Linq
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return Create<IGroupedAsyncObservable<TKey, TSource>>(observer => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector)));
+            return Create(
+                source,
+                keySelector,
+                default(IGroupedAsyncObservable<TKey, TSource>),
+                (source, keySelector, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupBy<TSource, TKey>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
@@ -30,7 +34,11 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<IGroupedAsyncObservable<TKey, TSource>>(observer => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector, comparer)));
+            return Create(
+                source,
+                (keySelector, comparer),
+                default(IGroupedAsyncObservable<TKey, TSource>),
+                (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.comparer)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupBy<TSource, TKey>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, int capacity)
@@ -42,7 +50,11 @@ namespace System.Reactive.Linq
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity));
 
-            return Create<IGroupedAsyncObservable<TKey, TSource>>(observer => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector, capacity)));
+            return Create(
+                source,
+                (keySelector, capacity),
+                default(IGroupedAsyncObservable<TKey, TSource>),
+                (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.capacity)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupBy<TSource, TKey>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, int capacity, IEqualityComparer<TKey> comparer)
@@ -56,7 +68,11 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<IGroupedAsyncObservable<TKey, TSource>>(observer => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector, capacity, comparer)));
+            return Create(
+                source,
+                (keySelector, capacity, comparer),
+                default(IGroupedAsyncObservable<TKey, TSource>),
+                (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.capacity, state.comparer)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
@@ -68,7 +84,11 @@ namespace System.Reactive.Linq
             if (elementSelector == null)
                 throw new ArgumentNullException(nameof(elementSelector));
 
-            return Create<IGroupedAsyncObservable<TKey, TElement>>(observer => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector, elementSelector)));
+            return Create(
+                source,
+                (keySelector, elementSelector),
+                default(IGroupedAsyncObservable<TKey, TElement>),
+                (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
@@ -82,7 +102,11 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<IGroupedAsyncObservable<TKey, TElement>>(observer => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector, elementSelector, comparer)));
+            return Create(
+                source,
+                (keySelector, elementSelector, comparer),
+                default(IGroupedAsyncObservable<TKey, TElement>),
+                (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.comparer)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, int capacity)
@@ -96,7 +120,11 @@ namespace System.Reactive.Linq
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity));
 
-            return Create<IGroupedAsyncObservable<TKey, TElement>>(observer => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector, elementSelector, capacity)));
+            return Create(
+                source,
+                (keySelector, elementSelector, capacity),
+                default(IGroupedAsyncObservable<TKey, TElement>),
+                (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.capacity)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, int capacity, IEqualityComparer<TKey> comparer)
@@ -112,7 +140,11 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<IGroupedAsyncObservable<TKey, TElement>>(observer => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector, elementSelector, capacity, comparer)));
+            return Create(
+                source,
+                (keySelector, elementSelector, capacity, comparer),
+                default(IGroupedAsyncObservable<TKey, TElement>),
+                (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.capacity, state.comparer)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupBy<TSource, TKey>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector)
@@ -122,7 +154,11 @@ namespace System.Reactive.Linq
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return Create<IGroupedAsyncObservable<TKey, TSource>>(observer => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector)));
+            return Create(
+                source,
+                keySelector,
+                default(IGroupedAsyncObservable<TKey, TSource>),
+                (source, keySelector, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupBy<TSource, TKey>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, IEqualityComparer<TKey> comparer)
@@ -134,7 +170,11 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<IGroupedAsyncObservable<TKey, TSource>>(observer => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector, comparer)));
+            return Create(
+                source,
+                (keySelector, comparer),
+                default(IGroupedAsyncObservable<TKey, TSource>),
+                (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.comparer)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupBy<TSource, TKey>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, int capacity)
@@ -146,7 +186,11 @@ namespace System.Reactive.Linq
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity));
 
-            return Create<IGroupedAsyncObservable<TKey, TSource>>(observer => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector, capacity)));
+            return Create(
+                source,
+                (keySelector, capacity),
+                default(IGroupedAsyncObservable<TKey, TSource>),
+                (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.capacity)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupBy<TSource, TKey>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, int capacity, IEqualityComparer<TKey> comparer)
@@ -160,7 +204,11 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<IGroupedAsyncObservable<TKey, TSource>>(observer => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector, capacity, comparer)));
+            return Create(
+                source,
+                (keySelector, capacity, comparer),
+                default(IGroupedAsyncObservable<TKey, TSource>),
+                (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.capacity, state.comparer)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector)
@@ -172,7 +220,11 @@ namespace System.Reactive.Linq
             if (elementSelector == null)
                 throw new ArgumentNullException(nameof(elementSelector));
 
-            return Create<IGroupedAsyncObservable<TKey, TElement>>(observer => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector, elementSelector)));
+            return Create(
+                source,
+                (keySelector, elementSelector),
+                default(IGroupedAsyncObservable<TKey, TElement>),
+                (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, IEqualityComparer<TKey> comparer)
@@ -186,7 +238,11 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<IGroupedAsyncObservable<TKey, TElement>>(observer => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector, elementSelector, comparer)));
+            return Create(
+                source,
+                (keySelector, elementSelector, comparer),
+                default(IGroupedAsyncObservable<TKey, TElement>),
+                (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.comparer)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, int capacity)
@@ -200,7 +256,11 @@ namespace System.Reactive.Linq
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity));
 
-            return Create<IGroupedAsyncObservable<TKey, TElement>>(observer => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector, elementSelector, capacity)));
+            return Create(
+                source,
+                (keySelector, elementSelector, capacity),
+                default(IGroupedAsyncObservable<TKey, TElement>),
+                (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.capacity)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, int capacity, IEqualityComparer<TKey> comparer)
@@ -216,7 +276,11 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<IGroupedAsyncObservable<TKey, TElement>>(observer => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector, elementSelector, capacity, comparer)));
+            return Create(
+                source,
+                (keySelector, elementSelector, capacity, comparer),
+                default(IGroupedAsyncObservable<TKey, TElement>),
+                (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.capacity, state.comparer)));
         }
 
         private static async ValueTask<IAsyncDisposable> GroupByCore<TSource, TKey, TElement>(IAsyncObservable<TSource> source, IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, Func<IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>>, IAsyncDisposable, (IAsyncObserver<TSource>, IAsyncDisposable)> createObserver)

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/GroupBy.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/GroupBy.cs
@@ -18,7 +18,7 @@ namespace System.Reactive.Linq
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 keySelector,
                 static (source, keySelector, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector)));
@@ -33,7 +33,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 (keySelector, comparer),
                 static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.comparer)));
@@ -48,7 +48,7 @@ namespace System.Reactive.Linq
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity));
 
-            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 (keySelector, capacity),
                 static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.capacity)));
@@ -65,7 +65,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 (keySelector, capacity, comparer),
                 static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.capacity, state.comparer)));
@@ -80,7 +80,7 @@ namespace System.Reactive.Linq
             if (elementSelector == null)
                 throw new ArgumentNullException(nameof(elementSelector));
 
-            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector),
                 static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector)));
@@ -97,7 +97,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector, comparer),
                 static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.comparer)));
@@ -114,7 +114,7 @@ namespace System.Reactive.Linq
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity));
 
-            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector, capacity),
                 static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.capacity)));
@@ -133,7 +133,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector, capacity, comparer),
                 static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.capacity, state.comparer)));
@@ -146,7 +146,7 @@ namespace System.Reactive.Linq
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 keySelector,
                 static (source, keySelector, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, keySelector)));
@@ -161,7 +161,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 (keySelector, comparer),
                 static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.comparer)));
@@ -176,7 +176,7 @@ namespace System.Reactive.Linq
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity));
 
-            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 (keySelector, capacity),
                 static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.capacity)));
@@ -193,7 +193,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 (keySelector, capacity, comparer),
                 static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.capacity, state.comparer)));
@@ -208,7 +208,7 @@ namespace System.Reactive.Linq
             if (elementSelector == null)
                 throw new ArgumentNullException(nameof(elementSelector));
 
-            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector),
                 static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector)));
@@ -225,7 +225,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector, comparer),
                 static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.comparer)));
@@ -242,7 +242,7 @@ namespace System.Reactive.Linq
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity));
 
-            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector, capacity),
                 static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.capacity)));
@@ -261,7 +261,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build< IGroupedAsyncObservable<TKey, TElement>>.From(
+            return CreateAsyncObservable< IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector, capacity, comparer),
                 static (source, state, observer) => GroupByCore(source, observer, (o, d) => AsyncObserver.GroupBy(o, d, state.keySelector, state.elementSelector, state.capacity, state.comparer)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/GroupByUntil.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/GroupByUntil.cs
@@ -22,7 +22,7 @@ namespace System.Reactive.Linq
             if (durationSelector == null)
                 throw new ArgumentNullException(nameof(durationSelector));
 
-            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 (keySelector, durationSelector),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector)));
@@ -39,7 +39,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 (keySelector, durationSelector, comparer),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.comparer)));
@@ -56,7 +56,7 @@ namespace System.Reactive.Linq
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity));
 
-            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 (keySelector, durationSelector, capacity),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.capacity)));
@@ -75,7 +75,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 (keySelector, durationSelector, capacity, comparer),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.capacity, state.comparer)));
@@ -92,7 +92,7 @@ namespace System.Reactive.Linq
             if (durationSelector == null)
                 throw new ArgumentNullException(nameof(durationSelector));
 
-            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector, durationSelector),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector)));
@@ -111,7 +111,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector, durationSelector, comparer),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.comparer)));
@@ -130,7 +130,7 @@ namespace System.Reactive.Linq
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity));
 
-            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector, durationSelector, capacity),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.capacity)));
@@ -151,7 +151,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector, durationSelector, capacity, comparer),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.capacity, state.comparer)));
@@ -166,7 +166,7 @@ namespace System.Reactive.Linq
             if (durationSelector == null)
                 throw new ArgumentNullException(nameof(durationSelector));
 
-            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 (keySelector, durationSelector),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector)));
@@ -183,7 +183,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 (keySelector, durationSelector, comparer),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.comparer)));
@@ -200,7 +200,7 @@ namespace System.Reactive.Linq
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity));
 
-            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 (keySelector, durationSelector, capacity),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.capacity)));
@@ -219,7 +219,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 (keySelector, durationSelector, capacity, comparer),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.capacity, state.comparer)));
@@ -236,7 +236,7 @@ namespace System.Reactive.Linq
             if (durationSelector == null)
                 throw new ArgumentNullException(nameof(durationSelector));
 
-            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector, durationSelector),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector)));
@@ -255,7 +255,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector, durationSelector, comparer),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.comparer)));
@@ -274,7 +274,7 @@ namespace System.Reactive.Linq
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity));
 
-            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector, durationSelector, capacity),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.capacity)));
@@ -295,7 +295,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
+            return CreateAsyncObservable<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector, durationSelector, capacity, comparer),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.capacity, state.comparer)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/GroupByUntil.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/GroupByUntil.cs
@@ -22,10 +22,9 @@ namespace System.Reactive.Linq
             if (durationSelector == null)
                 throw new ArgumentNullException(nameof(durationSelector));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 (keySelector, durationSelector),
-                default(IGroupedAsyncObservable<TKey, TSource>),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector)));
         }
 
@@ -40,10 +39,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 (keySelector, durationSelector, comparer),
-                default(IGroupedAsyncObservable<TKey, TSource>),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.comparer)));
         }
 
@@ -58,10 +56,9 @@ namespace System.Reactive.Linq
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 (keySelector, durationSelector, capacity),
-                default(IGroupedAsyncObservable<TKey, TSource>),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.capacity)));
         }
 
@@ -78,10 +75,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 (keySelector, durationSelector, capacity, comparer),
-                default(IGroupedAsyncObservable<TKey, TSource>),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.capacity, state.comparer)));
         }
 
@@ -96,10 +92,9 @@ namespace System.Reactive.Linq
             if (durationSelector == null)
                 throw new ArgumentNullException(nameof(durationSelector));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector, durationSelector),
-                default(IGroupedAsyncObservable<TKey, TElement>),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector)));
         }
 
@@ -116,10 +111,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector, durationSelector, comparer),
-                default(IGroupedAsyncObservable<TKey, TElement>),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.comparer)));
         }
 
@@ -136,10 +130,9 @@ namespace System.Reactive.Linq
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector, durationSelector, capacity),
-                default(IGroupedAsyncObservable<TKey, TElement>),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.capacity)));
         }
 
@@ -158,10 +151,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector, durationSelector, capacity, comparer),
-                default(IGroupedAsyncObservable<TKey, TElement>),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.capacity, state.comparer)));
         }
 
@@ -174,10 +166,9 @@ namespace System.Reactive.Linq
             if (durationSelector == null)
                 throw new ArgumentNullException(nameof(durationSelector));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 (keySelector, durationSelector),
-                default(IGroupedAsyncObservable<TKey, TSource>),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector)));
         }
 
@@ -192,10 +183,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 (keySelector, durationSelector, comparer),
-                default(IGroupedAsyncObservable<TKey, TSource>),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.comparer)));
         }
 
@@ -210,10 +200,9 @@ namespace System.Reactive.Linq
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 (keySelector, durationSelector, capacity),
-                default(IGroupedAsyncObservable<TKey, TSource>),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.capacity)));
         }
 
@@ -230,10 +219,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TSource>>.From(
                 source,
                 (keySelector, durationSelector, capacity, comparer),
-                default(IGroupedAsyncObservable<TKey, TSource>),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.capacity, state.comparer)));
         }
 
@@ -248,10 +236,9 @@ namespace System.Reactive.Linq
             if (durationSelector == null)
                 throw new ArgumentNullException(nameof(durationSelector));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector, durationSelector),
-                default(IGroupedAsyncObservable<TKey, TElement>),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector)));
         }
 
@@ -268,10 +255,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector, durationSelector, comparer),
-                default(IGroupedAsyncObservable<TKey, TElement>),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.comparer)));
         }
 
@@ -288,10 +274,9 @@ namespace System.Reactive.Linq
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector, durationSelector, capacity),
-                default(IGroupedAsyncObservable<TKey, TElement>),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.capacity)));
         }
 
@@ -310,10 +295,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build<IGroupedAsyncObservable<TKey, TElement>>.From(
                 source,
                 (keySelector, elementSelector, durationSelector, capacity, comparer),
-                default(IGroupedAsyncObservable<TKey, TElement>),
                 static (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.capacity, state.comparer)));
         }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/GroupByUntil.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/GroupByUntil.cs
@@ -26,7 +26,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, durationSelector),
                 default(IGroupedAsyncObservable<TKey, TSource>),
-                (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector)));
+                static (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupByUntil<TSource, TKey, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, IEqualityComparer<TKey> comparer)
@@ -44,7 +44,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, durationSelector, comparer),
                 default(IGroupedAsyncObservable<TKey, TSource>),
-                (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.comparer)));
+                static (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.comparer)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupByUntil<TSource, TKey, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, int capacity)
@@ -62,7 +62,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, durationSelector, capacity),
                 default(IGroupedAsyncObservable<TKey, TSource>),
-                (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.capacity)));
+                static (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.capacity)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupByUntil<TSource, TKey, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, int capacity, IEqualityComparer<TKey> comparer)
@@ -82,7 +82,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, durationSelector, capacity, comparer),
                 default(IGroupedAsyncObservable<TKey, TSource>),
-                (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.capacity, state.comparer)));
+                static (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.capacity, state.comparer)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupByUntil<TSource, TKey, TElement, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector)
@@ -100,7 +100,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, elementSelector, durationSelector),
                 default(IGroupedAsyncObservable<TKey, TElement>),
-                (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector)));
+                static (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupByUntil<TSource, TKey, TElement, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, IEqualityComparer<TKey> comparer)
@@ -120,7 +120,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, elementSelector, durationSelector, comparer),
                 default(IGroupedAsyncObservable<TKey, TElement>),
-                (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.comparer)));
+                static (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.comparer)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupByUntil<TSource, TKey, TElement, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, int capacity)
@@ -140,7 +140,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, elementSelector, durationSelector, capacity),
                 default(IGroupedAsyncObservable<TKey, TElement>),
-                (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.capacity)));
+                static (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.capacity)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupByUntil<TSource, TKey, TElement, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, int capacity, IEqualityComparer<TKey> comparer)
@@ -162,7 +162,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, elementSelector, durationSelector, capacity, comparer),
                 default(IGroupedAsyncObservable<TKey, TElement>),
-                (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.capacity, state.comparer)));
+                static (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.capacity, state.comparer)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupByUntil<TSource, TKey, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector)
@@ -178,7 +178,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, durationSelector),
                 default(IGroupedAsyncObservable<TKey, TSource>),
-                (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector)));
+                static (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupByUntil<TSource, TKey, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, IEqualityComparer<TKey> comparer)
@@ -196,7 +196,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, durationSelector, comparer),
                 default(IGroupedAsyncObservable<TKey, TSource>),
-                (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.comparer)));
+                static (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.comparer)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupByUntil<TSource, TKey, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, int capacity)
@@ -214,7 +214,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, durationSelector, capacity),
                 default(IGroupedAsyncObservable<TKey, TSource>),
-                (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.capacity)));
+                static (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.capacity)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupByUntil<TSource, TKey, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, int capacity, IEqualityComparer<TKey> comparer)
@@ -234,7 +234,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, durationSelector, capacity, comparer),
                 default(IGroupedAsyncObservable<TKey, TSource>),
-                (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.capacity, state.comparer)));
+                static (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.capacity, state.comparer)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupByUntil<TSource, TKey, TElement, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector)
@@ -252,7 +252,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, elementSelector, durationSelector),
                 default(IGroupedAsyncObservable<TKey, TElement>),
-                (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector)));
+                static (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupByUntil<TSource, TKey, TElement, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, IEqualityComparer<TKey> comparer)
@@ -272,7 +272,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, elementSelector, durationSelector, comparer),
                 default(IGroupedAsyncObservable<TKey, TElement>),
-                (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.comparer)));
+                static (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.comparer)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupByUntil<TSource, TKey, TElement, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, int capacity)
@@ -292,7 +292,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, elementSelector, durationSelector, capacity),
                 default(IGroupedAsyncObservable<TKey, TElement>),
-                (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.capacity)));
+                static (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.capacity)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupByUntil<TSource, TKey, TElement, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, int capacity, IEqualityComparer<TKey> comparer)
@@ -314,7 +314,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, elementSelector, durationSelector, capacity, comparer),
                 default(IGroupedAsyncObservable<TKey, TElement>),
-                (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.capacity, state.comparer)));
+                static (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.capacity, state.comparer)));
         }
 
         private static async ValueTask<IAsyncDisposable> GroupByUntilCore<TSource, TKey, TElement, TDuration>(IAsyncObservable<TSource> source, IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, Func<IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>>, IAsyncDisposable, ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)>> createObserver)

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/GroupByUntil.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/GroupByUntil.cs
@@ -22,7 +22,11 @@ namespace System.Reactive.Linq
             if (durationSelector == null)
                 throw new ArgumentNullException(nameof(durationSelector));
 
-            return Create<IGroupedAsyncObservable<TKey, TSource>>(observer => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, keySelector, durationSelector)));
+            return Create(
+                source,
+                (keySelector, durationSelector),
+                default(IGroupedAsyncObservable<TKey, TSource>),
+                (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupByUntil<TSource, TKey, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, IEqualityComparer<TKey> comparer)
@@ -36,7 +40,11 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<IGroupedAsyncObservable<TKey, TSource>>(observer => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, keySelector, durationSelector, comparer)));
+            return Create(
+                source,
+                (keySelector, durationSelector, comparer),
+                default(IGroupedAsyncObservable<TKey, TSource>),
+                (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.comparer)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupByUntil<TSource, TKey, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, int capacity)
@@ -50,7 +58,11 @@ namespace System.Reactive.Linq
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity));
 
-            return Create<IGroupedAsyncObservable<TKey, TSource>>(observer => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, keySelector, durationSelector, capacity)));
+            return Create(
+                source,
+                (keySelector, durationSelector, capacity),
+                default(IGroupedAsyncObservable<TKey, TSource>),
+                (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.capacity)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupByUntil<TSource, TKey, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, int capacity, IEqualityComparer<TKey> comparer)
@@ -66,7 +78,11 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<IGroupedAsyncObservable<TKey, TSource>>(observer => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, keySelector, durationSelector, capacity, comparer)));
+            return Create(
+                source,
+                (keySelector, durationSelector, capacity, comparer),
+                default(IGroupedAsyncObservable<TKey, TSource>),
+                (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.capacity, state.comparer)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupByUntil<TSource, TKey, TElement, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector)
@@ -80,7 +96,11 @@ namespace System.Reactive.Linq
             if (durationSelector == null)
                 throw new ArgumentNullException(nameof(durationSelector));
 
-            return Create<IGroupedAsyncObservable<TKey, TElement>>(observer => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, keySelector, elementSelector, durationSelector)));
+            return Create(
+                source,
+                (keySelector, elementSelector, durationSelector),
+                default(IGroupedAsyncObservable<TKey, TElement>),
+                (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupByUntil<TSource, TKey, TElement, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, IEqualityComparer<TKey> comparer)
@@ -96,7 +116,11 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<IGroupedAsyncObservable<TKey, TElement>>(observer => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, keySelector, elementSelector, durationSelector, comparer)));
+            return Create(
+                source,
+                (keySelector, elementSelector, durationSelector, comparer),
+                default(IGroupedAsyncObservable<TKey, TElement>),
+                (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.comparer)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupByUntil<TSource, TKey, TElement, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, int capacity)
@@ -112,7 +136,11 @@ namespace System.Reactive.Linq
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity));
 
-            return Create<IGroupedAsyncObservable<TKey, TElement>>(observer => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, keySelector, elementSelector, durationSelector, capacity)));
+            return Create(
+                source,
+                (keySelector, elementSelector, durationSelector, capacity),
+                default(IGroupedAsyncObservable<TKey, TElement>),
+                (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.capacity)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupByUntil<TSource, TKey, TElement, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, int capacity, IEqualityComparer<TKey> comparer)
@@ -130,7 +158,11 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<IGroupedAsyncObservable<TKey, TElement>>(observer => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, keySelector, elementSelector, durationSelector, capacity, comparer)));
+            return Create(
+                source,
+                (keySelector, elementSelector, durationSelector, capacity, comparer),
+                default(IGroupedAsyncObservable<TKey, TElement>),
+                (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.capacity, state.comparer)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupByUntil<TSource, TKey, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector)
@@ -142,7 +174,11 @@ namespace System.Reactive.Linq
             if (durationSelector == null)
                 throw new ArgumentNullException(nameof(durationSelector));
 
-            return Create<IGroupedAsyncObservable<TKey, TSource>>(observer => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, keySelector, durationSelector)));
+            return Create(
+                source,
+                (keySelector, durationSelector),
+                default(IGroupedAsyncObservable<TKey, TSource>),
+                (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupByUntil<TSource, TKey, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, IEqualityComparer<TKey> comparer)
@@ -156,7 +192,11 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<IGroupedAsyncObservable<TKey, TSource>>(observer => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, keySelector, durationSelector, comparer)));
+            return Create(
+                source,
+                (keySelector, durationSelector, comparer),
+                default(IGroupedAsyncObservable<TKey, TSource>),
+                (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.comparer)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupByUntil<TSource, TKey, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, int capacity)
@@ -170,7 +210,11 @@ namespace System.Reactive.Linq
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity));
 
-            return Create<IGroupedAsyncObservable<TKey, TSource>>(observer => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, keySelector, durationSelector, capacity)));
+            return Create(
+                source,
+                (keySelector, durationSelector, capacity),
+                default(IGroupedAsyncObservable<TKey, TSource>),
+                (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.capacity)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TSource>> GroupByUntil<TSource, TKey, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<IGroupedAsyncObservable<TKey, TSource>, IAsyncObservable<TDuration>> durationSelector, int capacity, IEqualityComparer<TKey> comparer)
@@ -186,7 +230,11 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<IGroupedAsyncObservable<TKey, TSource>>(observer => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, keySelector, durationSelector, capacity, comparer)));
+            return Create(
+                source,
+                (keySelector, durationSelector, capacity, comparer),
+                default(IGroupedAsyncObservable<TKey, TSource>),
+                (source, state, observer) => GroupByUntilCore<TSource, TKey, TSource, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.durationSelector, state.capacity, state.comparer)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupByUntil<TSource, TKey, TElement, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector)
@@ -200,7 +248,11 @@ namespace System.Reactive.Linq
             if (durationSelector == null)
                 throw new ArgumentNullException(nameof(durationSelector));
 
-            return Create<IGroupedAsyncObservable<TKey, TElement>>(observer => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, keySelector, elementSelector, durationSelector)));
+            return Create(
+                source,
+                (keySelector, elementSelector, durationSelector),
+                default(IGroupedAsyncObservable<TKey, TElement>),
+                (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupByUntil<TSource, TKey, TElement, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, IEqualityComparer<TKey> comparer)
@@ -216,7 +268,11 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<IGroupedAsyncObservable<TKey, TElement>>(observer => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, keySelector, elementSelector, durationSelector, comparer)));
+            return Create(
+                source,
+                (keySelector, elementSelector, durationSelector, comparer),
+                default(IGroupedAsyncObservable<TKey, TElement>),
+                (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.comparer)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupByUntil<TSource, TKey, TElement, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, int capacity)
@@ -232,7 +288,11 @@ namespace System.Reactive.Linq
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity));
 
-            return Create<IGroupedAsyncObservable<TKey, TElement>>(observer => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, keySelector, elementSelector, durationSelector, capacity)));
+            return Create(
+                source,
+                (keySelector, elementSelector, durationSelector, capacity),
+                default(IGroupedAsyncObservable<TKey, TElement>),
+                (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.capacity)));
         }
 
         public static IAsyncObservable<IGroupedAsyncObservable<TKey, TElement>> GroupByUntil<TSource, TKey, TElement, TDuration>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TElement>> elementSelector, Func<IGroupedAsyncObservable<TKey, TElement>, IAsyncObservable<TDuration>> durationSelector, int capacity, IEqualityComparer<TKey> comparer)
@@ -250,7 +310,11 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<IGroupedAsyncObservable<TKey, TElement>>(observer => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, keySelector, elementSelector, durationSelector, capacity, comparer)));
+            return Create(
+                source,
+                (keySelector, elementSelector, durationSelector, capacity, comparer),
+                default(IGroupedAsyncObservable<TKey, TElement>),
+                (source, state, observer) => GroupByUntilCore<TSource, TKey, TElement, TDuration>(source, observer, (o, d) => AsyncObserver.GroupByUntil(o, d, state.keySelector, state.elementSelector, state.durationSelector, state.capacity, state.comparer)));
         }
 
         private static async ValueTask<IAsyncDisposable> GroupByUntilCore<TSource, TKey, TElement, TDuration>(IAsyncObservable<TSource> source, IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>> observer, Func<IAsyncObserver<IGroupedAsyncObservable<TKey, TElement>>, IAsyncDisposable, ValueTask<(IAsyncObserver<TSource>, IAsyncDisposable)>> createObserver)

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/If.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/If.cs
@@ -26,7 +26,7 @@ namespace System.Reactive.Linq
                 thenSource,
                 (elseSource, condition),
                 default(TResult),
-                (thenSource, state, observer) =>
+                static (thenSource, state, observer) =>
                 {
                     var b = default(bool);
 
@@ -60,7 +60,7 @@ namespace System.Reactive.Linq
                 thenSource,
                 (elseSource, condition),
                 default(TResult),
-                async (thenSource, state, observer) =>
+                static async (thenSource, state, observer) =>
                 {
                     var b = default(bool);
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/If.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/If.cs
@@ -22,10 +22,9 @@ namespace System.Reactive.Linq
             if (elseSource == null)
                 throw new ArgumentNullException(nameof(elseSource));
 
-            return Create(
+            return Build<TResult>.From(
                 thenSource,
                 (elseSource, condition),
-                default(TResult),
                 static (thenSource, state, observer) =>
                 {
                     var b = default(bool);
@@ -56,10 +55,9 @@ namespace System.Reactive.Linq
             if (elseSource == null)
                 throw new ArgumentNullException(nameof(elseSource));
 
-            return Create(
+            return Build<TResult>.From(
                 thenSource,
                 (elseSource, condition),
-                default(TResult),
                 static async (thenSource, state, observer) =>
                 {
                     var b = default(bool);

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/If.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/If.cs
@@ -22,7 +22,7 @@ namespace System.Reactive.Linq
             if (elseSource == null)
                 throw new ArgumentNullException(nameof(elseSource));
 
-            return Build<TResult>.From(
+            return CreateAsyncObservable<TResult>.From(
                 thenSource,
                 (elseSource, condition),
                 static (thenSource, state, observer) =>
@@ -55,7 +55,7 @@ namespace System.Reactive.Linq
             if (elseSource == null)
                 throw new ArgumentNullException(nameof(elseSource));
 
-            return Build<TResult>.From(
+            return CreateAsyncObservable<TResult>.From(
                 thenSource,
                 (elseSource, condition),
                 static async (thenSource, state, observer) =>

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Join.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Join.cs
@@ -24,20 +24,24 @@ namespace System.Reactive.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            return Create<TResult>(async observer =>
-            {
-                var subscriptions = new CompositeAsyncDisposable();
+            return Create(
+                left,
+                (right, leftDurationSelector, rightDurationSelector, resultSelector),
+                default(TResult),
+                async (left, state, observer) =>
+                {
+                    var subscriptions = new CompositeAsyncDisposable();
 
-                var (leftObserver, rightObserver, disposable) = AsyncObserver.Join(observer, subscriptions, leftDurationSelector, rightDurationSelector, resultSelector);
+                    var (leftObserver, rightObserver, disposable) = AsyncObserver.Join(observer, subscriptions, state.leftDurationSelector, state.rightDurationSelector, state.resultSelector);
 
-                var leftSubscription = await left.SubscribeSafeAsync(leftObserver).ConfigureAwait(false);
-                await subscriptions.AddAsync(leftSubscription).ConfigureAwait(false);
+                    var leftSubscription = await left.SubscribeSafeAsync(leftObserver).ConfigureAwait(false);
+                    await subscriptions.AddAsync(leftSubscription).ConfigureAwait(false);
 
-                var rightSubscription = await right.SubscribeSafeAsync(rightObserver).ConfigureAwait(false);
-                await subscriptions.AddAsync(rightSubscription).ConfigureAwait(false);
+                    var rightSubscription = await state.right.SubscribeSafeAsync(rightObserver).ConfigureAwait(false);
+                    await subscriptions.AddAsync(rightSubscription).ConfigureAwait(false);
 
-                return disposable;
-            });
+                    return disposable;
+                });
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Join.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Join.cs
@@ -28,7 +28,7 @@ namespace System.Reactive.Linq
                 left,
                 (right, leftDurationSelector, rightDurationSelector, resultSelector),
                 default(TResult),
-                async (left, state, observer) =>
+                static async (left, state, observer) =>
                 {
                     var subscriptions = new CompositeAsyncDisposable();
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Join.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Join.cs
@@ -24,10 +24,9 @@ namespace System.Reactive.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            return Create(
+            return Build<TResult>.From(
                 left,
                 (right, leftDurationSelector, rightDurationSelector, resultSelector),
-                default(TResult),
                 static async (left, state, observer) =>
                 {
                     var subscriptions = new CompositeAsyncDisposable();

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Join.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Join.cs
@@ -24,7 +24,7 @@ namespace System.Reactive.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            return Build<TResult>.From(
+            return CreateAsyncObservable<TResult>.From(
                 left,
                 (right, leftDurationSelector, rightDurationSelector, resultSelector),
                 static async (left, state, observer) =>

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Last.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Last.cs
@@ -29,7 +29,7 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 predicate,
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Last(observer, predicate)));
@@ -42,7 +42,7 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 predicate,
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Last(observer, predicate)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Last.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Last.cs
@@ -17,7 +17,9 @@ namespace System.Reactive.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.Last(observer)));
+            return Create(
+                source,
+                (source, observer) => source.SubscribeSafeAsync(AsyncObserver.Last(observer)));
         }
 
         public static IAsyncObservable<TSource> Last<TSource>(this IAsyncObservable<TSource> source, Func<TSource, bool> predicate)
@@ -27,7 +29,11 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.Last(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                default(TSource),
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Last(observer, predicate)));
         }
 
         public static IAsyncObservable<TSource> Last<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
@@ -37,7 +43,11 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.Last(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                default(TSource),
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Last(observer, predicate)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Last.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Last.cs
@@ -33,7 +33,7 @@ namespace System.Reactive.Linq
                 source,
                 predicate,
                 default(TSource),
-                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Last(observer, predicate)));
+                static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Last(observer, predicate)));
         }
 
         public static IAsyncObservable<TSource> Last<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
@@ -47,7 +47,7 @@ namespace System.Reactive.Linq
                 source,
                 predicate,
                 default(TSource),
-                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Last(observer, predicate)));
+                static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Last(observer, predicate)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Last.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Last.cs
@@ -29,10 +29,9 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 predicate,
-                default(TSource),
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Last(observer, predicate)));
         }
 
@@ -43,10 +42,9 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 predicate,
-                default(TSource),
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Last(observer, predicate)));
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/LastOrDefault.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/LastOrDefault.cs
@@ -29,10 +29,9 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 predicate,
-                default(TSource),
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.LastOrDefault(observer, predicate)));
         }
 
@@ -43,10 +42,9 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 predicate,
-                default(TSource),
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.LastOrDefault(observer, predicate)));
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/LastOrDefault.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/LastOrDefault.cs
@@ -29,7 +29,7 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 predicate,
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.LastOrDefault(observer, predicate)));
@@ -42,7 +42,7 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 predicate,
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.LastOrDefault(observer, predicate)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/LastOrDefault.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/LastOrDefault.cs
@@ -33,7 +33,7 @@ namespace System.Reactive.Linq
                 source,
                 predicate,
                 default(TSource),
-                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.LastOrDefault(observer, predicate)));
+                static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.LastOrDefault(observer, predicate)));
         }
 
         public static IAsyncObservable<TSource> LastOrDefault<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
@@ -47,7 +47,7 @@ namespace System.Reactive.Linq
                 source,
                 predicate,
                 default(TSource),
-                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.LastOrDefault(observer, predicate)));
+                static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.LastOrDefault(observer, predicate)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/LastOrDefault.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/LastOrDefault.cs
@@ -17,7 +17,9 @@ namespace System.Reactive.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.LastOrDefault(observer)));
+            return Create(
+                source,
+                (source, observer) => source.SubscribeSafeAsync(AsyncObserver.LastOrDefault(observer)));
         }
 
         public static IAsyncObservable<TSource> LastOrDefault<TSource>(this IAsyncObservable<TSource> source, Func<TSource, bool> predicate)
@@ -27,7 +29,11 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.LastOrDefault(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                default(TSource),
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.LastOrDefault(observer, predicate)));
         }
 
         public static IAsyncObservable<TSource> LastOrDefault<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
@@ -37,7 +43,11 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.LastOrDefault(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                default(TSource),
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.LastOrDefault(observer, predicate)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/LongCount.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/LongCount.cs
@@ -27,7 +27,7 @@ namespace System.Reactive.Linq
                 source,
                 predicate,
                 default(long),
-                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.LongCount(observer, predicate)));
+                static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.LongCount(observer, predicate)));
         }
 
         public static IAsyncObservable<long> LongCount<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
@@ -41,7 +41,7 @@ namespace System.Reactive.Linq
                 source,
                 predicate,
                 default(long),
-                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.LongCount(observer, predicate)));
+                static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.LongCount(observer, predicate)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/LongCount.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/LongCount.cs
@@ -23,7 +23,7 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Build<long>.From(
+            return CreateAsyncObservable<long>.From(
                 source,
                 predicate,
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.LongCount(observer, predicate)));
@@ -36,7 +36,7 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Build<long>.From(
+            return CreateAsyncObservable<long>.From(
                 source,
                 predicate,
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.LongCount(observer, predicate)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/LongCount.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/LongCount.cs
@@ -23,10 +23,9 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(
+            return Build<long>.From(
                 source,
                 predicate,
-                default(long),
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.LongCount(observer, predicate)));
         }
 
@@ -37,10 +36,9 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(
+            return Build<long>.From(
                 source,
                 predicate,
-                default(long),
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.LongCount(observer, predicate)));
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/LongCount.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/LongCount.cs
@@ -23,7 +23,11 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<long>(observer => source.SubscribeSafeAsync(AsyncObserver.LongCount(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                default(long),
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.LongCount(observer, predicate)));
         }
 
         public static IAsyncObservable<long> LongCount<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
@@ -33,7 +37,11 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<long>(observer => source.SubscribeSafeAsync(AsyncObserver.LongCount(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                default(long),
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.LongCount(observer, predicate)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Max.Generated.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Max.Generated.cs
@@ -23,7 +23,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Int32>.From(
+            return CreateAsyncObservable<Int32>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxInt32(observer, selector)));
@@ -36,7 +36,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Int32>.From(
+            return CreateAsyncObservable<Int32>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxInt32(observer, selector)));
@@ -57,7 +57,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Int32?>.From(
+            return CreateAsyncObservable<Int32?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableInt32(observer, selector)));
@@ -70,7 +70,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Int32?>.From(
+            return CreateAsyncObservable<Int32?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableInt32(observer, selector)));
@@ -91,7 +91,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Int64>.From(
+            return CreateAsyncObservable<Int64>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxInt64(observer, selector)));
@@ -104,7 +104,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Int64>.From(
+            return CreateAsyncObservable<Int64>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxInt64(observer, selector)));
@@ -125,7 +125,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Int64?>.From(
+            return CreateAsyncObservable<Int64?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableInt64(observer, selector)));
@@ -138,7 +138,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Int64?>.From(
+            return CreateAsyncObservable<Int64?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableInt64(observer, selector)));
@@ -159,7 +159,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Single>.From(
+            return CreateAsyncObservable<Single>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxSingle(observer, selector)));
@@ -172,7 +172,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Single>.From(
+            return CreateAsyncObservable<Single>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxSingle(observer, selector)));
@@ -193,7 +193,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Single?>.From(
+            return CreateAsyncObservable<Single?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableSingle(observer, selector)));
@@ -206,7 +206,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Single?>.From(
+            return CreateAsyncObservable<Single?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableSingle(observer, selector)));
@@ -227,7 +227,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Double>.From(
+            return CreateAsyncObservable<Double>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxDouble(observer, selector)));
@@ -240,7 +240,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Double>.From(
+            return CreateAsyncObservable<Double>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxDouble(observer, selector)));
@@ -261,7 +261,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Double?>.From(
+            return CreateAsyncObservable<Double?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableDouble(observer, selector)));
@@ -274,7 +274,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Double?>.From(
+            return CreateAsyncObservable<Double?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableDouble(observer, selector)));
@@ -295,7 +295,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Decimal>.From(
+            return CreateAsyncObservable<Decimal>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxDecimal(observer, selector)));
@@ -308,7 +308,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Decimal>.From(
+            return CreateAsyncObservable<Decimal>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxDecimal(observer, selector)));
@@ -329,7 +329,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Decimal?>.From(
+            return CreateAsyncObservable<Decimal?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableDecimal(observer, selector)));
@@ -342,7 +342,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Decimal?>.From(
+            return CreateAsyncObservable<Decimal?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableDecimal(observer, selector)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Max.Generated.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Max.Generated.cs
@@ -23,10 +23,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Int32>.From(
                 source,
                 selector,
-                default(Int32),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxInt32(observer, selector)));
         }
 
@@ -37,10 +36,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Int32>.From(
                 source,
                 selector,
-                default(Int32),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxInt32(observer, selector)));
         }
 
@@ -59,10 +57,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Int32?>.From(
                 source,
                 selector,
-                default(Int32?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableInt32(observer, selector)));
         }
 
@@ -73,10 +70,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Int32?>.From(
                 source,
                 selector,
-                default(Int32?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableInt32(observer, selector)));
         }
 
@@ -95,10 +91,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Int64>.From(
                 source,
                 selector,
-                default(Int64),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxInt64(observer, selector)));
         }
 
@@ -109,10 +104,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Int64>.From(
                 source,
                 selector,
-                default(Int64),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxInt64(observer, selector)));
         }
 
@@ -131,10 +125,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Int64?>.From(
                 source,
                 selector,
-                default(Int64?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableInt64(observer, selector)));
         }
 
@@ -145,10 +138,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Int64?>.From(
                 source,
                 selector,
-                default(Int64?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableInt64(observer, selector)));
         }
 
@@ -167,10 +159,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Single>.From(
                 source,
                 selector,
-                default(Single),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxSingle(observer, selector)));
         }
 
@@ -181,10 +172,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Single>.From(
                 source,
                 selector,
-                default(Single),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxSingle(observer, selector)));
         }
 
@@ -203,10 +193,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Single?>.From(
                 source,
                 selector,
-                default(Single?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableSingle(observer, selector)));
         }
 
@@ -217,10 +206,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Single?>.From(
                 source,
                 selector,
-                default(Single?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableSingle(observer, selector)));
         }
 
@@ -239,10 +227,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Double>.From(
                 source,
                 selector,
-                default(Double),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxDouble(observer, selector)));
         }
 
@@ -253,10 +240,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Double>.From(
                 source,
                 selector,
-                default(Double),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxDouble(observer, selector)));
         }
 
@@ -275,10 +261,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Double?>.From(
                 source,
                 selector,
-                default(Double?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableDouble(observer, selector)));
         }
 
@@ -289,10 +274,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Double?>.From(
                 source,
                 selector,
-                default(Double?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableDouble(observer, selector)));
         }
 
@@ -311,10 +295,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Decimal>.From(
                 source,
                 selector,
-                default(Decimal),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxDecimal(observer, selector)));
         }
 
@@ -325,10 +308,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Decimal>.From(
                 source,
                 selector,
-                default(Decimal),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxDecimal(observer, selector)));
         }
 
@@ -347,10 +329,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Decimal?>.From(
                 source,
                 selector,
-                default(Decimal?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableDecimal(observer, selector)));
         }
 
@@ -361,10 +342,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Decimal?>.From(
                 source,
                 selector,
-                default(Decimal?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableDecimal(observer, selector)));
         }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Max.Generated.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Max.Generated.cs
@@ -27,7 +27,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Int32),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxInt32(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Int32> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int32>> selector)
@@ -41,7 +41,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Int32),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxInt32(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Int32?> Max(this IAsyncObservable<Int32?> source)
@@ -63,7 +63,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Int32?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableInt32(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Int32?> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int32?>> selector)
@@ -77,7 +77,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Int32?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableInt32(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Int64> Max(this IAsyncObservable<Int64> source)
@@ -99,7 +99,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Int64),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxInt64(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Int64> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int64>> selector)
@@ -113,7 +113,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Int64),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxInt64(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Int64?> Max(this IAsyncObservable<Int64?> source)
@@ -135,7 +135,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Int64?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableInt64(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Int64?> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int64?>> selector)
@@ -149,7 +149,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Int64?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableInt64(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Single> Max(this IAsyncObservable<Single> source)
@@ -171,7 +171,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Single),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxSingle(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Single> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Single>> selector)
@@ -185,7 +185,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Single),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxSingle(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Single?> Max(this IAsyncObservable<Single?> source)
@@ -207,7 +207,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Single?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableSingle(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Single?> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Single?>> selector)
@@ -221,7 +221,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Single?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableSingle(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Double> Max(this IAsyncObservable<Double> source)
@@ -243,7 +243,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Double),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxDouble(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Double> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Double>> selector)
@@ -257,7 +257,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Double),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxDouble(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Double?> Max(this IAsyncObservable<Double?> source)
@@ -279,7 +279,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Double?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableDouble(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Double?> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Double?>> selector)
@@ -293,7 +293,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Double?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableDouble(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal> Max(this IAsyncObservable<Decimal> source)
@@ -315,7 +315,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Decimal),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxDecimal(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxDecimal(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Decimal>> selector)
@@ -329,7 +329,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Decimal),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxDecimal(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxDecimal(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal?> Max(this IAsyncObservable<Decimal?> source)
@@ -351,7 +351,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Decimal?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableDecimal(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableDecimal(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal?> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Decimal?>> selector)
@@ -365,7 +365,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Decimal?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableDecimal(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableDecimal(observer, selector)));
         }
 
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Max.Generated.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Max.Generated.cs
@@ -23,7 +23,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Int32>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxInt32(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Int32),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Int32> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int32>> selector)
@@ -33,7 +37,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Int32>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxInt32(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Int32),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Int32?> Max(this IAsyncObservable<Int32?> source)
@@ -51,7 +59,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Int32?>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxNullableInt32(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Int32?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Int32?> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int32?>> selector)
@@ -61,7 +73,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Int32?>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxNullableInt32(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Int32?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Int64> Max(this IAsyncObservable<Int64> source)
@@ -79,7 +95,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Int64>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxInt64(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Int64),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Int64> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int64>> selector)
@@ -89,7 +109,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Int64>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxInt64(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Int64),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Int64?> Max(this IAsyncObservable<Int64?> source)
@@ -107,7 +131,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Int64?>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxNullableInt64(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Int64?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Int64?> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int64?>> selector)
@@ -117,7 +145,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Int64?>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxNullableInt64(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Int64?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Single> Max(this IAsyncObservable<Single> source)
@@ -135,7 +167,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Single>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxSingle(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Single),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Single> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Single>> selector)
@@ -145,7 +181,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Single>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxSingle(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Single),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Single?> Max(this IAsyncObservable<Single?> source)
@@ -163,7 +203,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Single?>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxNullableSingle(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Single?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Single?> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Single?>> selector)
@@ -173,7 +217,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Single?>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxNullableSingle(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Single?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Double> Max(this IAsyncObservable<Double> source)
@@ -191,7 +239,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Double>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxDouble(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Double),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Double> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Double>> selector)
@@ -201,7 +253,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Double>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxDouble(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Double),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Double?> Max(this IAsyncObservable<Double?> source)
@@ -219,7 +275,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Double?>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxNullableDouble(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Double?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Double?> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Double?>> selector)
@@ -229,7 +289,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Double?>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxNullableDouble(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Double?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal> Max(this IAsyncObservable<Decimal> source)
@@ -247,7 +311,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Decimal>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxDecimal(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Decimal),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxDecimal(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Decimal>> selector)
@@ -257,7 +325,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Decimal>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxDecimal(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Decimal),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxDecimal(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal?> Max(this IAsyncObservable<Decimal?> source)
@@ -275,7 +347,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Decimal?>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxNullableDecimal(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Decimal?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableDecimal(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal?> Max<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Decimal?>> selector)
@@ -285,7 +361,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Decimal?>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxNullableDecimal(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Decimal?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxNullableDecimal(observer, selector)));
         }
 
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Max.Generated.tt
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Max.Generated.tt
@@ -42,10 +42,9 @@ foreach (var t in types)
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<<#=typeName#>>.From(
                 source,
                 selector,
-                default(<#=typeName#>),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
         }
 
@@ -56,10 +55,9 @@ foreach (var t in types)
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<<#=typeName#>>.From(
                 source,
                 selector,
-                default(<#=typeName#>),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
         }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Max.Generated.tt
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Max.Generated.tt
@@ -46,7 +46,7 @@ foreach (var t in types)
                 source,
                 selector,
                 default(<#=typeName#>),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
         }
 
         public static IAsyncObservable<<#=typeName#>> <#=name#><TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<<#=typeName#>>> selector)
@@ -60,7 +60,7 @@ foreach (var t in types)
                 source,
                 selector,
                 default(<#=typeName#>),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
         }
 
 <#

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Max.Generated.tt
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Max.Generated.tt
@@ -42,7 +42,11 @@ foreach (var t in types)
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<<#=typeName#>>(observer => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(<#=typeName#>),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
         }
 
         public static IAsyncObservable<<#=typeName#>> <#=name#><TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<<#=typeName#>>> selector)
@@ -52,7 +56,11 @@ foreach (var t in types)
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<<#=typeName#>>(observer => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(<#=typeName#>),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
         }
 
 <#

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Max.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Max.cs
@@ -24,10 +24,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 comparer,
-                default(TSource),
                 static (source, comparer, observer) => source.SubscribeSafeAsync(AsyncObserver.Max(observer, comparer)));
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Max.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Max.cs
@@ -24,7 +24,11 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.Max(observer, comparer)));
+            return Create(
+                source,
+                comparer,
+                default(TSource),
+                (source, comparer, observer) => source.SubscribeSafeAsync(AsyncObserver.Max(observer, comparer)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Max.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Max.cs
@@ -28,7 +28,7 @@ namespace System.Reactive.Linq
                 source,
                 comparer,
                 default(TSource),
-                (source, comparer, observer) => source.SubscribeSafeAsync(AsyncObserver.Max(observer, comparer)));
+                static (source, comparer, observer) => source.SubscribeSafeAsync(AsyncObserver.Max(observer, comparer)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Max.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Max.cs
@@ -24,7 +24,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 comparer,
                 static (source, comparer, observer) => source.SubscribeSafeAsync(AsyncObserver.Max(observer, comparer)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/MaxBy.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/MaxBy.cs
@@ -16,7 +16,7 @@ namespace System.Reactive.Linq
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return Build<IList<TSource>>.From(
+            return CreateAsyncObservable<IList<TSource>>.From(
                 source,
                 keySelector,
                 static (source, keySelector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxBy(observer, keySelector)));
@@ -31,7 +31,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build<IList<TSource>>.From(
+            return CreateAsyncObservable<IList<TSource>>.From(
                 source,
                 (keySelector, comparer),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxBy(observer, state.keySelector, state.comparer)));
@@ -44,7 +44,7 @@ namespace System.Reactive.Linq
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return Build<IList<TSource>>.From(
+            return CreateAsyncObservable<IList<TSource>>.From(
                 source,
                 keySelector,
                 static (source, keySelector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxBy(observer, keySelector)));
@@ -59,7 +59,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build<IList<TSource>>.From(
+            return CreateAsyncObservable<IList<TSource>>.From(
                 source,
                 (keySelector, comparer),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxBy(observer, state.keySelector, state.comparer)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/MaxBy.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/MaxBy.cs
@@ -20,7 +20,7 @@ namespace System.Reactive.Linq
                 source,
                 keySelector,
                 default(IList<TSource>),
-                (source, keySelector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxBy(observer, keySelector)));
+                static (source, keySelector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxBy(observer, keySelector)));
         }
 
         public static IAsyncObservable<IList<TSource>> MaxBy<TSource, TKey>(IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey> comparer)
@@ -36,7 +36,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, comparer),
                 default(IList<TSource>),
-                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxBy(observer, state.keySelector, state.comparer)));
+                static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxBy(observer, state.keySelector, state.comparer)));
         }
 
         public static IAsyncObservable<IList<TSource>> MaxBy<TSource, TKey>(IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector)
@@ -50,7 +50,7 @@ namespace System.Reactive.Linq
                 source,
                 keySelector,
                 default(IList<TSource>),
-                (source, keySelector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxBy(observer, keySelector)));
+                static (source, keySelector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxBy(observer, keySelector)));
         }
 
         public static IAsyncObservable<IList<TSource>> MaxBy<TSource, TKey>(IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, IComparer<TKey> comparer)
@@ -66,7 +66,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, comparer),
                 default(IList<TSource>),
-                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxBy(observer, state.keySelector, state.comparer)));
+                static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxBy(observer, state.keySelector, state.comparer)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/MaxBy.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/MaxBy.cs
@@ -16,10 +16,9 @@ namespace System.Reactive.Linq
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return Create(
+            return Build<IList<TSource>>.From(
                 source,
                 keySelector,
-                default(IList<TSource>),
                 static (source, keySelector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxBy(observer, keySelector)));
         }
 
@@ -32,10 +31,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build<IList<TSource>>.From(
                 source,
                 (keySelector, comparer),
-                default(IList<TSource>),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxBy(observer, state.keySelector, state.comparer)));
         }
 
@@ -46,10 +44,9 @@ namespace System.Reactive.Linq
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return Create(
+            return Build<IList<TSource>>.From(
                 source,
                 keySelector,
-                default(IList<TSource>),
                 static (source, keySelector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxBy(observer, keySelector)));
         }
 
@@ -62,10 +59,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build<IList<TSource>>.From(
                 source,
                 (keySelector, comparer),
-                default(IList<TSource>),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxBy(observer, state.keySelector, state.comparer)));
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/MaxBy.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/MaxBy.cs
@@ -16,7 +16,11 @@ namespace System.Reactive.Linq
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return Create<IList<TSource>>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxBy(observer, keySelector)));
+            return Create(
+                source,
+                keySelector,
+                default(IList<TSource>),
+                (source, keySelector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxBy(observer, keySelector)));
         }
 
         public static IAsyncObservable<IList<TSource>> MaxBy<TSource, TKey>(IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey> comparer)
@@ -28,7 +32,11 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<IList<TSource>>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxBy(observer, keySelector, comparer)));
+            return Create(
+                source,
+                (keySelector, comparer),
+                default(IList<TSource>),
+                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxBy(observer, state.keySelector, state.comparer)));
         }
 
         public static IAsyncObservable<IList<TSource>> MaxBy<TSource, TKey>(IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector)
@@ -38,7 +46,11 @@ namespace System.Reactive.Linq
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return Create<IList<TSource>>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxBy(observer, keySelector)));
+            return Create(
+                source,
+                keySelector,
+                default(IList<TSource>),
+                (source, keySelector, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxBy(observer, keySelector)));
         }
 
         public static IAsyncObservable<IList<TSource>> MaxBy<TSource, TKey>(IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, IComparer<TKey> comparer)
@@ -50,7 +62,11 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<IList<TSource>>(observer => source.SubscribeSafeAsync(AsyncObserver.MaxBy(observer, keySelector, comparer)));
+            return Create(
+                source,
+                (keySelector, comparer),
+                default(IList<TSource>),
+                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.MaxBy(observer, state.keySelector, state.comparer)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Min.Generated.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Min.Generated.cs
@@ -23,7 +23,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Int32>.From(
+            return CreateAsyncObservable<Int32>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinInt32(observer, selector)));
@@ -36,7 +36,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Int32>.From(
+            return CreateAsyncObservable<Int32>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinInt32(observer, selector)));
@@ -57,7 +57,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Int32?>.From(
+            return CreateAsyncObservable<Int32?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableInt32(observer, selector)));
@@ -70,7 +70,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Int32?>.From(
+            return CreateAsyncObservable<Int32?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableInt32(observer, selector)));
@@ -91,7 +91,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Int64>.From(
+            return CreateAsyncObservable<Int64>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinInt64(observer, selector)));
@@ -104,7 +104,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Int64>.From(
+            return CreateAsyncObservable<Int64>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinInt64(observer, selector)));
@@ -125,7 +125,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Int64?>.From(
+            return CreateAsyncObservable<Int64?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableInt64(observer, selector)));
@@ -138,7 +138,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Int64?>.From(
+            return CreateAsyncObservable<Int64?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableInt64(observer, selector)));
@@ -159,7 +159,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Single>.From(
+            return CreateAsyncObservable<Single>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinSingle(observer, selector)));
@@ -172,7 +172,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Single>.From(
+            return CreateAsyncObservable<Single>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinSingle(observer, selector)));
@@ -193,7 +193,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Single?>.From(
+            return CreateAsyncObservable<Single?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableSingle(observer, selector)));
@@ -206,7 +206,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Single?>.From(
+            return CreateAsyncObservable<Single?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableSingle(observer, selector)));
@@ -227,7 +227,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Double>.From(
+            return CreateAsyncObservable<Double>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinDouble(observer, selector)));
@@ -240,7 +240,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Double>.From(
+            return CreateAsyncObservable<Double>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinDouble(observer, selector)));
@@ -261,7 +261,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Double?>.From(
+            return CreateAsyncObservable<Double?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableDouble(observer, selector)));
@@ -274,7 +274,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Double?>.From(
+            return CreateAsyncObservable<Double?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableDouble(observer, selector)));
@@ -295,7 +295,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Decimal>.From(
+            return CreateAsyncObservable<Decimal>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinDecimal(observer, selector)));
@@ -308,7 +308,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Decimal>.From(
+            return CreateAsyncObservable<Decimal>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinDecimal(observer, selector)));
@@ -329,7 +329,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Decimal?>.From(
+            return CreateAsyncObservable<Decimal?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableDecimal(observer, selector)));
@@ -342,7 +342,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Decimal?>.From(
+            return CreateAsyncObservable<Decimal?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableDecimal(observer, selector)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Min.Generated.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Min.Generated.cs
@@ -23,10 +23,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Int32>.From(
                 source,
                 selector,
-                default(Int32),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinInt32(observer, selector)));
         }
 
@@ -37,10 +36,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Int32>.From(
                 source,
                 selector,
-                default(Int32),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinInt32(observer, selector)));
         }
 
@@ -59,10 +57,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Int32?>.From(
                 source,
                 selector,
-                default(Int32?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableInt32(observer, selector)));
         }
 
@@ -73,10 +70,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Int32?>.From(
                 source,
                 selector,
-                default(Int32?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableInt32(observer, selector)));
         }
 
@@ -95,10 +91,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Int64>.From(
                 source,
                 selector,
-                default(Int64),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinInt64(observer, selector)));
         }
 
@@ -109,10 +104,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Int64>.From(
                 source,
                 selector,
-                default(Int64),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinInt64(observer, selector)));
         }
 
@@ -131,10 +125,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Int64?>.From(
                 source,
                 selector,
-                default(Int64?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableInt64(observer, selector)));
         }
 
@@ -145,10 +138,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Int64?>.From(
                 source,
                 selector,
-                default(Int64?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableInt64(observer, selector)));
         }
 
@@ -167,10 +159,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Single>.From(
                 source,
                 selector,
-                default(Single),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinSingle(observer, selector)));
         }
 
@@ -181,10 +172,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Single>.From(
                 source,
                 selector,
-                default(Single),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinSingle(observer, selector)));
         }
 
@@ -203,10 +193,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Single?>.From(
                 source,
                 selector,
-                default(Single?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableSingle(observer, selector)));
         }
 
@@ -217,10 +206,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Single?>.From(
                 source,
                 selector,
-                default(Single?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableSingle(observer, selector)));
         }
 
@@ -239,10 +227,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Double>.From(
                 source,
                 selector,
-                default(Double),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinDouble(observer, selector)));
         }
 
@@ -253,10 +240,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Double>.From(
                 source,
                 selector,
-                default(Double),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinDouble(observer, selector)));
         }
 
@@ -275,10 +261,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Double?>.From(
                 source,
                 selector,
-                default(Double?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableDouble(observer, selector)));
         }
 
@@ -289,10 +274,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Double?>.From(
                 source,
                 selector,
-                default(Double?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableDouble(observer, selector)));
         }
 
@@ -311,10 +295,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Decimal>.From(
                 source,
                 selector,
-                default(Decimal),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinDecimal(observer, selector)));
         }
 
@@ -325,10 +308,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Decimal>.From(
                 source,
                 selector,
-                default(Decimal),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinDecimal(observer, selector)));
         }
 
@@ -347,10 +329,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Decimal?>.From(
                 source,
                 selector,
-                default(Decimal?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableDecimal(observer, selector)));
         }
 
@@ -361,10 +342,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Decimal?>.From(
                 source,
                 selector,
-                default(Decimal?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableDecimal(observer, selector)));
         }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Min.Generated.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Min.Generated.cs
@@ -27,7 +27,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Int32),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinInt32(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Int32> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int32>> selector)
@@ -41,7 +41,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Int32),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinInt32(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Int32?> Min(this IAsyncObservable<Int32?> source)
@@ -63,7 +63,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Int32?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableInt32(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Int32?> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int32?>> selector)
@@ -77,7 +77,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Int32?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableInt32(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Int64> Min(this IAsyncObservable<Int64> source)
@@ -99,7 +99,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Int64),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinInt64(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Int64> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int64>> selector)
@@ -113,7 +113,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Int64),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinInt64(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Int64?> Min(this IAsyncObservable<Int64?> source)
@@ -135,7 +135,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Int64?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableInt64(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Int64?> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int64?>> selector)
@@ -149,7 +149,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Int64?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableInt64(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Single> Min(this IAsyncObservable<Single> source)
@@ -171,7 +171,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Single),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinSingle(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Single> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Single>> selector)
@@ -185,7 +185,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Single),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinSingle(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Single?> Min(this IAsyncObservable<Single?> source)
@@ -207,7 +207,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Single?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableSingle(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Single?> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Single?>> selector)
@@ -221,7 +221,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Single?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableSingle(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Double> Min(this IAsyncObservable<Double> source)
@@ -243,7 +243,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Double),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinDouble(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Double> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Double>> selector)
@@ -257,7 +257,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Double),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinDouble(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Double?> Min(this IAsyncObservable<Double?> source)
@@ -279,7 +279,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Double?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableDouble(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Double?> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Double?>> selector)
@@ -293,7 +293,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Double?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableDouble(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal> Min(this IAsyncObservable<Decimal> source)
@@ -315,7 +315,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Decimal),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinDecimal(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinDecimal(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Decimal>> selector)
@@ -329,7 +329,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Decimal),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinDecimal(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinDecimal(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal?> Min(this IAsyncObservable<Decimal?> source)
@@ -351,7 +351,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Decimal?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableDecimal(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableDecimal(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal?> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Decimal?>> selector)
@@ -365,7 +365,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Decimal?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableDecimal(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableDecimal(observer, selector)));
         }
 
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Min.Generated.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Min.Generated.cs
@@ -23,7 +23,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Int32>(observer => source.SubscribeSafeAsync(AsyncObserver.MinInt32(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Int32),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Int32> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int32>> selector)
@@ -33,7 +37,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Int32>(observer => source.SubscribeSafeAsync(AsyncObserver.MinInt32(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Int32),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Int32?> Min(this IAsyncObservable<Int32?> source)
@@ -51,7 +59,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Int32?>(observer => source.SubscribeSafeAsync(AsyncObserver.MinNullableInt32(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Int32?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Int32?> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int32?>> selector)
@@ -61,7 +73,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Int32?>(observer => source.SubscribeSafeAsync(AsyncObserver.MinNullableInt32(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Int32?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Int64> Min(this IAsyncObservable<Int64> source)
@@ -79,7 +95,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Int64>(observer => source.SubscribeSafeAsync(AsyncObserver.MinInt64(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Int64),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Int64> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int64>> selector)
@@ -89,7 +109,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Int64>(observer => source.SubscribeSafeAsync(AsyncObserver.MinInt64(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Int64),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Int64?> Min(this IAsyncObservable<Int64?> source)
@@ -107,7 +131,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Int64?>(observer => source.SubscribeSafeAsync(AsyncObserver.MinNullableInt64(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Int64?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Int64?> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int64?>> selector)
@@ -117,7 +145,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Int64?>(observer => source.SubscribeSafeAsync(AsyncObserver.MinNullableInt64(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Int64?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Single> Min(this IAsyncObservable<Single> source)
@@ -135,7 +167,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Single>(observer => source.SubscribeSafeAsync(AsyncObserver.MinSingle(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Single),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Single> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Single>> selector)
@@ -145,7 +181,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Single>(observer => source.SubscribeSafeAsync(AsyncObserver.MinSingle(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Single),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Single?> Min(this IAsyncObservable<Single?> source)
@@ -163,7 +203,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Single?>(observer => source.SubscribeSafeAsync(AsyncObserver.MinNullableSingle(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Single?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Single?> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Single?>> selector)
@@ -173,7 +217,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Single?>(observer => source.SubscribeSafeAsync(AsyncObserver.MinNullableSingle(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Single?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Double> Min(this IAsyncObservable<Double> source)
@@ -191,7 +239,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Double>(observer => source.SubscribeSafeAsync(AsyncObserver.MinDouble(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Double),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Double> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Double>> selector)
@@ -201,7 +253,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Double>(observer => source.SubscribeSafeAsync(AsyncObserver.MinDouble(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Double),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Double?> Min(this IAsyncObservable<Double?> source)
@@ -219,7 +275,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Double?>(observer => source.SubscribeSafeAsync(AsyncObserver.MinNullableDouble(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Double?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Double?> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Double?>> selector)
@@ -229,7 +289,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Double?>(observer => source.SubscribeSafeAsync(AsyncObserver.MinNullableDouble(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Double?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal> Min(this IAsyncObservable<Decimal> source)
@@ -247,7 +311,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Decimal>(observer => source.SubscribeSafeAsync(AsyncObserver.MinDecimal(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Decimal),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinDecimal(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Decimal>> selector)
@@ -257,7 +325,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Decimal>(observer => source.SubscribeSafeAsync(AsyncObserver.MinDecimal(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Decimal),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinDecimal(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal?> Min(this IAsyncObservable<Decimal?> source)
@@ -275,7 +347,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Decimal?>(observer => source.SubscribeSafeAsync(AsyncObserver.MinNullableDecimal(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Decimal?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableDecimal(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal?> Min<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Decimal?>> selector)
@@ -285,7 +361,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Decimal?>(observer => source.SubscribeSafeAsync(AsyncObserver.MinNullableDecimal(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Decimal?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinNullableDecimal(observer, selector)));
         }
 
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Min.Generated.tt
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Min.Generated.tt
@@ -42,10 +42,9 @@ foreach (var t in types)
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<<#=typeName#>>.From(
                 source,
                 selector,
-                default(<#=typeName#>),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
         }
 
@@ -56,10 +55,9 @@ foreach (var t in types)
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<<#=typeName#>>.From(
                 source,
                 selector,
-                default(<#=typeName#>),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
         }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Min.Generated.tt
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Min.Generated.tt
@@ -46,7 +46,7 @@ foreach (var t in types)
                 source,
                 selector,
                 default(<#=typeName#>),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
         }
 
         public static IAsyncObservable<<#=typeName#>> <#=name#><TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<<#=typeName#>>> selector)
@@ -60,7 +60,7 @@ foreach (var t in types)
                 source,
                 selector,
                 default(<#=typeName#>),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
         }
 
 <#

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Min.Generated.tt
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Min.Generated.tt
@@ -42,7 +42,11 @@ foreach (var t in types)
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<<#=typeName#>>(observer => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(<#=typeName#>),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
         }
 
         public static IAsyncObservable<<#=typeName#>> <#=name#><TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<<#=typeName#>>> selector)
@@ -52,7 +56,11 @@ foreach (var t in types)
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<<#=typeName#>>(observer => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(<#=typeName#>),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
         }
 
 <#

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Min.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Min.cs
@@ -24,7 +24,11 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.Min(observer, comparer)));
+            return Create(
+                source,
+                comparer,
+                default(TSource),
+                (source, comparer, observer) => source.SubscribeSafeAsync(AsyncObserver.Min(observer, comparer)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Min.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Min.cs
@@ -28,7 +28,7 @@ namespace System.Reactive.Linq
                 source,
                 comparer,
                 default(TSource),
-                (source, comparer, observer) => source.SubscribeSafeAsync(AsyncObserver.Min(observer, comparer)));
+                static (source, comparer, observer) => source.SubscribeSafeAsync(AsyncObserver.Min(observer, comparer)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Min.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Min.cs
@@ -24,10 +24,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 comparer,
-                default(TSource),
                 static (source, comparer, observer) => source.SubscribeSafeAsync(AsyncObserver.Min(observer, comparer)));
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Min.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Min.cs
@@ -24,7 +24,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 comparer,
                 static (source, comparer, observer) => source.SubscribeSafeAsync(AsyncObserver.Min(observer, comparer)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/MinBy.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/MinBy.cs
@@ -16,7 +16,7 @@ namespace System.Reactive.Linq
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return Build<IList<TSource>>.From(
+            return CreateAsyncObservable<IList<TSource>>.From(
                 source,
                 keySelector,
                 static (source, keySelector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinBy(observer, keySelector)));
@@ -31,7 +31,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build<IList<TSource>>.From(
+            return CreateAsyncObservable<IList<TSource>>.From(
                 source,
                 (keySelector, comparer),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.MinBy(observer, state.keySelector, state.comparer)));
@@ -44,7 +44,7 @@ namespace System.Reactive.Linq
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return Build<IList<TSource>>.From(
+            return CreateAsyncObservable<IList<TSource>>.From(
                 source,
                 keySelector,
                 static (source, keySelector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinBy(observer, keySelector)));
@@ -59,7 +59,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build<IList<TSource>>.From(
+            return CreateAsyncObservable<IList<TSource>>.From(
                 source,
                 (keySelector, comparer),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.MinBy(observer, state.keySelector, state.comparer)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/MinBy.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/MinBy.cs
@@ -16,7 +16,11 @@ namespace System.Reactive.Linq
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return Create<IList<TSource>>(observer => source.SubscribeSafeAsync(AsyncObserver.MinBy(observer, keySelector)));
+            return Create(
+                source,
+                keySelector,
+                default(IList<TSource>),               
+                (source, keySelector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinBy(observer, keySelector)));
         }
 
         public static IAsyncObservable<IList<TSource>> MinBy<TSource, TKey>(IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey> comparer)
@@ -28,7 +32,11 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<IList<TSource>>(observer => source.SubscribeSafeAsync(AsyncObserver.MinBy(observer, keySelector, comparer)));
+            return Create(
+                source,
+                (keySelector, comparer),
+                default(IList<TSource>),
+                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.MinBy(observer, state.keySelector, state.comparer)));
         }
 
         public static IAsyncObservable<IList<TSource>> MinBy<TSource, TKey>(IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector)
@@ -38,7 +46,11 @@ namespace System.Reactive.Linq
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return Create<IList<TSource>>(observer => source.SubscribeSafeAsync(AsyncObserver.MinBy(observer, keySelector)));
+            return Create(
+                source,
+                keySelector,
+                default(IList<TSource>),
+                (source, keySelector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinBy(observer, keySelector)));
         }
 
         public static IAsyncObservable<IList<TSource>> MinBy<TSource, TKey>(IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, IComparer<TKey> comparer)
@@ -50,7 +62,11 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<IList<TSource>>(observer => source.SubscribeSafeAsync(AsyncObserver.MinBy(observer, keySelector, comparer)));
+            return Create(
+                source,
+                (keySelector, comparer),
+                default(IList<TSource>),
+                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.MinBy(observer, state.keySelector, state.comparer)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/MinBy.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/MinBy.cs
@@ -19,8 +19,8 @@ namespace System.Reactive.Linq
             return Create(
                 source,
                 keySelector,
-                default(IList<TSource>),               
-                (source, keySelector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinBy(observer, keySelector)));
+                default(IList<TSource>),
+                static (source, keySelector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinBy(observer, keySelector)));
         }
 
         public static IAsyncObservable<IList<TSource>> MinBy<TSource, TKey>(IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey> comparer)
@@ -36,7 +36,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, comparer),
                 default(IList<TSource>),
-                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.MinBy(observer, state.keySelector, state.comparer)));
+                static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.MinBy(observer, state.keySelector, state.comparer)));
         }
 
         public static IAsyncObservable<IList<TSource>> MinBy<TSource, TKey>(IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector)
@@ -50,7 +50,7 @@ namespace System.Reactive.Linq
                 source,
                 keySelector,
                 default(IList<TSource>),
-                (source, keySelector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinBy(observer, keySelector)));
+                static (source, keySelector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinBy(observer, keySelector)));
         }
 
         public static IAsyncObservable<IList<TSource>> MinBy<TSource, TKey>(IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, IComparer<TKey> comparer)
@@ -66,7 +66,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, comparer),
                 default(IList<TSource>),
-                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.MinBy(observer, state.keySelector, state.comparer)));
+                static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.MinBy(observer, state.keySelector, state.comparer)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/MinBy.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/MinBy.cs
@@ -16,10 +16,9 @@ namespace System.Reactive.Linq
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return Create(
+            return Build<IList<TSource>>.From(
                 source,
                 keySelector,
-                default(IList<TSource>),
                 static (source, keySelector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinBy(observer, keySelector)));
         }
 
@@ -32,10 +31,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build<IList<TSource>>.From(
                 source,
                 (keySelector, comparer),
-                default(IList<TSource>),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.MinBy(observer, state.keySelector, state.comparer)));
         }
 
@@ -46,10 +44,9 @@ namespace System.Reactive.Linq
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return Create(
+            return Build<IList<TSource>>.From(
                 source,
                 keySelector,
-                default(IList<TSource>),
                 static (source, keySelector, observer) => source.SubscribeSafeAsync(AsyncObserver.MinBy(observer, keySelector)));
         }
 
@@ -62,10 +59,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build<IList<TSource>>.From(
                 source,
                 (keySelector, comparer),
-                default(IList<TSource>),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.MinBy(observer, state.keySelector, state.comparer)));
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Multicast.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Multicast.cs
@@ -67,7 +67,7 @@ namespace System.Reactive.Linq
                 source,
                 (subjectFactory, selector),
                 default(TResult),
-                async (source, state, observer) =>
+                static async (source, state, observer) =>
                 {
                     var observable = default(IAsyncObservable<TResult>);
                     var connectable = default(IConnectableAsyncObservable<TIntermediate>);

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Multicast.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Multicast.cs
@@ -63,10 +63,9 @@ namespace System.Reactive.Linq
 
             // REVIEW: Use a lifted observer operator.
 
-            return Create(
+            return Build<TResult>.From(
                 source,
                 (subjectFactory, selector),
-                default(TResult),
                 static async (source, state, observer) =>
                 {
                     var observable = default(IAsyncObservable<TResult>);

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Multicast.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Multicast.cs
@@ -63,7 +63,7 @@ namespace System.Reactive.Linq
 
             // REVIEW: Use a lifted observer operator.
 
-            return Build<TResult>.From(
+            return CreateAsyncObservable<TResult>.From(
                 source,
                 (subjectFactory, selector),
                 static async (source, state, observer) =>

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Multicast.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Multicast.cs
@@ -63,33 +63,37 @@ namespace System.Reactive.Linq
 
             // REVIEW: Use a lifted observer operator.
 
-            return Create<TResult>(async observer =>
-            {
-                var observable = default(IAsyncObservable<TResult>);
-                var connectable = default(IConnectableAsyncObservable<TIntermediate>);
-
-                try
+            return Create(
+                source,
+                (subjectFactory, selector),
+                default(TResult),
+                async (source, state, observer) =>
                 {
-                    var subject = await subjectFactory().ConfigureAwait(false);
-                    connectable = new ConnectableAsyncObservable<TSource, TIntermediate>(source, subject);
-                    observable = await selector(connectable).ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    await observer.OnErrorAsync(ex).ConfigureAwait(false);
-                    return AsyncDisposable.Nop;
-                }
+                    var observable = default(IAsyncObservable<TResult>);
+                    var connectable = default(IConnectableAsyncObservable<TIntermediate>);
 
-                var d = new CompositeAsyncDisposable();
+                    try
+                    {
+                        var subject = await state.subjectFactory().ConfigureAwait(false);
+                        connectable = new ConnectableAsyncObservable<TSource, TIntermediate>(source, subject);
+                        observable = await state.selector(connectable).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        await observer.OnErrorAsync(ex).ConfigureAwait(false);
+                        return AsyncDisposable.Nop;
+                    }
 
-                var subscription = await observable.SubscribeAsync(observer).ConfigureAwait(false);
-                await d.AddAsync(subscription).ConfigureAwait(false);
+                    var d = new CompositeAsyncDisposable();
 
-                var connection = await connectable.ConnectAsync().ConfigureAwait(false);
-                await d.AddAsync(connection).ConfigureAwait(false);
+                    var subscription = await observable.SubscribeAsync(observer).ConfigureAwait(false);
+                    await d.AddAsync(subscription).ConfigureAwait(false);
 
-                return d;
-            });
+                    var connection = await connectable.ConnectAsync().ConfigureAwait(false);
+                    await d.AddAsync(connection).ConfigureAwait(false);
+
+                    return d;
+                });
         }
     }
 }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ObserveOn.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ObserveOn.cs
@@ -19,14 +19,18 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Create<TSource>(async observer =>
-            {
-                var (sink, drain) = await AsyncObserver.ObserveOn(observer, scheduler).ConfigureAwait(false);
+            return Create(
+                source,
+                scheduler,
+                default(TSource),
+                async (source, scheduler, observer) =>
+                {
+                    var (sink, drain) = await AsyncObserver.ObserveOn(observer, scheduler).ConfigureAwait(false);
 
-                var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, drain);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, drain);
+                });
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ObserveOn.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ObserveOn.cs
@@ -19,10 +19,9 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 scheduler,
-                default(TSource),
                 static async (source, scheduler, observer) =>
                 {
                     var (sink, drain) = await AsyncObserver.ObserveOn(observer, scheduler).ConfigureAwait(false);

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ObserveOn.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ObserveOn.cs
@@ -19,7 +19,7 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 scheduler,
                 static async (source, scheduler, observer) =>

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ObserveOn.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ObserveOn.cs
@@ -23,7 +23,7 @@ namespace System.Reactive.Linq
                 source,
                 scheduler,
                 default(TSource),
-                async (source, scheduler, observer) =>
+                static async (source, scheduler, observer) =>
                 {
                     var (sink, drain) = await AsyncObserver.ObserveOn(observer, scheduler).ConfigureAwait(false);
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/OnErrorResumeNext.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/OnErrorResumeNext.cs
@@ -23,7 +23,7 @@ namespace System.Reactive.Linq
                 first,
                 second,
                 default(TSource),
-                async (first, second, observer) =>
+                static async (first, second, observer) =>
                 {
                     var (sink, inner) = AsyncObserver.OnErrorResumeNext(observer, second);
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/OnErrorResumeNext.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/OnErrorResumeNext.cs
@@ -19,7 +19,7 @@ namespace System.Reactive.Linq
             if (second == null)
                 throw new ArgumentNullException(nameof(second));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 first,
                 second,
                 static async (first, second, observer) =>

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/OnErrorResumeNext.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/OnErrorResumeNext.cs
@@ -19,14 +19,18 @@ namespace System.Reactive.Linq
             if (second == null)
                 throw new ArgumentNullException(nameof(second));
 
-            return Create<TSource>(async observer =>
-            {
-                var (sink, inner) = AsyncObserver.OnErrorResumeNext(observer, second);
+            return Create(
+                first,
+                second,
+                default(TSource),
+                async (first, second, observer) =>
+                {
+                    var (sink, inner) = AsyncObserver.OnErrorResumeNext(observer, second);
 
-                var subscription = await first.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await first.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, inner);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, inner);
+                });
         }
 
         public static IAsyncObservable<TSource> OnErrorResumeNext<TSource>(params IAsyncObservable<TSource>[] sources) => OnErrorResumeNext((IEnumerable<IAsyncObservable<TSource>>)sources);

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/OnErrorResumeNext.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/OnErrorResumeNext.cs
@@ -19,10 +19,9 @@ namespace System.Reactive.Linq
             if (second == null)
                 throw new ArgumentNullException(nameof(second));
 
-            return Create(
+            return Build<TSource>.From(
                 first,
                 second,
-                default(TSource),
                 static async (first, second, observer) =>
                 {
                     var (sink, inner) = AsyncObserver.OnErrorResumeNext(observer, second);

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Prepend.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Prepend.cs
@@ -21,10 +21,9 @@ namespace System.Reactive.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 value,
-                default(TSource),
                 static async (source, value, observer) => await source.SubscribeSafeAsync(await AsyncObserver.Prepend(observer, value).ConfigureAwait(false)).ConfigureAwait(false));
         }
 
@@ -35,10 +34,9 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 (scheduler, value),
-                default(TSource),
                 static (source, state, observer) => AsyncObserver.Prepend(observer, source, state.value, state.scheduler));
         }
 
@@ -49,10 +47,9 @@ namespace System.Reactive.Linq
             if (values == null)
                 throw new ArgumentNullException(nameof(values));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 values,
-                default(TSource),
                 static async (source, values, observer) => await source.SubscribeSafeAsync(await AsyncObserver.Prepend(observer, values).ConfigureAwait(false)).ConfigureAwait(false));
         }
 
@@ -65,10 +62,9 @@ namespace System.Reactive.Linq
             if (values == null)
                 throw new ArgumentNullException(nameof(values));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 (scheduler, values),
-                default(TSource),
                 static (source, state, observer) => AsyncObserver.Prepend(observer, source, state.scheduler, state.values)); ;
         }
 
@@ -79,10 +75,9 @@ namespace System.Reactive.Linq
             if (values == null)
                 throw new ArgumentNullException(nameof(values));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 values,
-                default(TSource),
                 static async (source, values, observer) => await source.SubscribeSafeAsync(await AsyncObserver.Prepend(observer, values).ConfigureAwait(false)).ConfigureAwait(false));
         }
 
@@ -95,10 +90,9 @@ namespace System.Reactive.Linq
             if (values == null)
                 throw new ArgumentNullException(nameof(values));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 (scheduler, values),
-                default(TSource),
                 static (source, state, observer) => AsyncObserver.Prepend(observer, source, state.scheduler, state.values));
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Prepend.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Prepend.cs
@@ -21,7 +21,11 @@ namespace System.Reactive.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return Create<TSource>(async observer => await source.SubscribeSafeAsync(await AsyncObserver.Prepend(observer, value).ConfigureAwait(false)).ConfigureAwait(false));
+            return Create(
+                source,
+                value,
+                default(TSource),
+                async (source, value, observer) => await source.SubscribeSafeAsync(await AsyncObserver.Prepend(observer, value).ConfigureAwait(false)).ConfigureAwait(false));
         }
 
         public static IAsyncObservable<TSource> Prepend<TSource>(this IAsyncObservable<TSource> source, TSource value, IAsyncScheduler scheduler)
@@ -31,7 +35,11 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Create<TSource>(observer => AsyncObserver.Prepend(observer, source, value, scheduler));
+            return Create(
+                source,
+                (scheduler, value),
+                default(TSource),
+                (source, state, observer) => AsyncObserver.Prepend(observer, source, state.value, state.scheduler));
         }
 
         public static IAsyncObservable<TSource> Prepend<TSource>(this IAsyncObservable<TSource> source, params TSource[] values)
@@ -41,7 +49,11 @@ namespace System.Reactive.Linq
             if (values == null)
                 throw new ArgumentNullException(nameof(values));
 
-            return Create<TSource>(async observer => await source.SubscribeSafeAsync(await AsyncObserver.Prepend(observer, values).ConfigureAwait(false)).ConfigureAwait(false));
+            return Create(
+                source,
+                values,
+                default(TSource),
+                async (source, values, observer) => await source.SubscribeSafeAsync(await AsyncObserver.Prepend(observer, values).ConfigureAwait(false)).ConfigureAwait(false));
         }
 
         public static IAsyncObservable<TSource> Prepend<TSource>(this IAsyncObservable<TSource> source, IAsyncScheduler scheduler, params TSource[] values)
@@ -53,7 +65,11 @@ namespace System.Reactive.Linq
             if (values == null)
                 throw new ArgumentNullException(nameof(values));
 
-            return Create<TSource>(observer => AsyncObserver.Prepend(observer, source, scheduler, values));
+            return Create(
+                source,
+                (scheduler, values),
+                default(TSource),
+                (source, state, observer) => AsyncObserver.Prepend(observer, source, state.scheduler, state.values)); ;
         }
 
         public static IAsyncObservable<TSource> Prepend<TSource>(this IAsyncObservable<TSource> source, IEnumerable<TSource> values)
@@ -63,7 +79,11 @@ namespace System.Reactive.Linq
             if (values == null)
                 throw new ArgumentNullException(nameof(values));
 
-            return Create<TSource>(async observer => await source.SubscribeSafeAsync(await AsyncObserver.Prepend(observer, values).ConfigureAwait(false)).ConfigureAwait(false));
+            return Create(
+                source,
+                values,
+                default(TSource),
+                async (source, values, observer) => await source.SubscribeSafeAsync(await AsyncObserver.Prepend(observer, values).ConfigureAwait(false)).ConfigureAwait(false));
         }
 
         public static IAsyncObservable<TSource> Prepend<TSource>(this IAsyncObservable<TSource> source, IAsyncScheduler scheduler, IEnumerable<TSource> values)
@@ -75,7 +95,11 @@ namespace System.Reactive.Linq
             if (values == null)
                 throw new ArgumentNullException(nameof(values));
 
-            return Create<TSource>(observer => AsyncObserver.Prepend(observer, source, scheduler, values));
+            return Create(
+                source,
+                (scheduler, values),
+                default(TSource),
+                (source, state, observer) => AsyncObserver.Prepend(observer, source, state.scheduler, state.values));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Prepend.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Prepend.cs
@@ -25,7 +25,7 @@ namespace System.Reactive.Linq
                 source,
                 value,
                 default(TSource),
-                async (source, value, observer) => await source.SubscribeSafeAsync(await AsyncObserver.Prepend(observer, value).ConfigureAwait(false)).ConfigureAwait(false));
+                static async (source, value, observer) => await source.SubscribeSafeAsync(await AsyncObserver.Prepend(observer, value).ConfigureAwait(false)).ConfigureAwait(false));
         }
 
         public static IAsyncObservable<TSource> Prepend<TSource>(this IAsyncObservable<TSource> source, TSource value, IAsyncScheduler scheduler)
@@ -39,7 +39,7 @@ namespace System.Reactive.Linq
                 source,
                 (scheduler, value),
                 default(TSource),
-                (source, state, observer) => AsyncObserver.Prepend(observer, source, state.value, state.scheduler));
+                static (source, state, observer) => AsyncObserver.Prepend(observer, source, state.value, state.scheduler));
         }
 
         public static IAsyncObservable<TSource> Prepend<TSource>(this IAsyncObservable<TSource> source, params TSource[] values)
@@ -53,7 +53,7 @@ namespace System.Reactive.Linq
                 source,
                 values,
                 default(TSource),
-                async (source, values, observer) => await source.SubscribeSafeAsync(await AsyncObserver.Prepend(observer, values).ConfigureAwait(false)).ConfigureAwait(false));
+                static async (source, values, observer) => await source.SubscribeSafeAsync(await AsyncObserver.Prepend(observer, values).ConfigureAwait(false)).ConfigureAwait(false));
         }
 
         public static IAsyncObservable<TSource> Prepend<TSource>(this IAsyncObservable<TSource> source, IAsyncScheduler scheduler, params TSource[] values)
@@ -69,7 +69,7 @@ namespace System.Reactive.Linq
                 source,
                 (scheduler, values),
                 default(TSource),
-                (source, state, observer) => AsyncObserver.Prepend(observer, source, state.scheduler, state.values)); ;
+                static (source, state, observer) => AsyncObserver.Prepend(observer, source, state.scheduler, state.values)); ;
         }
 
         public static IAsyncObservable<TSource> Prepend<TSource>(this IAsyncObservable<TSource> source, IEnumerable<TSource> values)
@@ -83,7 +83,7 @@ namespace System.Reactive.Linq
                 source,
                 values,
                 default(TSource),
-                async (source, values, observer) => await source.SubscribeSafeAsync(await AsyncObserver.Prepend(observer, values).ConfigureAwait(false)).ConfigureAwait(false));
+                static async (source, values, observer) => await source.SubscribeSafeAsync(await AsyncObserver.Prepend(observer, values).ConfigureAwait(false)).ConfigureAwait(false));
         }
 
         public static IAsyncObservable<TSource> Prepend<TSource>(this IAsyncObservable<TSource> source, IAsyncScheduler scheduler, IEnumerable<TSource> values)
@@ -99,7 +99,7 @@ namespace System.Reactive.Linq
                 source,
                 (scheduler, values),
                 default(TSource),
-                (source, state, observer) => AsyncObserver.Prepend(observer, source, state.scheduler, state.values));
+                static (source, state, observer) => AsyncObserver.Prepend(observer, source, state.scheduler, state.values));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Prepend.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Prepend.cs
@@ -21,7 +21,7 @@ namespace System.Reactive.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 value,
                 static async (source, value, observer) => await source.SubscribeSafeAsync(await AsyncObserver.Prepend(observer, value).ConfigureAwait(false)).ConfigureAwait(false));
@@ -34,7 +34,7 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 (scheduler, value),
                 static (source, state, observer) => AsyncObserver.Prepend(observer, source, state.value, state.scheduler));
@@ -47,7 +47,7 @@ namespace System.Reactive.Linq
             if (values == null)
                 throw new ArgumentNullException(nameof(values));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 values,
                 static async (source, values, observer) => await source.SubscribeSafeAsync(await AsyncObserver.Prepend(observer, values).ConfigureAwait(false)).ConfigureAwait(false));
@@ -62,7 +62,7 @@ namespace System.Reactive.Linq
             if (values == null)
                 throw new ArgumentNullException(nameof(values));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 (scheduler, values),
                 static (source, state, observer) => AsyncObserver.Prepend(observer, source, state.scheduler, state.values)); ;
@@ -75,7 +75,7 @@ namespace System.Reactive.Linq
             if (values == null)
                 throw new ArgumentNullException(nameof(values));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 values,
                 static async (source, values, observer) => await source.SubscribeSafeAsync(await AsyncObserver.Prepend(observer, values).ConfigureAwait(false)).ConfigureAwait(false));
@@ -90,7 +90,7 @@ namespace System.Reactive.Linq
             if (values == null)
                 throw new ArgumentNullException(nameof(values));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 (scheduler, values),
                 static (source, state, observer) => AsyncObserver.Prepend(observer, source, state.scheduler, state.values));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Repeat.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Repeat.cs
@@ -58,10 +58,9 @@ namespace System.Reactive.Linq
             if (repeatCount < 0)
                 throw new ArgumentNullException(nameof(repeatCount));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 repeatCount,
-                default(TSource),
                 static (source, repeatCount, observer) => AsyncObserver.Repeat(observer, source, repeatCount));
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Repeat.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Repeat.cs
@@ -62,7 +62,7 @@ namespace System.Reactive.Linq
                 source,
                 repeatCount,
                 default(TSource),
-                (source, repeatCount, observer) => AsyncObserver.Repeat(observer, source, repeatCount));
+                static (source, repeatCount, observer) => AsyncObserver.Repeat(observer, source, repeatCount));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Repeat.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Repeat.cs
@@ -58,7 +58,11 @@ namespace System.Reactive.Linq
             if (repeatCount < 0)
                 throw new ArgumentNullException(nameof(repeatCount));
 
-            return Create<TSource>(observer => AsyncObserver.Repeat(observer, source, repeatCount));
+            return Create(
+                source,
+                repeatCount,
+                default(TSource),
+                (source, repeatCount, observer) => AsyncObserver.Repeat(observer, source, repeatCount));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Repeat.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Repeat.cs
@@ -58,7 +58,7 @@ namespace System.Reactive.Linq
             if (repeatCount < 0)
                 throw new ArgumentNullException(nameof(repeatCount));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 repeatCount,
                 static (source, repeatCount, observer) => AsyncObserver.Repeat(observer, source, repeatCount));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Retry.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Retry.cs
@@ -33,7 +33,7 @@ namespace System.Reactive.Linq
             if (retryCount < 0)
                 throw new ArgumentOutOfRangeException(nameof(retryCount));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 retryCount,
                 static async (source, retryCount, observer) =>

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Retry.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Retry.cs
@@ -33,14 +33,18 @@ namespace System.Reactive.Linq
             if (retryCount < 0)
                 throw new ArgumentOutOfRangeException(nameof(retryCount));
 
-            return Create<TSource>(async observer =>
-            {
-                var (sink, inner) = AsyncObserver.Retry(observer, source, retryCount);
+            return Create(
+                source,
+                retryCount,
+                default(TSource),
+                async (source, retryCount, observer) =>
+                {
+                    var (sink, inner) = AsyncObserver.Retry(observer, source, retryCount);
 
-                var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, inner);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, inner);
+                });
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Retry.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Retry.cs
@@ -33,10 +33,9 @@ namespace System.Reactive.Linq
             if (retryCount < 0)
                 throw new ArgumentOutOfRangeException(nameof(retryCount));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 retryCount,
-                default(TSource),
                 static async (source, retryCount, observer) =>
                 {
                     var (sink, inner) = AsyncObserver.Retry(observer, source, retryCount);

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Retry.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Retry.cs
@@ -37,7 +37,7 @@ namespace System.Reactive.Linq
                 source,
                 retryCount,
                 default(TSource),
-                async (source, retryCount, observer) =>
+                static async (source, retryCount, observer) =>
                 {
                     var (sink, inner) = AsyncObserver.Retry(observer, source, retryCount);
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Sample.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Sample.cs
@@ -18,7 +18,7 @@ namespace System.Reactive.Linq
             if (sampler == null)
                 throw new ArgumentNullException(nameof(sampler));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 sampler,
                 static async (source, sampler, observer) =>
@@ -37,7 +37,7 @@ namespace System.Reactive.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 interval,
                 static async (source, interval, observer) =>
@@ -57,7 +57,7 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 (scheduler, interval),
                 static async (source, state, observer) =>

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Sample.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Sample.cs
@@ -22,7 +22,7 @@ namespace System.Reactive.Linq
                 source,
                 sampler,
                 default(TSource),
-                async (source, sampler, observer) =>
+                static async (source, sampler, observer) =>
                 {
                     var (sourceSink, samplerSink) = AsyncObserver.Sample<TSource, TSample>(observer);
 
@@ -42,7 +42,7 @@ namespace System.Reactive.Linq
                 source,
                 interval,
                 default(TSource),
-                async (source, interval, observer) =>
+                static async (source, interval, observer) =>
                 {
                     var (sourceSink, sampler) = await AsyncObserver.Sample(observer, interval).ConfigureAwait(false);
 
@@ -63,7 +63,7 @@ namespace System.Reactive.Linq
                 source,
                 (scheduler, interval),
                 default(TSource),
-                async (source, state, observer) =>
+                static async (source, state, observer) =>
                 {
                     var (sourceSink, sampler) = await AsyncObserver.Sample(observer, state.interval, state.scheduler).ConfigureAwait(false);
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Sample.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Sample.cs
@@ -18,15 +18,19 @@ namespace System.Reactive.Linq
             if (sampler == null)
                 throw new ArgumentNullException(nameof(sampler));
 
-            return Create<TSource>(async observer =>
-            {
-                var (sourceSink, samplerSink) = AsyncObserver.Sample<TSource, TSample>(observer);
+            return Create(
+                source,
+                sampler,
+                default(TSource),
+                async (source, sampler, observer) =>
+                {
+                    var (sourceSink, samplerSink) = AsyncObserver.Sample<TSource, TSample>(observer);
 
-                var sourceSubscription = await source.SubscribeSafeAsync(sourceSink).ConfigureAwait(false);
-                var samplerSubscription = await sampler.SubscribeSafeAsync(samplerSink).ConfigureAwait(false);
+                    var sourceSubscription = await source.SubscribeSafeAsync(sourceSink).ConfigureAwait(false);
+                    var samplerSubscription = await sampler.SubscribeSafeAsync(samplerSink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(sourceSubscription, samplerSubscription);
-            });
+                    return StableCompositeAsyncDisposable.Create(sourceSubscription, samplerSubscription);
+                });
         }
 
         public static IAsyncObservable<TSource> Sample<TSource>(this IAsyncObservable<TSource> source, TimeSpan interval)
@@ -34,14 +38,18 @@ namespace System.Reactive.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return Create<TSource>(async observer =>
-            {
-                var (sourceSink, sampler) = await AsyncObserver.Sample(observer, interval).ConfigureAwait(false);
+            return Create(
+                source,
+                interval,
+                default(TSource),
+                async (source, interval, observer) =>
+                {
+                    var (sourceSink, sampler) = await AsyncObserver.Sample(observer, interval).ConfigureAwait(false);
 
-                var sourceSubscription = await source.SubscribeSafeAsync(sourceSink).ConfigureAwait(false);
+                    var sourceSubscription = await source.SubscribeSafeAsync(sourceSink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(sourceSubscription, sampler);
-            });
+                    return StableCompositeAsyncDisposable.Create(sourceSubscription, sampler);
+                });
         }
 
         public static IAsyncObservable<TSource> Sample<TSource>(this IAsyncObservable<TSource> source, TimeSpan interval, IAsyncScheduler scheduler)
@@ -51,14 +59,18 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Create<TSource>(async observer =>
-            {
-                var (sourceSink, sampler) = await AsyncObserver.Sample(observer, interval, scheduler).ConfigureAwait(false);
+            return Create(
+                source,
+                (scheduler, interval),
+                default(TSource),
+                async (source, state, observer) =>
+                {
+                    var (sourceSink, sampler) = await AsyncObserver.Sample(observer, state.interval, state.scheduler).ConfigureAwait(false);
 
-                var sourceSubscription = await source.SubscribeSafeAsync(sourceSink).ConfigureAwait(false);
+                    var sourceSubscription = await source.SubscribeSafeAsync(sourceSink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(sourceSubscription, sampler);
-            });
+                    return StableCompositeAsyncDisposable.Create(sourceSubscription, sampler);
+                });
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Sample.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Sample.cs
@@ -18,10 +18,9 @@ namespace System.Reactive.Linq
             if (sampler == null)
                 throw new ArgumentNullException(nameof(sampler));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 sampler,
-                default(TSource),
                 static async (source, sampler, observer) =>
                 {
                     var (sourceSink, samplerSink) = AsyncObserver.Sample<TSource, TSample>(observer);
@@ -38,10 +37,9 @@ namespace System.Reactive.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 interval,
-                default(TSource),
                 static async (source, interval, observer) =>
                 {
                     var (sourceSink, sampler) = await AsyncObserver.Sample(observer, interval).ConfigureAwait(false);
@@ -59,10 +57,9 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 (scheduler, interval),
-                default(TSource),
                 static async (source, state, observer) =>
                 {
                     var (sourceSink, sampler) = await AsyncObserver.Sample(observer, state.interval, state.scheduler).ConfigureAwait(false);

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Scan.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Scan.cs
@@ -15,7 +15,11 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.Scan(observer, func)));
+            return Create(
+                source,
+                func,
+                default(TSource),
+                (source, func, observer) => source.SubscribeSafeAsync(AsyncObserver.Scan(observer, func)));
         }
 
         public static IAsyncObservable<TSource> Scan<TSource>(this IAsyncObservable<TSource> source, Func<TSource, TSource, ValueTask<TSource>> func)
@@ -25,7 +29,11 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.Scan(observer, func)));
+            return Create(
+                source,
+                func,
+                default(TSource),
+                (source, func, observer) => source.SubscribeSafeAsync(AsyncObserver.Scan(observer, func)));
         }
 
         public static IAsyncObservable<TResult> Scan<TSource, TResult>(this IAsyncObservable<TSource> source, TResult seed, Func<TResult, TSource, TResult> func)
@@ -35,7 +43,11 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Create<TResult>(observer => source.SubscribeSafeAsync(AsyncObserver.Scan(observer, seed, func)));
+            return Create(
+                source,
+                (func, seed),
+                default(TResult),
+                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Scan(observer, state.seed, state.func)));
         }
 
         public static IAsyncObservable<TResult> Scan<TSource, TResult>(this IAsyncObservable<TSource> source, TResult seed, Func<TResult, TSource, ValueTask<TResult>> func)
@@ -45,7 +57,11 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Create<TResult>(observer => source.SubscribeSafeAsync(AsyncObserver.Scan(observer, seed, func)));
+            return Create(
+                source,
+                (func, seed),
+                default(TResult),
+                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Scan(observer, state.seed, state.func)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Scan.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Scan.cs
@@ -15,10 +15,9 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 func,
-                default(TSource),
                 static (source, func, observer) => source.SubscribeSafeAsync(AsyncObserver.Scan(observer, func)));
         }
 
@@ -29,10 +28,9 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 func,
-                default(TSource),
                 static (source, func, observer) => source.SubscribeSafeAsync(AsyncObserver.Scan(observer, func)));
         }
 
@@ -43,10 +41,9 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Create(
+            return Build<TResult>.From(
                 source,
                 (func, seed),
-                default(TResult),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Scan(observer, state.seed, state.func)));
         }
 
@@ -57,10 +54,9 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Create(
+            return Build<TResult>.From(
                 source,
                 (func, seed),
-                default(TResult),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Scan(observer, state.seed, state.func)));
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Scan.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Scan.cs
@@ -15,7 +15,7 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 func,
                 static (source, func, observer) => source.SubscribeSafeAsync(AsyncObserver.Scan(observer, func)));
@@ -28,7 +28,7 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 func,
                 static (source, func, observer) => source.SubscribeSafeAsync(AsyncObserver.Scan(observer, func)));
@@ -41,7 +41,7 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Build<TResult>.From(
+            return CreateAsyncObservable<TResult>.From(
                 source,
                 (func, seed),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Scan(observer, state.seed, state.func)));
@@ -54,7 +54,7 @@ namespace System.Reactive.Linq
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            return Build<TResult>.From(
+            return CreateAsyncObservable<TResult>.From(
                 source,
                 (func, seed),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Scan(observer, state.seed, state.func)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Scan.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Scan.cs
@@ -19,7 +19,7 @@ namespace System.Reactive.Linq
                 source,
                 func,
                 default(TSource),
-                (source, func, observer) => source.SubscribeSafeAsync(AsyncObserver.Scan(observer, func)));
+                static (source, func, observer) => source.SubscribeSafeAsync(AsyncObserver.Scan(observer, func)));
         }
 
         public static IAsyncObservable<TSource> Scan<TSource>(this IAsyncObservable<TSource> source, Func<TSource, TSource, ValueTask<TSource>> func)
@@ -33,7 +33,7 @@ namespace System.Reactive.Linq
                 source,
                 func,
                 default(TSource),
-                (source, func, observer) => source.SubscribeSafeAsync(AsyncObserver.Scan(observer, func)));
+                static (source, func, observer) => source.SubscribeSafeAsync(AsyncObserver.Scan(observer, func)));
         }
 
         public static IAsyncObservable<TResult> Scan<TSource, TResult>(this IAsyncObservable<TSource> source, TResult seed, Func<TResult, TSource, TResult> func)
@@ -47,7 +47,7 @@ namespace System.Reactive.Linq
                 source,
                 (func, seed),
                 default(TResult),
-                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Scan(observer, state.seed, state.func)));
+                static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Scan(observer, state.seed, state.func)));
         }
 
         public static IAsyncObservable<TResult> Scan<TSource, TResult>(this IAsyncObservable<TSource> source, TResult seed, Func<TResult, TSource, ValueTask<TResult>> func)
@@ -61,7 +61,7 @@ namespace System.Reactive.Linq
                 source,
                 (func, seed),
                 default(TResult),
-                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Scan(observer, state.seed, state.func)));
+                static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.Scan(observer, state.seed, state.func)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Select.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Select.cs
@@ -15,7 +15,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<TResult>(observer => source.SubscribeSafeAsync(AsyncObserver.Select(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(TResult),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.Select(observer, selector)));
         }
 
         public static IAsyncObservable<TResult> Select<TSource, TResult>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TResult>> selector)
@@ -25,7 +29,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<TResult>(observer => source.SubscribeSafeAsync(AsyncObserver.Select(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(TResult),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.Select(observer, selector)));
         }
 
         public static IAsyncObservable<TResult> Select<TSource, TResult>(this IAsyncObservable<TSource> source, Func<TSource, int, TResult> selector)
@@ -35,7 +43,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<TResult>(observer => source.SubscribeSafeAsync(AsyncObserver.Select(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(TResult),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.Select(observer, selector)));
         }
 
         public static IAsyncObservable<TResult> Select<TSource, TResult>(this IAsyncObservable<TSource> source, Func<TSource, int, ValueTask<TResult>> selector)
@@ -45,7 +57,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<TResult>(observer => source.SubscribeSafeAsync(AsyncObserver.Select(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(TResult),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.Select(observer, selector)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Select.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Select.cs
@@ -15,7 +15,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<TResult>.From(
+            return CreateAsyncObservable<TResult>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.Select(observer, selector)));
@@ -28,7 +28,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<TResult>.From(
+            return CreateAsyncObservable<TResult>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.Select(observer, selector)));
@@ -41,7 +41,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<TResult>.From(
+            return CreateAsyncObservable<TResult>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.Select(observer, selector)));
@@ -54,7 +54,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<TResult>.From(
+            return CreateAsyncObservable<TResult>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.Select(observer, selector)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Select.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Select.cs
@@ -19,7 +19,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(TResult),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.Select(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.Select(observer, selector)));
         }
 
         public static IAsyncObservable<TResult> Select<TSource, TResult>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TResult>> selector)
@@ -33,7 +33,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(TResult),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.Select(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.Select(observer, selector)));
         }
 
         public static IAsyncObservable<TResult> Select<TSource, TResult>(this IAsyncObservable<TSource> source, Func<TSource, int, TResult> selector)
@@ -47,7 +47,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(TResult),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.Select(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.Select(observer, selector)));
         }
 
         public static IAsyncObservable<TResult> Select<TSource, TResult>(this IAsyncObservable<TSource> source, Func<TSource, int, ValueTask<TResult>> selector)
@@ -61,7 +61,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(TResult),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.Select(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.Select(observer, selector)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Select.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Select.cs
@@ -15,10 +15,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<TResult>.From(
                 source,
                 selector,
-                default(TResult),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.Select(observer, selector)));
         }
 
@@ -29,10 +28,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<TResult>.From(
                 source,
                 selector,
-                default(TResult),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.Select(observer, selector)));
         }
 
@@ -43,10 +41,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<TResult>.From(
                 source,
                 selector,
-                default(TResult),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.Select(observer, selector)));
         }
 
@@ -57,10 +54,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<TResult>.From(
                 source,
                 selector,
-                default(TResult),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.Select(observer, selector)));
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SelectMany.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SelectMany.cs
@@ -21,7 +21,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(TResult),
-                async (source, selector, observer) =>
+                static async (source, selector, observer) =>
                 {
                     var (sink, inner) = AsyncObserver.SelectMany(observer, selector);
 
@@ -42,7 +42,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(TResult),
-                async (source, selector, observer) =>
+                static async (source, selector, observer) =>
                 {
                     var (sink, inner) = AsyncObserver.SelectMany(observer, selector);
 
@@ -65,7 +65,7 @@ namespace System.Reactive.Linq
                 source,
                 (collectionSelector, resultSelector),
                 default(TResult),
-                async (source, state, observer) =>
+                static async (source, state, observer) =>
                 {
                     var (sink, inner) = AsyncObserver.SelectMany(observer, state.collectionSelector, state.resultSelector);
 
@@ -88,7 +88,7 @@ namespace System.Reactive.Linq
                 source,
                 (collectionSelector, resultSelector),
                 default(TResult),
-                async (source, state, observer) =>
+                static async (source, state, observer) =>
                 {
                     var (sink, inner) = AsyncObserver.SelectMany(observer, state.collectionSelector, state.resultSelector);
 
@@ -109,7 +109,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(TResult),
-                async (source, selector, observer) =>
+                static async (source, selector, observer) =>
                 {
                     var (sink, inner) = AsyncObserver.SelectMany(observer, selector);
 
@@ -130,7 +130,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(TResult),
-                async (source, selector, observer) =>
+                static async (source, selector, observer) =>
                 {
                     var (sink, inner) = AsyncObserver.SelectMany(observer, selector);
 
@@ -153,7 +153,7 @@ namespace System.Reactive.Linq
                 source,
                 (collectionSelector, resultSelector),
                 default(TResult),
-                async (source, state, observer) =>
+                static async (source, state, observer) =>
                 {
                     var (sink, inner) = AsyncObserver.SelectMany(observer, state.collectionSelector, state.resultSelector);
 
@@ -176,7 +176,7 @@ namespace System.Reactive.Linq
                 source,
                 (collectionSelector, resultSelector),
                 default(TResult),
-                async (source, state, observer) =>
+                static async (source, state, observer) =>
                 {
                     var (sink, inner) = AsyncObserver.SelectMany(observer, state.collectionSelector, state.resultSelector);
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SelectMany.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SelectMany.cs
@@ -17,7 +17,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<TResult>.From(
+            return CreateAsyncObservable<TResult>.From(
                 source,
                 selector,
                 static async (source, selector, observer) =>
@@ -37,7 +37,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<TResult>.From(
+            return CreateAsyncObservable<TResult>.From(
                 source,
                 selector,
                 static async (source, selector, observer) =>
@@ -59,7 +59,7 @@ namespace System.Reactive.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            return Build<TResult>.From(
+            return CreateAsyncObservable<TResult>.From(
                 source,
                 (collectionSelector, resultSelector),
                 static async (source, state, observer) =>
@@ -81,7 +81,7 @@ namespace System.Reactive.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            return Build<TResult>.From(
+            return CreateAsyncObservable<TResult>.From(
                 source,
                 (collectionSelector, resultSelector),
                 static async (source, state, observer) =>
@@ -101,7 +101,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<TResult>.From(
+            return CreateAsyncObservable<TResult>.From(
                 source,
                 selector,
                 static async (source, selector, observer) =>
@@ -121,7 +121,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<TResult>.From(
+            return CreateAsyncObservable<TResult>.From(
                 source,
                 selector,
                 static async (source, selector, observer) =>
@@ -143,7 +143,7 @@ namespace System.Reactive.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            return Build<TResult>.From(
+            return CreateAsyncObservable<TResult>.From(
                 source,
                 (collectionSelector, resultSelector),
                 static async (source, state, observer) =>
@@ -165,7 +165,7 @@ namespace System.Reactive.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            return Build<TResult>.From(
+            return CreateAsyncObservable<TResult>.From(
                 source,
                 (collectionSelector, resultSelector),
                 static async (source, state, observer) =>

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SelectMany.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SelectMany.cs
@@ -17,10 +17,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<TResult>.From(
                 source,
                 selector,
-                default(TResult),
                 static async (source, selector, observer) =>
                 {
                     var (sink, inner) = AsyncObserver.SelectMany(observer, selector);
@@ -38,10 +37,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<TResult>.From(
                 source,
                 selector,
-                default(TResult),
                 static async (source, selector, observer) =>
                 {
                     var (sink, inner) = AsyncObserver.SelectMany(observer, selector);
@@ -61,10 +59,9 @@ namespace System.Reactive.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            return Create(
+            return Build<TResult>.From(
                 source,
                 (collectionSelector, resultSelector),
-                default(TResult),
                 static async (source, state, observer) =>
                 {
                     var (sink, inner) = AsyncObserver.SelectMany(observer, state.collectionSelector, state.resultSelector);
@@ -84,10 +81,9 @@ namespace System.Reactive.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            return Create(
+            return Build<TResult>.From(
                 source,
                 (collectionSelector, resultSelector),
-                default(TResult),
                 static async (source, state, observer) =>
                 {
                     var (sink, inner) = AsyncObserver.SelectMany(observer, state.collectionSelector, state.resultSelector);
@@ -105,10 +101,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<TResult>.From(
                 source,
                 selector,
-                default(TResult),
                 static async (source, selector, observer) =>
                 {
                     var (sink, inner) = AsyncObserver.SelectMany(observer, selector);
@@ -126,10 +121,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<TResult>.From(
                 source,
                 selector,
-                default(TResult),
                 static async (source, selector, observer) =>
                 {
                     var (sink, inner) = AsyncObserver.SelectMany(observer, selector);
@@ -149,10 +143,9 @@ namespace System.Reactive.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            return Create(
+            return Build<TResult>.From(
                 source,
                 (collectionSelector, resultSelector),
-                default(TResult),
                 static async (source, state, observer) =>
                 {
                     var (sink, inner) = AsyncObserver.SelectMany(observer, state.collectionSelector, state.resultSelector);
@@ -172,10 +165,9 @@ namespace System.Reactive.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            return Create(
+            return Build<TResult>.From(
                 source,
                 (collectionSelector, resultSelector),
-                default(TResult),
                 static async (source, state, observer) =>
                 {
                     var (sink, inner) = AsyncObserver.SelectMany(observer, state.collectionSelector, state.resultSelector);

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SelectMany.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SelectMany.cs
@@ -17,14 +17,18 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<TResult>(async observer =>
-            {
-                var (sink, inner) = AsyncObserver.SelectMany(observer, selector);
+            return Create(
+                source,
+                selector,
+                default(TResult),
+                async (source, selector, observer) =>
+                {
+                    var (sink, inner) = AsyncObserver.SelectMany(observer, selector);
 
-                var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, inner);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, inner);
+                });
         }
 
         public static IAsyncObservable<TResult> SelectMany<TSource, TResult>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<IAsyncObservable<TResult>>> selector)
@@ -34,14 +38,18 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<TResult>(async observer =>
-            {
-                var (sink, inner) = AsyncObserver.SelectMany(observer, selector);
+            return Create(
+                source,
+                selector,
+                default(TResult),
+                async (source, selector, observer) =>
+                {
+                    var (sink, inner) = AsyncObserver.SelectMany(observer, selector);
 
-                var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, inner);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, inner);
+                });
         }
 
         public static IAsyncObservable<TResult> SelectMany<TSource, TCollection, TResult>(this IAsyncObservable<TSource> source, Func<TSource, IAsyncObservable<TCollection>> collectionSelector, Func<TSource, TCollection, TResult> resultSelector)
@@ -53,14 +61,18 @@ namespace System.Reactive.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            return Create<TResult>(async observer =>
-            {
-                var (sink, inner) = AsyncObserver.SelectMany(observer, collectionSelector, resultSelector);
+            return Create(
+                source,
+                (collectionSelector, resultSelector),
+                default(TResult),
+                async (source, state, observer) =>
+                {
+                    var (sink, inner) = AsyncObserver.SelectMany(observer, state.collectionSelector, state.resultSelector);
 
-                var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, inner);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, inner);
+                });
         }
 
         public static IAsyncObservable<TResult> SelectMany<TSource, TCollection, TResult>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<IAsyncObservable<TCollection>>> collectionSelector, Func<TSource, TCollection, ValueTask<TResult>> resultSelector)
@@ -72,14 +84,18 @@ namespace System.Reactive.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            return Create<TResult>(async observer =>
-            {
-                var (sink, inner) = AsyncObserver.SelectMany(observer, collectionSelector, resultSelector);
+            return Create(
+                source,
+                (collectionSelector, resultSelector),
+                default(TResult),
+                async (source, state, observer) =>
+                {
+                    var (sink, inner) = AsyncObserver.SelectMany(observer, state.collectionSelector, state.resultSelector);
 
-                var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, inner);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, inner);
+                });
         }
 
         public static IAsyncObservable<TResult> SelectMany<TSource, TResult>(this IAsyncObservable<TSource> source, Func<TSource, int, IAsyncObservable<TResult>> selector)
@@ -89,14 +105,18 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<TResult>(async observer =>
-            {
-                var (sink, inner) = AsyncObserver.SelectMany(observer, selector);
+            return Create(
+                source,
+                selector,
+                default(TResult),
+                async (source, selector, observer) =>
+                {
+                    var (sink, inner) = AsyncObserver.SelectMany(observer, selector);
 
-                var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, inner);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, inner);
+                });
         }
 
         public static IAsyncObservable<TResult> SelectMany<TSource, TResult>(this IAsyncObservable<TSource> source, Func<TSource, int, ValueTask<IAsyncObservable<TResult>>> selector)
@@ -106,14 +126,18 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<TResult>(async observer =>
-            {
-                var (sink, inner) = AsyncObserver.SelectMany(observer, selector);
+            return Create(
+                source,
+                selector,
+                default(TResult),
+                async (source, selector, observer) =>
+                {
+                    var (sink, inner) = AsyncObserver.SelectMany(observer, selector);
 
-                var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, inner);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, inner);
+                });
         }
 
         public static IAsyncObservable<TResult> SelectMany<TSource, TCollection, TResult>(this IAsyncObservable<TSource> source, Func<TSource, int, IAsyncObservable<TCollection>> collectionSelector, Func<TSource, int, TCollection, int, TResult> resultSelector)
@@ -125,14 +149,18 @@ namespace System.Reactive.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            return Create<TResult>(async observer =>
-            {
-                var (sink, inner) = AsyncObserver.SelectMany(observer, collectionSelector, resultSelector);
+            return Create(
+                source,
+                (collectionSelector, resultSelector),
+                default(TResult),
+                async (source, state, observer) =>
+                {
+                    var (sink, inner) = AsyncObserver.SelectMany(observer, state.collectionSelector, state.resultSelector);
 
-                var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, inner);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, inner);
+                });
         }
 
         public static IAsyncObservable<TResult> SelectMany<TSource, TCollection, TResult>(this IAsyncObservable<TSource> source, Func<TSource, int, ValueTask<IAsyncObservable<TCollection>>> collectionSelector, Func<TSource, int, TCollection, int, ValueTask<TResult>> resultSelector)
@@ -144,14 +172,18 @@ namespace System.Reactive.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            return Create<TResult>(async observer =>
-            {
-                var (sink, inner) = AsyncObserver.SelectMany(observer, collectionSelector, resultSelector);
+            return Create(
+                source,
+                (collectionSelector, resultSelector),
+                default(TResult),
+                async (source, state, observer) =>
+                {
+                    var (sink, inner) = AsyncObserver.SelectMany(observer, state.collectionSelector, state.resultSelector);
 
-                var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, inner);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, inner);
+                });
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SequenceEqual.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SequenceEqual.cs
@@ -19,10 +19,9 @@ namespace System.Reactive.Linq
             if (second == null)
                 throw new ArgumentNullException(nameof(second));
 
-            return Create(
+            return Build<bool>.From(
                 first,
                 second,
-                default(bool),
                 static async (first, second, observer) =>
                 {
                     var (firstObserver, secondObserver) = AsyncObserver.SequenceEqual<TSource>(observer);
@@ -48,10 +47,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build<bool>.From(
                 first,
                 (second, comparer),
-                default(bool),
                 static async (first, state, observer) =>
                 {
                     var (firstObserver, secondObserver) = AsyncObserver.SequenceEqual(observer, state.comparer);

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SequenceEqual.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SequenceEqual.cs
@@ -23,7 +23,7 @@ namespace System.Reactive.Linq
                 first,
                 second,
                 default(bool),
-                async (first, second, observer) =>
+                static async (first, second, observer) =>
                 {
                     var (firstObserver, secondObserver) = AsyncObserver.SequenceEqual<TSource>(observer);
 
@@ -52,7 +52,7 @@ namespace System.Reactive.Linq
                 first,
                 (second, comparer),
                 default(bool),
-                async (first, state, observer) =>
+                static async (first, state, observer) =>
                 {
                     var (firstObserver, secondObserver) = AsyncObserver.SequenceEqual(observer, state.comparer);
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SequenceEqual.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SequenceEqual.cs
@@ -19,7 +19,7 @@ namespace System.Reactive.Linq
             if (second == null)
                 throw new ArgumentNullException(nameof(second));
 
-            return Build<bool>.From(
+            return CreateAsyncObservable<bool>.From(
                 first,
                 second,
                 static async (first, second, observer) =>
@@ -47,7 +47,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build<bool>.From(
+            return CreateAsyncObservable<bool>.From(
                 first,
                 (second, comparer),
                 static async (first, state, observer) =>

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SequenceEqual.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SequenceEqual.cs
@@ -19,20 +19,24 @@ namespace System.Reactive.Linq
             if (second == null)
                 throw new ArgumentNullException(nameof(second));
 
-            return Create<bool>(async observer =>
-            {
-                var (firstObserver, secondObserver) = AsyncObserver.SequenceEqual<TSource>(observer);
+            return Create(
+                first,
+                second,
+                default(bool),
+                async (first, second, observer) =>
+                {
+                    var (firstObserver, secondObserver) = AsyncObserver.SequenceEqual<TSource>(observer);
 
-                var firstTask = first.SubscribeSafeAsync(firstObserver);
-                var secondTask = second.SubscribeSafeAsync(secondObserver);
+                    var firstTask = first.SubscribeSafeAsync(firstObserver);
+                    var secondTask = second.SubscribeSafeAsync(secondObserver);
 
-                // REVIEW: Consider concurrent subscriptions.
+                    // REVIEW: Consider concurrent subscriptions.
 
-                var d1 = await firstTask.ConfigureAwait(false);
-                var d2 = await secondTask.ConfigureAwait(false);
+                    var d1 = await firstTask.ConfigureAwait(false);
+                    var d2 = await secondTask.ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(d1, d2);
-            });
+                    return StableCompositeAsyncDisposable.Create(d1, d2);
+                });
         }
 
         public static IAsyncObservable<bool> SequenceEqual<TSource>(this IAsyncObservable<TSource> first, IAsyncObservable<TSource> second, IEqualityComparer<TSource> comparer)
@@ -44,20 +48,24 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<bool>(async observer =>
-            {
-                var (firstObserver, secondObserver) = AsyncObserver.SequenceEqual(observer, comparer);
+            return Create(
+                first,
+                (second, comparer),
+                default(bool),
+                async (first, state, observer) =>
+                {
+                    var (firstObserver, secondObserver) = AsyncObserver.SequenceEqual(observer, state.comparer);
 
-                var firstTask = first.SubscribeSafeAsync(firstObserver);
-                var secondTask = second.SubscribeSafeAsync(secondObserver);
+                    var firstTask = first.SubscribeSafeAsync(firstObserver);
+                    var secondTask = state.second.SubscribeSafeAsync(secondObserver);
 
-                // REVIEW: Consider concurrent subscriptions.
+                    // REVIEW: Consider concurrent subscriptions.
 
-                var d1 = await firstTask.ConfigureAwait(false);
-                var d2 = await secondTask.ConfigureAwait(false);
+                    var d1 = await firstTask.ConfigureAwait(false);
+                    var d2 = await secondTask.ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(d1, d2);
-            });
+                    return StableCompositeAsyncDisposable.Create(d1, d2);
+                });
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Single.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Single.cs
@@ -31,7 +31,7 @@ namespace System.Reactive.Linq
                 source,
                 predicate,
                 default(TSource),
-                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Single(observer, predicate)));
+                static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Single(observer, predicate)));
         }
 
         public static IAsyncObservable<TSource> Single<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
@@ -45,7 +45,7 @@ namespace System.Reactive.Linq
                 source,
                 predicate,
                 default(TSource),
-                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Single(observer, predicate)));
+                static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Single(observer, predicate)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Single.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Single.cs
@@ -27,10 +27,9 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 predicate,
-                default(TSource),
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Single(observer, predicate)));
         }
 
@@ -41,10 +40,9 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 predicate,
-                default(TSource),
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Single(observer, predicate)));
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Single.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Single.cs
@@ -27,7 +27,7 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 predicate,
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Single(observer, predicate)));
@@ -40,7 +40,7 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 predicate,
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Single(observer, predicate)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Single.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Single.cs
@@ -27,7 +27,11 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.Single(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                default(TSource),
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Single(observer, predicate)));
         }
 
         public static IAsyncObservable<TSource> Single<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
@@ -37,7 +41,11 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.Single(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                default(TSource),
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Single(observer, predicate)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SingleOrDefault.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SingleOrDefault.cs
@@ -27,7 +27,7 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 predicate,
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SingleOrDefault(observer, predicate)));
@@ -40,7 +40,7 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 predicate,
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SingleOrDefault(observer, predicate)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SingleOrDefault.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SingleOrDefault.cs
@@ -27,10 +27,9 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 predicate,
-                default(TSource),
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SingleOrDefault(observer, predicate)));
         }
 
@@ -41,10 +40,9 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 predicate,
-                default(TSource),
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SingleOrDefault(observer, predicate)));
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SingleOrDefault.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SingleOrDefault.cs
@@ -27,7 +27,11 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.SingleOrDefault(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                default(TSource),
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SingleOrDefault(observer, predicate)));
         }
 
         public static IAsyncObservable<TSource> SingleOrDefault<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
@@ -37,7 +41,11 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.SingleOrDefault(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                default(TSource),
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SingleOrDefault(observer, predicate)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SingleOrDefault.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SingleOrDefault.cs
@@ -31,7 +31,7 @@ namespace System.Reactive.Linq
                 source,
                 predicate,
                 default(TSource),
-                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SingleOrDefault(observer, predicate)));
+                static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SingleOrDefault(observer, predicate)));
         }
 
         public static IAsyncObservable<TSource> SingleOrDefault<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
@@ -45,7 +45,7 @@ namespace System.Reactive.Linq
                 source,
                 predicate,
                 default(TSource),
-                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SingleOrDefault(observer, predicate)));
+                static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SingleOrDefault(observer, predicate)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Skip.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Skip.cs
@@ -27,7 +27,7 @@ namespace System.Reactive.Linq
                 source,
                 count,
                 default(TSource),
-                (source, count, observer) => source.SubscribeSafeAsync(AsyncObserver.Skip(observer, count)));
+                static (source, count, observer) => source.SubscribeSafeAsync(AsyncObserver.Skip(observer, count)));
         }
 
         public static IAsyncObservable<TSource> Skip<TSource>(this IAsyncObservable<TSource> source, TimeSpan duration)
@@ -48,7 +48,7 @@ namespace System.Reactive.Linq
                 source,
                 duration,
                 default(TSource),
-                async (source, duration, observer) =>
+                static async (source, duration, observer) =>
                 {
                     var (sourceObserver, timer) = await AsyncObserver.Skip(observer, duration).ConfigureAwait(false);
 
@@ -78,7 +78,7 @@ namespace System.Reactive.Linq
                 source,
                 (duration, scheduler),
                 default(TSource),
-                async (source, state, observer) =>
+                static async (source, state, observer) =>
                 {
                     var (sourceObserver, timer) = await AsyncObserver.Skip(observer, state.duration).ConfigureAwait(false);
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Skip.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Skip.cs
@@ -23,7 +23,7 @@ namespace System.Reactive.Linq
                 return source;
             }
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 count,
                 static (source, count, observer) => source.SubscribeSafeAsync(AsyncObserver.Skip(observer, count)));
@@ -43,7 +43,7 @@ namespace System.Reactive.Linq
 
             // REVIEW: May be easier to just use SkipUntil with a Timer parameter. Do we want Skip on the observer?
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 duration,
                 static async (source, duration, observer) =>
@@ -72,7 +72,7 @@ namespace System.Reactive.Linq
 
             // REVIEW: May be easier to just use SkipUntil with a Timer parameter. Do we want Skip on the observer?
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 (duration, scheduler),
                 static async (source, state, observer) =>

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Skip.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Skip.cs
@@ -23,10 +23,9 @@ namespace System.Reactive.Linq
                 return source;
             }
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 count,
-                default(TSource),
                 static (source, count, observer) => source.SubscribeSafeAsync(AsyncObserver.Skip(observer, count)));
         }
 
@@ -44,10 +43,9 @@ namespace System.Reactive.Linq
 
             // REVIEW: May be easier to just use SkipUntil with a Timer parameter. Do we want Skip on the observer?
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 duration,
-                default(TSource),
                 static async (source, duration, observer) =>
                 {
                     var (sourceObserver, timer) = await AsyncObserver.Skip(observer, duration).ConfigureAwait(false);
@@ -74,10 +72,9 @@ namespace System.Reactive.Linq
 
             // REVIEW: May be easier to just use SkipUntil with a Timer parameter. Do we want Skip on the observer?
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 (duration, scheduler),
-                default(TSource),
                 static async (source, state, observer) =>
                 {
                     var (sourceObserver, timer) = await AsyncObserver.Skip(observer, state.duration).ConfigureAwait(false);

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Skip.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Skip.cs
@@ -23,7 +23,11 @@ namespace System.Reactive.Linq
                 return source;
             }
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.Skip(observer, count)));
+            return Create(
+                source,
+                count,
+                default(TSource),
+                (source, count, observer) => source.SubscribeSafeAsync(AsyncObserver.Skip(observer, count)));
         }
 
         public static IAsyncObservable<TSource> Skip<TSource>(this IAsyncObservable<TSource> source, TimeSpan duration)
@@ -40,14 +44,18 @@ namespace System.Reactive.Linq
 
             // REVIEW: May be easier to just use SkipUntil with a Timer parameter. Do we want Skip on the observer?
 
-            return Create<TSource>(async observer =>
-            {
-                var (sourceObserver, timer) = await AsyncObserver.Skip(observer, duration).ConfigureAwait(false);
+            return Create(
+                source,
+                duration,
+                default(TSource),
+                async (source, duration, observer) =>
+                {
+                    var (sourceObserver, timer) = await AsyncObserver.Skip(observer, duration).ConfigureAwait(false);
 
-                var subscription = await source.SubscribeSafeAsync(sourceObserver).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sourceObserver).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, timer);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, timer);
+                });
         }
 
         public static IAsyncObservable<TSource> Skip<TSource>(this IAsyncObservable<TSource> source, TimeSpan duration, IAsyncScheduler scheduler)
@@ -66,14 +74,18 @@ namespace System.Reactive.Linq
 
             // REVIEW: May be easier to just use SkipUntil with a Timer parameter. Do we want Skip on the observer?
 
-            return Create<TSource>(async observer =>
-            {
-                var (sourceObserver, timer) = await AsyncObserver.Skip(observer, duration).ConfigureAwait(false);
+            return Create(
+                source,
+                (duration, scheduler),
+                default(TSource),
+                async (source, state, observer) =>
+                {
+                    var (sourceObserver, timer) = await AsyncObserver.Skip(observer, state.duration).ConfigureAwait(false);
 
-                var subscription = await source.SubscribeSafeAsync(sourceObserver).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sourceObserver).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, timer);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, timer);
+                });
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SkipLast.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SkipLast.cs
@@ -26,7 +26,7 @@ namespace System.Reactive.Linq
                 source,
                 count,
                 default(TSource),
-                (source, count, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipLast(observer, count)));
+                static (source, count, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipLast(observer, count)));
         }
 
 
@@ -46,7 +46,7 @@ namespace System.Reactive.Linq
                 source,
                 duration,
                 default(TSource),
-                (source, duration, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipLast(observer, duration)));
+                static (source, duration, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipLast(observer, duration)));
         }
 
         public static IAsyncObservable<TSource> SkipLast<TSource>(this IAsyncObservable<TSource> source, TimeSpan duration, IClock clock)
@@ -67,7 +67,7 @@ namespace System.Reactive.Linq
                 source,
                 (duration, clock),
                 default(TSource),
-                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipLast(observer, state.duration, state.clock)));
+                static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipLast(observer, state.duration, state.clock)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SkipLast.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SkipLast.cs
@@ -22,7 +22,7 @@ namespace System.Reactive.Linq
                 return source;
             }
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 count,
                 static (source, count, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipLast(observer, count)));
@@ -41,7 +41,7 @@ namespace System.Reactive.Linq
                 return source;
             }
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 duration,
                 static (source, duration, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipLast(observer, duration)));
@@ -61,7 +61,7 @@ namespace System.Reactive.Linq
                 return source;
             }
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 (duration, clock),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipLast(observer, state.duration, state.clock)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SkipLast.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SkipLast.cs
@@ -22,10 +22,9 @@ namespace System.Reactive.Linq
                 return source;
             }
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 count,
-                default(TSource),
                 static (source, count, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipLast(observer, count)));
         }
 
@@ -42,10 +41,9 @@ namespace System.Reactive.Linq
                 return source;
             }
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 duration,
-                default(TSource),
                 static (source, duration, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipLast(observer, duration)));
         }
 
@@ -63,10 +61,9 @@ namespace System.Reactive.Linq
                 return source;
             }
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 (duration, clock),
-                default(TSource),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipLast(observer, state.duration, state.clock)));
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SkipLast.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SkipLast.cs
@@ -22,7 +22,11 @@ namespace System.Reactive.Linq
                 return source;
             }
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.SkipLast(observer, count)));
+            return Create(
+                source,
+                count,
+                default(TSource),
+                (source, count, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipLast(observer, count)));
         }
 
 
@@ -38,7 +42,11 @@ namespace System.Reactive.Linq
                 return source;
             }
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.SkipLast(observer, duration)));
+            return Create(
+                source,
+                duration,
+                default(TSource),
+                (source, duration, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipLast(observer, duration)));
         }
 
         public static IAsyncObservable<TSource> SkipLast<TSource>(this IAsyncObservable<TSource> source, TimeSpan duration, IClock clock)
@@ -55,7 +63,11 @@ namespace System.Reactive.Linq
                 return source;
             }
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.SkipLast(observer, duration, clock)));
+            return Create(
+                source,
+                (duration, clock),
+                default(TSource),
+                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipLast(observer, state.duration, state.clock)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SkipUntil.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SkipUntil.cs
@@ -18,7 +18,7 @@ namespace System.Reactive.Linq
             if (until == null)
                 throw new ArgumentNullException(nameof(until));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 until,
                 static async (source, until, observer) =>
@@ -44,7 +44,7 @@ namespace System.Reactive.Linq
 
             // REVIEW: May be easier to just use SkipUntil with a Timer parameter. Do we want SkipUntil on the observer?
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 endTime,
                 static async (source, endTime, observer) =>
@@ -66,7 +66,7 @@ namespace System.Reactive.Linq
 
             // REVIEW: May be easier to just use SkipUntil with a Timer parameter. Do we want SkipUntil on the observer?
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 (scheduler, endTime),
                 static async (source, state, observer) =>

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SkipUntil.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SkipUntil.cs
@@ -18,20 +18,24 @@ namespace System.Reactive.Linq
             if (until == null)
                 throw new ArgumentNullException(nameof(until));
 
-            return Create<TSource>(async observer =>
-            {
-                var (sourceObserver, untilObserver) = AsyncObserver.SkipUntil<TSource, TUntil>(observer);
+            return Create(
+                source,
+                until,
+                default(TSource),
+                async (source, until, observer) =>
+                {
+                    var (sourceObserver, untilObserver) = AsyncObserver.SkipUntil<TSource, TUntil>(observer);
 
-                var sourceTask = source.SubscribeSafeAsync(sourceObserver);
-                var untilTask = until.SubscribeSafeAsync(untilObserver);
+                    var sourceTask = source.SubscribeSafeAsync(sourceObserver);
+                    var untilTask = until.SubscribeSafeAsync(untilObserver);
 
-                // REVIEW: Consider concurrent subscriptions.
+                    // REVIEW: Consider concurrent subscriptions.
 
-                var d1 = await sourceTask.ConfigureAwait(false);
-                var d2 = await untilTask.ConfigureAwait(false);
+                    var d1 = await sourceTask.ConfigureAwait(false);
+                    var d2 = await untilTask.ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(d1, d2);
-            });
+                    return StableCompositeAsyncDisposable.Create(d1, d2);
+                });
         }
 
         public static IAsyncObservable<TSource> SkipUntil<TSource>(this IAsyncObservable<TSource> source, DateTimeOffset endTime)
@@ -41,14 +45,18 @@ namespace System.Reactive.Linq
 
             // REVIEW: May be easier to just use SkipUntil with a Timer parameter. Do we want SkipUntil on the observer?
 
-            return Create<TSource>(async observer =>
-            {
-                var (sourceObserver, timer) = await AsyncObserver.SkipUntil(observer, endTime).ConfigureAwait(false);
+            return Create(
+                source,
+                endTime,
+                default(TSource),
+                async (source, endTime, observer) =>
+                {
+                    var (sourceObserver, timer) = await AsyncObserver.SkipUntil(observer, endTime).ConfigureAwait(false);
 
-                var subscription = await source.SubscribeSafeAsync(sourceObserver).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sourceObserver).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, timer);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, timer);
+                });
         }
 
         public static IAsyncObservable<TSource> SkipUntil<TSource>(this IAsyncObservable<TSource> source, DateTimeOffset endTime, IAsyncScheduler scheduler)
@@ -60,14 +68,18 @@ namespace System.Reactive.Linq
 
             // REVIEW: May be easier to just use SkipUntil with a Timer parameter. Do we want SkipUntil on the observer?
 
-            return Create<TSource>(async observer =>
-            {
-                var (sourceObserver, timer) = await AsyncObserver.SkipUntil(observer, endTime).ConfigureAwait(false);
+            return Create(
+                source,
+                (scheduler, endTime),
+                default(TSource),
+                async (source, state, observer) =>
+                {
+                    var (sourceObserver, timer) = await AsyncObserver.SkipUntil(observer, state.endTime).ConfigureAwait(false);
 
-                var subscription = await source.SubscribeSafeAsync(sourceObserver).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sourceObserver).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, timer);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, timer);
+                });
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SkipUntil.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SkipUntil.cs
@@ -22,7 +22,7 @@ namespace System.Reactive.Linq
                 source,
                 until,
                 default(TSource),
-                async (source, until, observer) =>
+                static async (source, until, observer) =>
                 {
                     var (sourceObserver, untilObserver) = AsyncObserver.SkipUntil<TSource, TUntil>(observer);
 
@@ -49,7 +49,7 @@ namespace System.Reactive.Linq
                 source,
                 endTime,
                 default(TSource),
-                async (source, endTime, observer) =>
+                static async (source, endTime, observer) =>
                 {
                     var (sourceObserver, timer) = await AsyncObserver.SkipUntil(observer, endTime).ConfigureAwait(false);
 
@@ -72,7 +72,7 @@ namespace System.Reactive.Linq
                 source,
                 (scheduler, endTime),
                 default(TSource),
-                async (source, state, observer) =>
+                static async (source, state, observer) =>
                 {
                     var (sourceObserver, timer) = await AsyncObserver.SkipUntil(observer, state.endTime).ConfigureAwait(false);
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SkipUntil.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SkipUntil.cs
@@ -18,10 +18,9 @@ namespace System.Reactive.Linq
             if (until == null)
                 throw new ArgumentNullException(nameof(until));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 until,
-                default(TSource),
                 static async (source, until, observer) =>
                 {
                     var (sourceObserver, untilObserver) = AsyncObserver.SkipUntil<TSource, TUntil>(observer);
@@ -45,10 +44,9 @@ namespace System.Reactive.Linq
 
             // REVIEW: May be easier to just use SkipUntil with a Timer parameter. Do we want SkipUntil on the observer?
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 endTime,
-                default(TSource),
                 static async (source, endTime, observer) =>
                 {
                     var (sourceObserver, timer) = await AsyncObserver.SkipUntil(observer, endTime).ConfigureAwait(false);
@@ -68,10 +66,9 @@ namespace System.Reactive.Linq
 
             // REVIEW: May be easier to just use SkipUntil with a Timer parameter. Do we want SkipUntil on the observer?
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 (scheduler, endTime),
-                default(TSource),
                 static async (source, state, observer) =>
                 {
                     var (sourceObserver, timer) = await AsyncObserver.SkipUntil(observer, state.endTime).ConfigureAwait(false);

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SkipWhile.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SkipWhile.cs
@@ -15,7 +15,11 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.SkipWhile(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                default(TSource),
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipWhile(observer, predicate)));
         }
 
         public static IAsyncObservable<TSource> SkipWhile<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
@@ -25,7 +29,11 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.SkipWhile(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                default(TSource),
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipWhile(observer, predicate)));
         }
 
         public static IAsyncObservable<TSource> SkipWhile<TSource>(this IAsyncObservable<TSource> source, Func<TSource, int, bool> predicate)
@@ -35,7 +43,11 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.SkipWhile(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                default(TSource),
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipWhile(observer, predicate)));
         }
 
         public static IAsyncObservable<TSource> SkipWhile<TSource>(this IAsyncObservable<TSource> source, Func<TSource, int, ValueTask<bool>> predicate)
@@ -45,7 +57,11 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.SkipWhile(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                default(TSource),
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipWhile(observer, predicate)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SkipWhile.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SkipWhile.cs
@@ -19,7 +19,7 @@ namespace System.Reactive.Linq
                 source,
                 predicate,
                 default(TSource),
-                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipWhile(observer, predicate)));
+                static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipWhile(observer, predicate)));
         }
 
         public static IAsyncObservable<TSource> SkipWhile<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
@@ -33,7 +33,7 @@ namespace System.Reactive.Linq
                 source,
                 predicate,
                 default(TSource),
-                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipWhile(observer, predicate)));
+                static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipWhile(observer, predicate)));
         }
 
         public static IAsyncObservable<TSource> SkipWhile<TSource>(this IAsyncObservable<TSource> source, Func<TSource, int, bool> predicate)
@@ -47,7 +47,7 @@ namespace System.Reactive.Linq
                 source,
                 predicate,
                 default(TSource),
-                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipWhile(observer, predicate)));
+                static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipWhile(observer, predicate)));
         }
 
         public static IAsyncObservable<TSource> SkipWhile<TSource>(this IAsyncObservable<TSource> source, Func<TSource, int, ValueTask<bool>> predicate)
@@ -61,7 +61,7 @@ namespace System.Reactive.Linq
                 source,
                 predicate,
                 default(TSource),
-                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipWhile(observer, predicate)));
+                static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipWhile(observer, predicate)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SkipWhile.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SkipWhile.cs
@@ -15,10 +15,9 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 predicate,
-                default(TSource),
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipWhile(observer, predicate)));
         }
 
@@ -29,10 +28,9 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 predicate,
-                default(TSource),
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipWhile(observer, predicate)));
         }
 
@@ -43,10 +41,9 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 predicate,
-                default(TSource),
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipWhile(observer, predicate)));
         }
 
@@ -57,10 +54,9 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 predicate,
-                default(TSource),
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipWhile(observer, predicate)));
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SkipWhile.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SkipWhile.cs
@@ -15,7 +15,7 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 predicate,
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipWhile(observer, predicate)));
@@ -28,7 +28,7 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 predicate,
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipWhile(observer, predicate)));
@@ -41,7 +41,7 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 predicate,
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipWhile(observer, predicate)));
@@ -54,7 +54,7 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 predicate,
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.SkipWhile(observer, predicate)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SubscribeOn.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SubscribeOn.cs
@@ -28,7 +28,7 @@ namespace System.Reactive.Linq
             if (disposeScheduler == null)
                 throw new ArgumentNullException(nameof(disposeScheduler));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 (subscribeScheduler, disposeScheduler),
                 static async (source, state, observer) =>

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SubscribeOn.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SubscribeOn.cs
@@ -28,10 +28,9 @@ namespace System.Reactive.Linq
             if (disposeScheduler == null)
                 throw new ArgumentNullException(nameof(disposeScheduler));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 (subscribeScheduler, disposeScheduler),
-                default(TSource),
                 static async (source, state, observer) =>
                 {
                     var m = new SingleAssignmentAsyncDisposable();

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SubscribeOn.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/SubscribeOn.cs
@@ -32,7 +32,7 @@ namespace System.Reactive.Linq
                 source,
                 (subscribeScheduler, disposeScheduler),
                 default(TSource),
-                async (source, state, observer) =>
+                static async (source, state, observer) =>
                 {
                     var m = new SingleAssignmentAsyncDisposable();
                     var d = new SerialAsyncDisposable();

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Sum.Generated.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Sum.Generated.cs
@@ -23,10 +23,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Int32>.From(
                 source,
                 selector,
-                default(Int32),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumInt32(observer, selector)));
         }
 
@@ -37,10 +36,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Int32>.From(
                 source,
                 selector,
-                default(Int32),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumInt32(observer, selector)));
         }
 
@@ -59,10 +57,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Int32?>.From(
                 source,
                 selector,
-                default(Int32?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableInt32(observer, selector)));
         }
 
@@ -73,10 +70,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Int32?>.From(
                 source,
                 selector,
-                default(Int32?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableInt32(observer, selector)));
         }
 
@@ -95,10 +91,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Int64>.From(
                 source,
                 selector,
-                default(Int64),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumInt64(observer, selector)));
         }
 
@@ -109,10 +104,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Int64>.From(
                 source,
                 selector,
-                default(Int64),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumInt64(observer, selector)));
         }
 
@@ -131,10 +125,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Int64?>.From(
                 source,
                 selector,
-                default(Int64?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableInt64(observer, selector)));
         }
 
@@ -145,10 +138,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Int64?>.From(
                 source,
                 selector,
-                default(Int64?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableInt64(observer, selector)));
         }
 
@@ -167,10 +159,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Single>.From(
                 source,
                 selector,
-                default(Single),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumSingle(observer, selector)));
         }
 
@@ -181,10 +172,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Single>.From(
                 source,
                 selector,
-                default(Single),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumSingle(observer, selector)));
         }
 
@@ -203,10 +193,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Single?>.From(
                 source,
                 selector,
-                default(Single?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableSingle(observer, selector)));
         }
 
@@ -217,10 +206,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Single?>.From(
                 source,
                 selector,
-                default(Single?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableSingle(observer, selector)));
         }
 
@@ -239,10 +227,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Double>.From(
                 source,
                 selector,
-                default(Double),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumDouble(observer, selector)));
         }
 
@@ -253,10 +240,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Double>.From(
                 source,
                 selector,
-                default(Double),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumDouble(observer, selector)));
         }
 
@@ -275,10 +261,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Double?>.From(
                 source,
                 selector,
-                default(Double?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableDouble(observer, selector)));
         }
 
@@ -289,10 +274,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Double?>.From(
                 source,
                 selector,
-                default(Double?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableDouble(observer, selector)));
         }
 
@@ -311,10 +295,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Decimal>.From(
                 source,
                 selector,
-                default(Decimal),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumDecimal(observer, selector)));
         }
 
@@ -325,10 +308,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Decimal>.From(
                 source,
                 selector,
-                default(Decimal),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumDecimal(observer, selector)));
         }
 
@@ -347,10 +329,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Decimal?>.From(
                 source,
                 selector,
-                default(Decimal?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableDecimal(observer, selector)));
         }
 
@@ -361,10 +342,9 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<Decimal?>.From(
                 source,
                 selector,
-                default(Decimal?),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableDecimal(observer, selector)));
         }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Sum.Generated.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Sum.Generated.cs
@@ -23,7 +23,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Int32>.From(
+            return CreateAsyncObservable<Int32>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumInt32(observer, selector)));
@@ -36,7 +36,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Int32>.From(
+            return CreateAsyncObservable<Int32>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumInt32(observer, selector)));
@@ -57,7 +57,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Int32?>.From(
+            return CreateAsyncObservable<Int32?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableInt32(observer, selector)));
@@ -70,7 +70,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Int32?>.From(
+            return CreateAsyncObservable<Int32?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableInt32(observer, selector)));
@@ -91,7 +91,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Int64>.From(
+            return CreateAsyncObservable<Int64>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumInt64(observer, selector)));
@@ -104,7 +104,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Int64>.From(
+            return CreateAsyncObservable<Int64>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumInt64(observer, selector)));
@@ -125,7 +125,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Int64?>.From(
+            return CreateAsyncObservable<Int64?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableInt64(observer, selector)));
@@ -138,7 +138,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Int64?>.From(
+            return CreateAsyncObservable<Int64?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableInt64(observer, selector)));
@@ -159,7 +159,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Single>.From(
+            return CreateAsyncObservable<Single>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumSingle(observer, selector)));
@@ -172,7 +172,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Single>.From(
+            return CreateAsyncObservable<Single>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumSingle(observer, selector)));
@@ -193,7 +193,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Single?>.From(
+            return CreateAsyncObservable<Single?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableSingle(observer, selector)));
@@ -206,7 +206,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Single?>.From(
+            return CreateAsyncObservable<Single?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableSingle(observer, selector)));
@@ -227,7 +227,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Double>.From(
+            return CreateAsyncObservable<Double>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumDouble(observer, selector)));
@@ -240,7 +240,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Double>.From(
+            return CreateAsyncObservable<Double>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumDouble(observer, selector)));
@@ -261,7 +261,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Double?>.From(
+            return CreateAsyncObservable<Double?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableDouble(observer, selector)));
@@ -274,7 +274,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Double?>.From(
+            return CreateAsyncObservable<Double?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableDouble(observer, selector)));
@@ -295,7 +295,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Decimal>.From(
+            return CreateAsyncObservable<Decimal>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumDecimal(observer, selector)));
@@ -308,7 +308,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Decimal>.From(
+            return CreateAsyncObservable<Decimal>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumDecimal(observer, selector)));
@@ -329,7 +329,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Decimal?>.From(
+            return CreateAsyncObservable<Decimal?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableDecimal(observer, selector)));
@@ -342,7 +342,7 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Build<Decimal?>.From(
+            return CreateAsyncObservable<Decimal?>.From(
                 source,
                 selector,
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableDecimal(observer, selector)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Sum.Generated.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Sum.Generated.cs
@@ -27,7 +27,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Int32),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumInt32(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Int32> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int32>> selector)
@@ -41,7 +41,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Int32),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumInt32(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Int32?> Sum(this IAsyncObservable<Int32?> source)
@@ -63,7 +63,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Int32?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableInt32(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Int32?> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int32?>> selector)
@@ -77,7 +77,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Int32?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableInt32(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Int64> Sum(this IAsyncObservable<Int64> source)
@@ -99,7 +99,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Int64),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumInt64(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Int64> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int64>> selector)
@@ -113,7 +113,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Int64),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumInt64(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Int64?> Sum(this IAsyncObservable<Int64?> source)
@@ -135,7 +135,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Int64?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableInt64(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Int64?> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int64?>> selector)
@@ -149,7 +149,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Int64?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableInt64(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Single> Sum(this IAsyncObservable<Single> source)
@@ -171,7 +171,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Single),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumSingle(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Single> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Single>> selector)
@@ -185,7 +185,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Single),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumSingle(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Single?> Sum(this IAsyncObservable<Single?> source)
@@ -207,7 +207,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Single?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableSingle(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Single?> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Single?>> selector)
@@ -221,7 +221,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Single?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableSingle(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Double> Sum(this IAsyncObservable<Double> source)
@@ -243,7 +243,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Double),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumDouble(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Double> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Double>> selector)
@@ -257,7 +257,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Double),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumDouble(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Double?> Sum(this IAsyncObservable<Double?> source)
@@ -279,7 +279,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Double?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableDouble(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Double?> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Double?>> selector)
@@ -293,7 +293,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Double?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableDouble(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal> Sum(this IAsyncObservable<Decimal> source)
@@ -315,7 +315,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Decimal),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumDecimal(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumDecimal(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Decimal>> selector)
@@ -329,7 +329,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Decimal),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumDecimal(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumDecimal(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal?> Sum(this IAsyncObservable<Decimal?> source)
@@ -351,7 +351,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Decimal?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableDecimal(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableDecimal(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal?> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Decimal?>> selector)
@@ -365,7 +365,7 @@ namespace System.Reactive.Linq
                 source,
                 selector,
                 default(Decimal?),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableDecimal(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableDecimal(observer, selector)));
         }
 
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Sum.Generated.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Sum.Generated.cs
@@ -23,7 +23,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Int32>(observer => source.SubscribeSafeAsync(AsyncObserver.SumInt32(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Int32),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Int32> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int32>> selector)
@@ -33,7 +37,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Int32>(observer => source.SubscribeSafeAsync(AsyncObserver.SumInt32(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Int32),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Int32?> Sum(this IAsyncObservable<Int32?> source)
@@ -51,7 +59,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Int32?>(observer => source.SubscribeSafeAsync(AsyncObserver.SumNullableInt32(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Int32?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Int32?> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int32?>> selector)
@@ -61,7 +73,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Int32?>(observer => source.SubscribeSafeAsync(AsyncObserver.SumNullableInt32(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Int32?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableInt32(observer, selector)));
         }
 
         public static IAsyncObservable<Int64> Sum(this IAsyncObservable<Int64> source)
@@ -79,7 +95,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Int64>(observer => source.SubscribeSafeAsync(AsyncObserver.SumInt64(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Int64),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Int64> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int64>> selector)
@@ -89,7 +109,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Int64>(observer => source.SubscribeSafeAsync(AsyncObserver.SumInt64(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Int64),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Int64?> Sum(this IAsyncObservable<Int64?> source)
@@ -107,7 +131,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Int64?>(observer => source.SubscribeSafeAsync(AsyncObserver.SumNullableInt64(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Int64?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Int64?> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Int64?>> selector)
@@ -117,7 +145,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Int64?>(observer => source.SubscribeSafeAsync(AsyncObserver.SumNullableInt64(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Int64?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableInt64(observer, selector)));
         }
 
         public static IAsyncObservable<Single> Sum(this IAsyncObservable<Single> source)
@@ -135,7 +167,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Single>(observer => source.SubscribeSafeAsync(AsyncObserver.SumSingle(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Single),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Single> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Single>> selector)
@@ -145,7 +181,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Single>(observer => source.SubscribeSafeAsync(AsyncObserver.SumSingle(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Single),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Single?> Sum(this IAsyncObservable<Single?> source)
@@ -163,7 +203,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Single?>(observer => source.SubscribeSafeAsync(AsyncObserver.SumNullableSingle(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Single?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Single?> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Single?>> selector)
@@ -173,7 +217,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Single?>(observer => source.SubscribeSafeAsync(AsyncObserver.SumNullableSingle(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Single?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableSingle(observer, selector)));
         }
 
         public static IAsyncObservable<Double> Sum(this IAsyncObservable<Double> source)
@@ -191,7 +239,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Double>(observer => source.SubscribeSafeAsync(AsyncObserver.SumDouble(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Double),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Double> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Double>> selector)
@@ -201,7 +253,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Double>(observer => source.SubscribeSafeAsync(AsyncObserver.SumDouble(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Double),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Double?> Sum(this IAsyncObservable<Double?> source)
@@ -219,7 +275,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Double?>(observer => source.SubscribeSafeAsync(AsyncObserver.SumNullableDouble(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Double?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Double?> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Double?>> selector)
@@ -229,7 +289,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Double?>(observer => source.SubscribeSafeAsync(AsyncObserver.SumNullableDouble(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Double?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableDouble(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal> Sum(this IAsyncObservable<Decimal> source)
@@ -247,7 +311,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Decimal>(observer => source.SubscribeSafeAsync(AsyncObserver.SumDecimal(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Decimal),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumDecimal(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Decimal>> selector)
@@ -257,7 +325,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Decimal>(observer => source.SubscribeSafeAsync(AsyncObserver.SumDecimal(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Decimal),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumDecimal(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal?> Sum(this IAsyncObservable<Decimal?> source)
@@ -275,7 +347,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Decimal?>(observer => source.SubscribeSafeAsync(AsyncObserver.SumNullableDecimal(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Decimal?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableDecimal(observer, selector)));
         }
 
         public static IAsyncObservable<Decimal?> Sum<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<Decimal?>> selector)
@@ -285,7 +361,11 @@ namespace System.Reactive.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<Decimal?>(observer => source.SubscribeSafeAsync(AsyncObserver.SumNullableDecimal(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(Decimal?),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.SumNullableDecimal(observer, selector)));
         }
 
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Sum.Generated.tt
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Sum.Generated.tt
@@ -42,10 +42,9 @@ foreach (var t in types)
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<<#=typeName#>>.From(
                 source,
                 selector,
-                default(<#=typeName#>),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
         }
 
@@ -56,10 +55,9 @@ foreach (var t in types)
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(
+            return Build<<#=typeName#>>.From(
                 source,
                 selector,
-                default(<#=typeName#>),
                 static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
         }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Sum.Generated.tt
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Sum.Generated.tt
@@ -46,7 +46,7 @@ foreach (var t in types)
                 source,
                 selector,
                 default(<#=typeName#>),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
         }
 
         public static IAsyncObservable<<#=typeName#>> <#=name#><TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<<#=typeName#>>> selector)
@@ -60,7 +60,7 @@ foreach (var t in types)
                 source,
                 selector,
                 default(<#=typeName#>),
-                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
+                static (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
         }
 
 <#

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Sum.Generated.tt
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Sum.Generated.tt
@@ -42,7 +42,11 @@ foreach (var t in types)
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<<#=typeName#>>(observer => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(<#=typeName#>),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
         }
 
         public static IAsyncObservable<<#=typeName#>> <#=name#><TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<<#=typeName#>>> selector)
@@ -52,7 +56,11 @@ foreach (var t in types)
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create<<#=typeName#>>(observer => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
+            return Create(
+                source,
+                selector,
+                default(<#=typeName#>),
+                (source, selector, observer) => source.SubscribeSafeAsync(AsyncObserver.<#=name#><#=methodName#>(observer, selector)));
         }
 
 <#

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Synchronize.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Synchronize.cs
@@ -23,7 +23,7 @@ namespace System.Reactive.Linq
             if (gate == null)
                 throw new ArgumentNullException(nameof(gate));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 gate,
                 static (source, gate, observer) => source.SubscribeSafeAsync(AsyncObserver.Synchronize(observer, gate)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Synchronize.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Synchronize.cs
@@ -23,7 +23,11 @@ namespace System.Reactive.Linq
             if (gate == null)
                 throw new ArgumentNullException(nameof(gate));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.Synchronize(observer, gate)));
+            return Create(
+                source,
+                gate,
+                default(TSource),
+                (source, gate, observer) => source.SubscribeSafeAsync(AsyncObserver.Synchronize(observer, gate)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Synchronize.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Synchronize.cs
@@ -23,10 +23,9 @@ namespace System.Reactive.Linq
             if (gate == null)
                 throw new ArgumentNullException(nameof(gate));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 gate,
-                default(TSource),
                 static (source, gate, observer) => source.SubscribeSafeAsync(AsyncObserver.Synchronize(observer, gate)));
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Synchronize.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Synchronize.cs
@@ -27,7 +27,7 @@ namespace System.Reactive.Linq
                 source,
                 gate,
                 default(TSource),
-                (source, gate, observer) => source.SubscribeSafeAsync(AsyncObserver.Synchronize(observer, gate)));
+                static (source, gate, observer) => source.SubscribeSafeAsync(AsyncObserver.Synchronize(observer, gate)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Take.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Take.cs
@@ -23,7 +23,7 @@ namespace System.Reactive.Linq
                 return Empty<TSource>();
             }
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 count,
                 static (source, count, observer) => source.SubscribeSafeAsync(AsyncObserver.Take(observer, count)));
@@ -43,7 +43,7 @@ namespace System.Reactive.Linq
 
             // REVIEW: May be easier to just use TakeUntil with a Timer parameter. Do we want Take on the observer?
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 duration,
                 static async (source, duration, observer) =>
@@ -72,7 +72,7 @@ namespace System.Reactive.Linq
 
             // REVIEW: May be easier to just use TakeUntil with a Timer parameter. Do we want Take on the observer?
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 (duration, scheduler),
                 static async (source, state, observer) =>

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Take.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Take.cs
@@ -23,10 +23,9 @@ namespace System.Reactive.Linq
                 return Empty<TSource>();
             }
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 count,
-                default(TSource),
                 static (source, count, observer) => source.SubscribeSafeAsync(AsyncObserver.Take(observer, count)));
         }
 
@@ -44,10 +43,9 @@ namespace System.Reactive.Linq
 
             // REVIEW: May be easier to just use TakeUntil with a Timer parameter. Do we want Take on the observer?
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 duration,
-                default(TSource),
                 static async (source, duration, observer) =>
                 {
                     var (sourceObserver, timer) = await AsyncObserver.Take(observer, duration).ConfigureAwait(false);
@@ -74,10 +72,9 @@ namespace System.Reactive.Linq
 
             // REVIEW: May be easier to just use TakeUntil with a Timer parameter. Do we want Take on the observer?
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 (duration, scheduler),
-                default(TSource),
                 static async (source, state, observer) =>
                 {
                     var (sourceObserver, timer) = await AsyncObserver.Take(observer, state.duration).ConfigureAwait(false);

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Take.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Take.cs
@@ -23,7 +23,11 @@ namespace System.Reactive.Linq
                 return Empty<TSource>();
             }
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.Take(observer, count)));
+            return Create(
+                source,
+                count,
+                default(TSource),
+                (source, count, observer) => source.SubscribeSafeAsync(AsyncObserver.Take(observer, count)));
         }
 
         public static IAsyncObservable<TSource> Take<TSource>(this IAsyncObservable<TSource> source, TimeSpan duration)
@@ -40,14 +44,18 @@ namespace System.Reactive.Linq
 
             // REVIEW: May be easier to just use TakeUntil with a Timer parameter. Do we want Take on the observer?
 
-            return Create<TSource>(async observer =>
-            {
-                var (sourceObserver, timer) = await AsyncObserver.Take(observer, duration).ConfigureAwait(false);
+            return Create(
+                source,
+                duration,
+                default(TSource),
+                async (source, duration, observer) =>
+                {
+                    var (sourceObserver, timer) = await AsyncObserver.Take(observer, duration).ConfigureAwait(false);
 
-                var subscription = await source.SubscribeSafeAsync(sourceObserver).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sourceObserver).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, timer);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, timer);
+                });
         }
 
         public static IAsyncObservable<TSource> Take<TSource>(this IAsyncObservable<TSource> source, TimeSpan duration, IAsyncScheduler scheduler)
@@ -56,7 +64,7 @@ namespace System.Reactive.Linq
                 throw new ArgumentNullException(nameof(source));
             if (duration < TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException(nameof(duration));
-            if (scheduler == null)
+            if (scheduler == null)  // REVIEW: scheduler not used.
                 throw new ArgumentNullException(nameof(scheduler));
 
             if (duration == TimeSpan.Zero)
@@ -66,14 +74,18 @@ namespace System.Reactive.Linq
 
             // REVIEW: May be easier to just use TakeUntil with a Timer parameter. Do we want Take on the observer?
 
-            return Create<TSource>(async observer =>
-            {
-                var (sourceObserver, timer) = await AsyncObserver.Take(observer, duration).ConfigureAwait(false);
+            return Create(
+                source,
+                (duration, scheduler),
+                default(TSource),
+                async (source, state, observer) =>
+                {
+                    var (sourceObserver, timer) = await AsyncObserver.Take(observer, state.duration).ConfigureAwait(false);
 
-                var subscription = await source.SubscribeSafeAsync(sourceObserver).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sourceObserver).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, timer);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, timer);
+                });
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Take.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Take.cs
@@ -27,7 +27,7 @@ namespace System.Reactive.Linq
                 source,
                 count,
                 default(TSource),
-                (source, count, observer) => source.SubscribeSafeAsync(AsyncObserver.Take(observer, count)));
+                static (source, count, observer) => source.SubscribeSafeAsync(AsyncObserver.Take(observer, count)));
         }
 
         public static IAsyncObservable<TSource> Take<TSource>(this IAsyncObservable<TSource> source, TimeSpan duration)
@@ -48,7 +48,7 @@ namespace System.Reactive.Linq
                 source,
                 duration,
                 default(TSource),
-                async (source, duration, observer) =>
+                static async (source, duration, observer) =>
                 {
                     var (sourceObserver, timer) = await AsyncObserver.Take(observer, duration).ConfigureAwait(false);
 
@@ -78,7 +78,7 @@ namespace System.Reactive.Linq
                 source,
                 (duration, scheduler),
                 default(TSource),
-                async (source, state, observer) =>
+                static async (source, state, observer) =>
                 {
                     var (sourceObserver, timer) = await AsyncObserver.Take(observer, state.duration).ConfigureAwait(false);
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeLast.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeLast.cs
@@ -27,7 +27,7 @@ namespace System.Reactive.Linq
                 source,
                 count,
                 default(TSource),
-                async (source, count, observer) =>
+                static async (source, count, observer) =>
                 {
                     var (sink, drain) = AsyncObserver.TakeLast(observer, count);
 
@@ -55,7 +55,7 @@ namespace System.Reactive.Linq
                 source,
                 (count, scheduler),
                 default(TSource),
-                async (source, state, observer) =>
+                static async (source, state, observer) =>
                 {
                     var (sink, drain) = AsyncObserver.TakeLast(observer, state.count, state.scheduler);
 
@@ -81,7 +81,7 @@ namespace System.Reactive.Linq
                 source,
                 duration,
                 default(TSource),
-                async (source, duration, observer) =>
+                static async (source, duration, observer) =>
                 {
                     var (sink, drain) = AsyncObserver.TakeLast(observer, duration);
 
@@ -109,7 +109,7 @@ namespace System.Reactive.Linq
                 source,
                 (duration, clock),
                 default(TSource),
-                async (source, state, observer) =>
+                static async (source, state, observer) =>
                 {
                     var (sink, drain) = AsyncObserver.TakeLast(observer, state.duration, state.clock);
 
@@ -139,7 +139,7 @@ namespace System.Reactive.Linq
                 source,
                 (duration, clock, scheduler),
                 default(TSource),
-                async (source, state, observer) =>
+                static async (source, state, observer) =>
                 {
                     var (sink, drain) = AsyncObserver.TakeLast(observer, state.duration, state.clock, state.scheduler);
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeLast.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeLast.cs
@@ -23,10 +23,9 @@ namespace System.Reactive.Linq
                 return Empty<TSource>();
             }
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 count,
-                default(TSource),
                 static async (source, count, observer) =>
                 {
                     var (sink, drain) = AsyncObserver.TakeLast(observer, count);
@@ -51,10 +50,9 @@ namespace System.Reactive.Linq
                 return Empty<TSource>();
             }
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 (count, scheduler),
-                default(TSource),
                 static async (source, state, observer) =>
                 {
                     var (sink, drain) = AsyncObserver.TakeLast(observer, state.count, state.scheduler);
@@ -77,10 +75,9 @@ namespace System.Reactive.Linq
                 return Empty<TSource>();
             }
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 duration,
-                default(TSource),
                 static async (source, duration, observer) =>
                 {
                     var (sink, drain) = AsyncObserver.TakeLast(observer, duration);
@@ -105,10 +102,9 @@ namespace System.Reactive.Linq
                 return Empty<TSource>();
             }
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 (duration, clock),
-                default(TSource),
                 static async (source, state, observer) =>
                 {
                     var (sink, drain) = AsyncObserver.TakeLast(observer, state.duration, state.clock);
@@ -135,10 +131,9 @@ namespace System.Reactive.Linq
                 return Empty<TSource>();
             }
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 (duration, clock, scheduler),
-                default(TSource),
                 static async (source, state, observer) =>
                 {
                     var (sink, drain) = AsyncObserver.TakeLast(observer, state.duration, state.clock, state.scheduler);

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeLast.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeLast.cs
@@ -23,14 +23,18 @@ namespace System.Reactive.Linq
                 return Empty<TSource>();
             }
 
-            return Create<TSource>(async observer =>
-            {
-                var (sink, drain) = AsyncObserver.TakeLast(observer, count);
+            return Create(
+                source,
+                count,
+                default(TSource),
+                async (source, count, observer) =>
+                {
+                    var (sink, drain) = AsyncObserver.TakeLast(observer, count);
 
-                var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, drain);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, drain);
+                });
         }
 
         public static IAsyncObservable<TSource> TakeLast<TSource>(this IAsyncObservable<TSource> source, int count, IAsyncScheduler scheduler)
@@ -47,14 +51,18 @@ namespace System.Reactive.Linq
                 return Empty<TSource>();
             }
 
-            return Create<TSource>(async observer =>
-            {
-                var (sink, drain) = AsyncObserver.TakeLast(observer, count, scheduler);
+            return Create(
+                source,
+                (count, scheduler),
+                default(TSource),
+                async (source, state, observer) =>
+                {
+                    var (sink, drain) = AsyncObserver.TakeLast(observer, state.count, state.scheduler);
 
-                var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, drain);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, drain);
+                });
         }
 
         public static IAsyncObservable<TSource> TakeLast<TSource>(this IAsyncObservable<TSource> source, TimeSpan duration)
@@ -69,14 +77,18 @@ namespace System.Reactive.Linq
                 return Empty<TSource>();
             }
 
-            return Create<TSource>(async observer =>
-            {
-                var (sink, drain) = AsyncObserver.TakeLast(observer, duration);
+            return Create(
+                source,
+                duration,
+                default(TSource),
+                async (source, duration, observer) =>
+                {
+                    var (sink, drain) = AsyncObserver.TakeLast(observer, duration);
 
-                var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, drain);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, drain);
+                });
         }
 
         public static IAsyncObservable<TSource> TakeLast<TSource>(this IAsyncObservable<TSource> source, TimeSpan duration, IClock clock)
@@ -93,14 +105,18 @@ namespace System.Reactive.Linq
                 return Empty<TSource>();
             }
 
-            return Create<TSource>(async observer =>
-            {
-                var (sink, drain) = AsyncObserver.TakeLast(observer, duration, clock);
+            return Create(
+                source,
+                (duration, clock),
+                default(TSource),
+                async (source, state, observer) =>
+                {
+                    var (sink, drain) = AsyncObserver.TakeLast(observer, state.duration, state.clock);
 
-                var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, drain);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, drain);
+                });
         }
 
         public static IAsyncObservable<TSource> TakeLast<TSource>(this IAsyncObservable<TSource> source, TimeSpan duration, IClock clock, IAsyncScheduler scheduler)
@@ -119,14 +135,18 @@ namespace System.Reactive.Linq
                 return Empty<TSource>();
             }
 
-            return Create<TSource>(async observer =>
-            {
-                var (sink, drain) = AsyncObserver.TakeLast(observer, duration, clock, scheduler);
+            return Create(
+                source,
+                (duration, clock, scheduler),
+                default(TSource),
+                async (source, state, observer) =>
+                {
+                    var (sink, drain) = AsyncObserver.TakeLast(observer, state.duration, state.clock, state.scheduler);
 
-                var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var subscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(subscription, drain);
-            });
+                    return StableCompositeAsyncDisposable.Create(subscription, drain);
+                });
         }
 
         public static IAsyncObservable<TSource> TakeLast<TSource>(this IAsyncObservable<TSource> source, TimeSpan duration, IAsyncScheduler scheduler) => TakeLast(source, duration, scheduler, scheduler);

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeLast.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeLast.cs
@@ -23,7 +23,7 @@ namespace System.Reactive.Linq
                 return Empty<TSource>();
             }
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 count,
                 static async (source, count, observer) =>
@@ -50,7 +50,7 @@ namespace System.Reactive.Linq
                 return Empty<TSource>();
             }
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 (count, scheduler),
                 static async (source, state, observer) =>
@@ -75,7 +75,7 @@ namespace System.Reactive.Linq
                 return Empty<TSource>();
             }
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 duration,
                 static async (source, duration, observer) =>
@@ -102,7 +102,7 @@ namespace System.Reactive.Linq
                 return Empty<TSource>();
             }
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 (duration, clock),
                 static async (source, state, observer) =>
@@ -131,7 +131,7 @@ namespace System.Reactive.Linq
                 return Empty<TSource>();
             }
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 (duration, clock, scheduler),
                 static async (source, state, observer) =>

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeLastBuffer.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeLastBuffer.cs
@@ -22,10 +22,9 @@ namespace System.Reactive.Linq
                 return Empty<IList<TSource>>();
             }
 
-            return Create(
+            return Build<IList<TSource>>.From(
                 source,
                 count,
-                default(IList<TSource>),
                 static (source, count, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeLastBuffer(observer, count)));
         }
 
@@ -41,10 +40,9 @@ namespace System.Reactive.Linq
                 return Empty<IList<TSource>>();
             }
 
-            return Create(
+            return Build<IList<TSource>>.From(
                 source,
                 duration,
-                default(IList<TSource>),
                 static (source, duration, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeLastBuffer(observer, duration)));
         }
 
@@ -62,10 +60,9 @@ namespace System.Reactive.Linq
                 return Empty<IList<TSource>>();
             }
 
-            return Create(
+            return Build<IList<TSource>>.From(
                 source,
                 (duration, clock),
-                default(IList<TSource>),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeLastBuffer(observer, state.duration, state.clock)));
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeLastBuffer.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeLastBuffer.cs
@@ -26,7 +26,7 @@ namespace System.Reactive.Linq
                 source,
                 count,
                 default(IList<TSource>),
-                (source, count, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeLastBuffer(observer, count)));
+                static (source, count, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeLastBuffer(observer, count)));
         }
 
         public static IAsyncObservable<IList<TSource>> TakeLastBuffer<TSource>(this IAsyncObservable<TSource> source, TimeSpan duration)
@@ -45,7 +45,7 @@ namespace System.Reactive.Linq
                 source,
                 duration,
                 default(IList<TSource>),
-                (source, duration, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeLastBuffer(observer, duration)));
+                static (source, duration, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeLastBuffer(observer, duration)));
         }
 
         public static IAsyncObservable<IList<TSource>> TakeLastBuffer<TSource>(this IAsyncObservable<TSource> source, TimeSpan duration, IClock clock)
@@ -66,7 +66,7 @@ namespace System.Reactive.Linq
                 source,
                 (duration, clock),
                 default(IList<TSource>),
-                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeLastBuffer(observer, state.duration, state.clock)));
+                static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeLastBuffer(observer, state.duration, state.clock)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeLastBuffer.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeLastBuffer.cs
@@ -22,7 +22,11 @@ namespace System.Reactive.Linq
                 return Empty<IList<TSource>>();
             }
 
-            return Create<IList<TSource>>(observer => source.SubscribeSafeAsync(AsyncObserver.TakeLastBuffer(observer, count)));
+            return Create(
+                source,
+                count,
+                default(IList<TSource>),
+                (source, count, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeLastBuffer(observer, count)));
         }
 
         public static IAsyncObservable<IList<TSource>> TakeLastBuffer<TSource>(this IAsyncObservable<TSource> source, TimeSpan duration)
@@ -37,7 +41,11 @@ namespace System.Reactive.Linq
                 return Empty<IList<TSource>>();
             }
 
-            return Create<IList<TSource>>(observer => source.SubscribeSafeAsync(AsyncObserver.TakeLastBuffer(observer, duration)));
+            return Create(
+                source,
+                duration,
+                default(IList<TSource>),
+                (source, duration, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeLastBuffer(observer, duration)));
         }
 
         public static IAsyncObservable<IList<TSource>> TakeLastBuffer<TSource>(this IAsyncObservable<TSource> source, TimeSpan duration, IClock clock)
@@ -54,7 +62,11 @@ namespace System.Reactive.Linq
                 return Empty<IList<TSource>>();
             }
 
-            return Create<IList<TSource>>(observer => source.SubscribeSafeAsync(AsyncObserver.TakeLastBuffer(observer, duration, clock)));
+            return Create(
+                source,
+                (duration, clock),
+                default(IList<TSource>),
+                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeLastBuffer(observer, state.duration, state.clock)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeLastBuffer.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeLastBuffer.cs
@@ -22,7 +22,7 @@ namespace System.Reactive.Linq
                 return Empty<IList<TSource>>();
             }
 
-            return Build<IList<TSource>>.From(
+            return CreateAsyncObservable<IList<TSource>>.From(
                 source,
                 count,
                 static (source, count, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeLastBuffer(observer, count)));
@@ -40,7 +40,7 @@ namespace System.Reactive.Linq
                 return Empty<IList<TSource>>();
             }
 
-            return Build<IList<TSource>>.From(
+            return CreateAsyncObservable<IList<TSource>>.From(
                 source,
                 duration,
                 static (source, duration, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeLastBuffer(observer, duration)));
@@ -60,7 +60,7 @@ namespace System.Reactive.Linq
                 return Empty<IList<TSource>>();
             }
 
-            return Build<IList<TSource>>.From(
+            return CreateAsyncObservable<IList<TSource>>.From(
                 source,
                 (duration, clock),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeLastBuffer(observer, state.duration, state.clock)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeUntil.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeUntil.cs
@@ -22,7 +22,7 @@ namespace System.Reactive.Linq
                 source,
                 until,
                 default(TSource),
-                async (source, until, observer) =>
+                static async (source, until, observer) =>
                 {
                     var (sourceObserver, untilObserver) = AsyncObserver.TakeUntil<TSource, TUntil>(observer);
 
@@ -49,7 +49,7 @@ namespace System.Reactive.Linq
                 source,
                 endTime,
                 default(TSource),
-                async (source, endTime, observer) =>
+                static async (source, endTime, observer) =>
                 {
                     var (sourceObserver, timer) = await AsyncObserver.TakeUntil(observer, endTime).ConfigureAwait(false);
 
@@ -72,7 +72,7 @@ namespace System.Reactive.Linq
                 source,
                 (endTime, scheduler),
                 default(TSource),
-                async (source, state, observer) =>
+                static async (source, state, observer) =>
                 {
                     var (sourceObserver, timer) = await AsyncObserver.TakeUntil(observer, state.endTime, state.scheduler).ConfigureAwait(false);
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeUntil.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeUntil.cs
@@ -18,10 +18,9 @@ namespace System.Reactive.Linq
             if (until == null)
                 throw new ArgumentNullException(nameof(until));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 until,
-                default(TSource),
                 static async (source, until, observer) =>
                 {
                     var (sourceObserver, untilObserver) = AsyncObserver.TakeUntil<TSource, TUntil>(observer);
@@ -45,10 +44,9 @@ namespace System.Reactive.Linq
 
             // REVIEW: May be easier to just use TakeUntil with a Timer parameter. Do we want TakeUntil on the observer?
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 endTime,
-                default(TSource),
                 static async (source, endTime, observer) =>
                 {
                     var (sourceObserver, timer) = await AsyncObserver.TakeUntil(observer, endTime).ConfigureAwait(false);
@@ -68,10 +66,9 @@ namespace System.Reactive.Linq
 
             // REVIEW: May be easier to just use TakeUntil with a Timer parameter. Do we want TakeUntil on the observer?
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 (endTime, scheduler),
-                default(TSource),
                 static async (source, state, observer) =>
                 {
                     var (sourceObserver, timer) = await AsyncObserver.TakeUntil(observer, state.endTime, state.scheduler).ConfigureAwait(false);

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeUntil.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeUntil.cs
@@ -18,7 +18,7 @@ namespace System.Reactive.Linq
             if (until == null)
                 throw new ArgumentNullException(nameof(until));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 until,
                 static async (source, until, observer) =>
@@ -44,7 +44,7 @@ namespace System.Reactive.Linq
 
             // REVIEW: May be easier to just use TakeUntil with a Timer parameter. Do we want TakeUntil on the observer?
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 endTime,
                 static async (source, endTime, observer) =>
@@ -66,7 +66,7 @@ namespace System.Reactive.Linq
 
             // REVIEW: May be easier to just use TakeUntil with a Timer parameter. Do we want TakeUntil on the observer?
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 (endTime, scheduler),
                 static async (source, state, observer) =>

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeWhile.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeWhile.cs
@@ -15,7 +15,11 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.TakeWhile(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                default(TSource),
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeWhile(observer, predicate)));
         }
 
         public static IAsyncObservable<TSource> TakeWhile<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
@@ -25,7 +29,11 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.TakeWhile(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                default(TSource),
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeWhile(observer, predicate)));
         }
 
         public static IAsyncObservable<TSource> TakeWhile<TSource>(this IAsyncObservable<TSource> source, Func<TSource, int, bool> predicate)
@@ -35,7 +43,11 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.TakeWhile(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                default(TSource),
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeWhile(observer, predicate)));
         }
 
         public static IAsyncObservable<TSource> TakeWhile<TSource>(this IAsyncObservable<TSource> source, Func<TSource, int, ValueTask<bool>> predicate)
@@ -45,7 +57,11 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.TakeWhile(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                default(TSource),
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeWhile(observer, predicate)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeWhile.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeWhile.cs
@@ -15,10 +15,9 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 predicate,
-                default(TSource),
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeWhile(observer, predicate)));
         }
 
@@ -29,10 +28,9 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 predicate,
-                default(TSource),
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeWhile(observer, predicate)));
         }
 
@@ -43,10 +41,9 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 predicate,
-                default(TSource),
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeWhile(observer, predicate)));
         }
 
@@ -57,10 +54,9 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 predicate,
-                default(TSource),
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeWhile(observer, predicate)));
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeWhile.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeWhile.cs
@@ -19,7 +19,7 @@ namespace System.Reactive.Linq
                 source,
                 predicate,
                 default(TSource),
-                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeWhile(observer, predicate)));
+                static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeWhile(observer, predicate)));
         }
 
         public static IAsyncObservable<TSource> TakeWhile<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
@@ -33,7 +33,7 @@ namespace System.Reactive.Linq
                 source,
                 predicate,
                 default(TSource),
-                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeWhile(observer, predicate)));
+                static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeWhile(observer, predicate)));
         }
 
         public static IAsyncObservable<TSource> TakeWhile<TSource>(this IAsyncObservable<TSource> source, Func<TSource, int, bool> predicate)
@@ -47,7 +47,7 @@ namespace System.Reactive.Linq
                 source,
                 predicate,
                 default(TSource),
-                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeWhile(observer, predicate)));
+                static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeWhile(observer, predicate)));
         }
 
         public static IAsyncObservable<TSource> TakeWhile<TSource>(this IAsyncObservable<TSource> source, Func<TSource, int, ValueTask<bool>> predicate)
@@ -61,7 +61,7 @@ namespace System.Reactive.Linq
                 source,
                 predicate,
                 default(TSource),
-                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeWhile(observer, predicate)));
+                static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeWhile(observer, predicate)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeWhile.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TakeWhile.cs
@@ -15,7 +15,7 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 predicate,
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeWhile(observer, predicate)));
@@ -28,7 +28,7 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 predicate,
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeWhile(observer, predicate)));
@@ -41,7 +41,7 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 predicate,
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeWhile(observer, predicate)));
@@ -54,7 +54,7 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 predicate,
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.TakeWhile(observer, predicate)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Throttle.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Throttle.cs
@@ -17,7 +17,7 @@ namespace System.Reactive.Linq
             if (dueTime < TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException(nameof(dueTime));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 dueTime,
                 static async (source, dueTime, observer) =>
@@ -45,7 +45,7 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 (dueTime, scheduler),
                 static async (source, state, observer) =>
@@ -71,7 +71,7 @@ namespace System.Reactive.Linq
             if (throttleSelector == null)
                 throw new ArgumentNullException(nameof(throttleSelector));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 throttleSelector,
                 static async (source, throttleSelector, observer) =>

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Throttle.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Throttle.cs
@@ -17,10 +17,9 @@ namespace System.Reactive.Linq
             if (dueTime < TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException(nameof(dueTime));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 dueTime,
-                default(TSource),
                 static async (source, dueTime, observer) =>
                 {
                     var d = new CompositeAsyncDisposable();
@@ -46,10 +45,9 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 (dueTime, scheduler),
-                default(TSource),
                 static async (source, state, observer) =>
                 {
                     var d = new CompositeAsyncDisposable();
@@ -73,10 +71,9 @@ namespace System.Reactive.Linq
             if (throttleSelector == null)
                 throw new ArgumentNullException(nameof(throttleSelector));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 throttleSelector,
-                default(TSource),
                 static async (source, throttleSelector, observer) =>
                 {
                     var d = new CompositeAsyncDisposable();

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Throttle.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Throttle.cs
@@ -21,7 +21,7 @@ namespace System.Reactive.Linq
                 source,
                 dueTime,
                 default(TSource),
-                async (source, dueTime, observer) =>
+                static async (source, dueTime, observer) =>
                 {
                     var d = new CompositeAsyncDisposable();
 
@@ -50,7 +50,7 @@ namespace System.Reactive.Linq
                 source,
                 (dueTime, scheduler),
                 default(TSource),
-                async (source, state, observer) =>
+                static async (source, state, observer) =>
                 {
                     var d = new CompositeAsyncDisposable();
 
@@ -77,7 +77,7 @@ namespace System.Reactive.Linq
                 source,
                 throttleSelector,
                 default(TSource),
-                async (source, throttleSelector, observer) =>
+                static async (source, throttleSelector, observer) =>
                 {
                     var d = new CompositeAsyncDisposable();
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Throttle.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Throttle.cs
@@ -17,20 +17,24 @@ namespace System.Reactive.Linq
             if (dueTime < TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException(nameof(dueTime));
 
-            return Create<TSource>(async observer =>
-            {
-                var d = new CompositeAsyncDisposable();
+            return Create(
+                source,
+                dueTime,
+                default(TSource),
+                async (source, dueTime, observer) =>
+                {
+                    var d = new CompositeAsyncDisposable();
 
-                var (sink, throttler) = AsyncObserver.Throttle(observer, dueTime);
+                    var (sink, throttler) = AsyncObserver.Throttle(observer, dueTime);
 
-                await d.AddAsync(throttler).ConfigureAwait(false);
+                    await d.AddAsync(throttler).ConfigureAwait(false);
 
-                var sourceSubscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var sourceSubscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                await d.AddAsync(sourceSubscription).ConfigureAwait(false);
+                    await d.AddAsync(sourceSubscription).ConfigureAwait(false);
 
-                return d;
-            });
+                    return d;
+                });
         }
 
         public static IAsyncObservable<TSource> Throttle<TSource>(this IAsyncObservable<TSource> source, TimeSpan dueTime, IAsyncScheduler scheduler)
@@ -42,20 +46,24 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Create<TSource>(async observer =>
-            {
-                var d = new CompositeAsyncDisposable();
+            return Create(
+                source,
+                (dueTime, scheduler),
+                default(TSource),
+                async (source, state, observer) =>
+                {
+                    var d = new CompositeAsyncDisposable();
 
-                var (sink, throttler) = AsyncObserver.Throttle(observer, dueTime, scheduler);
+                    var (sink, throttler) = AsyncObserver.Throttle(observer, state.dueTime, state.scheduler);
 
-                await d.AddAsync(throttler).ConfigureAwait(false);
+                    await d.AddAsync(throttler).ConfigureAwait(false);
 
-                var sourceSubscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var sourceSubscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                await d.AddAsync(sourceSubscription).ConfigureAwait(false);
+                    await d.AddAsync(sourceSubscription).ConfigureAwait(false);
 
-                return d;
-            });
+                    return d;
+                });
         }
 
         public static IAsyncObservable<TSource> Throttle<TSource, TThrottle>(this IAsyncObservable<TSource> source, Func<TSource, IAsyncObservable<TThrottle>> throttleSelector)
@@ -65,20 +73,24 @@ namespace System.Reactive.Linq
             if (throttleSelector == null)
                 throw new ArgumentNullException(nameof(throttleSelector));
 
-            return Create<TSource>(async observer =>
-            {
-                var d = new CompositeAsyncDisposable();
+            return Create(
+                source,
+                throttleSelector,
+                default(TSource),
+                async (source, throttleSelector, observer) =>
+                {
+                    var d = new CompositeAsyncDisposable();
 
-                var (sink, throttler) = AsyncObserver.Throttle(observer, throttleSelector);
+                    var (sink, throttler) = AsyncObserver.Throttle(observer, throttleSelector);
 
-                await d.AddAsync(throttler).ConfigureAwait(false);
+                    await d.AddAsync(throttler).ConfigureAwait(false);
 
-                var sourceSubscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var sourceSubscription = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                await d.AddAsync(sourceSubscription).ConfigureAwait(false);
+                    await d.AddAsync(sourceSubscription).ConfigureAwait(false);
 
-                return d;
-            });
+                    return d;
+                });
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TimeInterval.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TimeInterval.cs
@@ -27,7 +27,7 @@ namespace System.Reactive.Linq
                 source,
                 clock,
                 default(TimeInterval<TSource>),
-                (source, clock, observer) => source.SubscribeSafeAsync(AsyncObserver.TimeInterval(observer, clock))); ;
+                static (source, clock, observer) => source.SubscribeSafeAsync(AsyncObserver.TimeInterval(observer, clock))); ;
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TimeInterval.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TimeInterval.cs
@@ -23,7 +23,11 @@ namespace System.Reactive.Linq
             if (clock == null)
                 throw new ArgumentNullException(nameof(clock));
 
-            return Create<TimeInterval<TSource>>(observer => source.SubscribeSafeAsync(AsyncObserver.TimeInterval(observer, clock)));
+            return Create(
+                source,
+                clock,
+                default(TimeInterval<TSource>),
+                (source, clock, observer) => source.SubscribeSafeAsync(AsyncObserver.TimeInterval(observer, clock))); ;
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TimeInterval.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TimeInterval.cs
@@ -23,10 +23,9 @@ namespace System.Reactive.Linq
             if (clock == null)
                 throw new ArgumentNullException(nameof(clock));
 
-            return Create(
+            return Build<TimeInterval<TSource>>.From(
                 source,
                 clock,
-                default(TimeInterval<TSource>),
                 static (source, clock, observer) => source.SubscribeSafeAsync(AsyncObserver.TimeInterval(observer, clock))); ;
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TimeInterval.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/TimeInterval.cs
@@ -23,7 +23,7 @@ namespace System.Reactive.Linq
             if (clock == null)
                 throw new ArgumentNullException(nameof(clock));
 
-            return Build<TimeInterval<TSource>>.From(
+            return CreateAsyncObservable<TimeInterval<TSource>>.From(
                 source,
                 clock,
                 static (source, clock, observer) => source.SubscribeSafeAsync(AsyncObserver.TimeInterval(observer, clock))); ;

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Timeout.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Timeout.cs
@@ -20,7 +20,7 @@ namespace System.Reactive.Linq
                 source,
                 dueTime,
                 default(TSource),
-                async (source, dueTime, observer) =>
+                static async (source, dueTime, observer) =>
                 {
                     var sourceSubscription = new SingleAssignmentAsyncDisposable();
 
@@ -45,7 +45,7 @@ namespace System.Reactive.Linq
                 source,
                 (dueTime, scheduler),
                 default(TSource),
-                async (source, state, observer) =>
+                static async (source, state, observer) =>
                 {
                     var sourceSubscription = new SingleAssignmentAsyncDisposable();
 
@@ -70,7 +70,7 @@ namespace System.Reactive.Linq
                 source,
                 (dueTime, other),
                 default(TSource),
-                async (source, state, observer) =>
+                static async (source, state, observer) =>
                 {
                     var sourceSubscription = new SingleAssignmentAsyncDisposable();
 
@@ -97,7 +97,7 @@ namespace System.Reactive.Linq
                 source,
                 (dueTime, other, scheduler),
                 default(TSource),
-                async (source, state, observer) =>
+                static async (source, state, observer) =>
                 {
                     var sourceSubscription = new SingleAssignmentAsyncDisposable();
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Timeout.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Timeout.cs
@@ -16,10 +16,9 @@ namespace System.Reactive.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 dueTime,
-                default(TSource),
                 static async (source, dueTime, observer) =>
                 {
                     var sourceSubscription = new SingleAssignmentAsyncDisposable();
@@ -41,10 +40,9 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 (dueTime, scheduler),
-                default(TSource),
                 static async (source, state, observer) =>
                 {
                     var sourceSubscription = new SingleAssignmentAsyncDisposable();
@@ -66,10 +64,9 @@ namespace System.Reactive.Linq
             if (other == null)
                 throw new ArgumentNullException(nameof(other));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 (dueTime, other),
-                default(TSource),
                 static async (source, state, observer) =>
                 {
                     var sourceSubscription = new SingleAssignmentAsyncDisposable();
@@ -93,10 +90,9 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 (dueTime, other, scheduler),
-                default(TSource),
                 static async (source, state, observer) =>
                 {
                     var sourceSubscription = new SingleAssignmentAsyncDisposable();

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Timeout.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Timeout.cs
@@ -16,7 +16,7 @@ namespace System.Reactive.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 dueTime,
                 static async (source, dueTime, observer) =>
@@ -40,7 +40,7 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 (dueTime, scheduler),
                 static async (source, state, observer) =>
@@ -64,7 +64,7 @@ namespace System.Reactive.Linq
             if (other == null)
                 throw new ArgumentNullException(nameof(other));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 (dueTime, other),
                 static async (source, state, observer) =>
@@ -90,7 +90,7 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 (dueTime, other, scheduler),
                 static async (source, state, observer) =>

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Timeout.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Timeout.cs
@@ -16,18 +16,22 @@ namespace System.Reactive.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return Create<TSource>(async observer =>
-            {
-                var sourceSubscription = new SingleAssignmentAsyncDisposable();
+            return Create(
+                source,
+                dueTime,
+                default(TSource),
+                async (source, dueTime, observer) =>
+                {
+                    var sourceSubscription = new SingleAssignmentAsyncDisposable();
 
-                var (sink, disposable) = await AsyncObserver.Timeout(observer, sourceSubscription, dueTime).ConfigureAwait(false);
+                    var (sink, disposable) = await AsyncObserver.Timeout(observer, sourceSubscription, dueTime).ConfigureAwait(false);
 
-                var sourceSubscriptionInner = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var sourceSubscriptionInner = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                await sourceSubscription.AssignAsync(sourceSubscriptionInner).ConfigureAwait(false);
+                    await sourceSubscription.AssignAsync(sourceSubscriptionInner).ConfigureAwait(false);
 
-                return disposable;
-            });
+                    return disposable;
+                });
         }
 
         public static IAsyncObservable<TSource> Timeout<TSource>(this IAsyncObservable<TSource> source, TimeSpan dueTime, IAsyncScheduler scheduler)
@@ -37,18 +41,22 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Create<TSource>(async observer =>
-            {
-                var sourceSubscription = new SingleAssignmentAsyncDisposable();
+            return Create(
+                source,
+                (dueTime, scheduler),
+                default(TSource),
+                async (source, state, observer) =>
+                {
+                    var sourceSubscription = new SingleAssignmentAsyncDisposable();
 
-                var (sink, disposable) = await AsyncObserver.Timeout(observer, sourceSubscription, dueTime, scheduler).ConfigureAwait(false);
+                    var (sink, disposable) = await AsyncObserver.Timeout(observer, sourceSubscription, state.dueTime, state.scheduler).ConfigureAwait(false);
 
-                var sourceSubscriptionInner = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var sourceSubscriptionInner = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                await sourceSubscription.AssignAsync(sourceSubscriptionInner).ConfigureAwait(false);
+                    await sourceSubscription.AssignAsync(sourceSubscriptionInner).ConfigureAwait(false);
 
-                return disposable;
-            });
+                    return disposable;
+                });
         }
 
         public static IAsyncObservable<TSource> Timeout<TSource>(this IAsyncObservable<TSource> source, TimeSpan dueTime, IAsyncObservable<TSource> other)
@@ -58,18 +66,22 @@ namespace System.Reactive.Linq
             if (other == null)
                 throw new ArgumentNullException(nameof(other));
 
-            return Create<TSource>(async observer =>
-            {
-                var sourceSubscription = new SingleAssignmentAsyncDisposable();
+            return Create(
+                source,
+                (dueTime, other),
+                default(TSource),
+                async (source, state, observer) =>
+                {
+                    var sourceSubscription = new SingleAssignmentAsyncDisposable();
 
-                var (sink, disposable) = await AsyncObserver.Timeout(observer, sourceSubscription, dueTime, other).ConfigureAwait(false);
+                    var (sink, disposable) = await AsyncObserver.Timeout(observer, sourceSubscription, state.dueTime, state.other).ConfigureAwait(false);
 
-                var sourceSubscriptionInner = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var sourceSubscriptionInner = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                await sourceSubscription.AssignAsync(sourceSubscriptionInner).ConfigureAwait(false);
+                    await sourceSubscription.AssignAsync(sourceSubscriptionInner).ConfigureAwait(false);
 
-                return disposable;
-            });
+                    return disposable;
+                });
         }
 
         public static IAsyncObservable<TSource> Timeout<TSource>(this IAsyncObservable<TSource> source, TimeSpan dueTime, IAsyncObservable<TSource> other, IAsyncScheduler scheduler)
@@ -81,18 +93,22 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Create<TSource>(async observer =>
-            {
-                var sourceSubscription = new SingleAssignmentAsyncDisposable();
+            return Create(
+                source,
+                (dueTime, other, scheduler),
+                default(TSource),
+                async (source, state, observer) =>
+                {
+                    var sourceSubscription = new SingleAssignmentAsyncDisposable();
 
-                var (sink, disposable) = await AsyncObserver.Timeout(observer, sourceSubscription, dueTime, other, scheduler).ConfigureAwait(false);
+                    var (sink, disposable) = await AsyncObserver.Timeout(observer, sourceSubscription, state.dueTime, state.other, state.scheduler).ConfigureAwait(false);
 
-                var sourceSubscriptionInner = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
+                    var sourceSubscriptionInner = await source.SubscribeSafeAsync(sink).ConfigureAwait(false);
 
-                await sourceSubscription.AssignAsync(sourceSubscriptionInner).ConfigureAwait(false);
+                    await sourceSubscription.AssignAsync(sourceSubscriptionInner).ConfigureAwait(false);
 
-                return disposable;
-            });
+                    return disposable;
+                });
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Timestamp.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Timestamp.cs
@@ -23,7 +23,7 @@ namespace System.Reactive.Linq
             if (clock == null)
                 throw new ArgumentNullException(nameof(clock));
 
-            return Build<Timestamped<TSource>>.From(
+            return CreateAsyncObservable<Timestamped<TSource>>.From(
                 source,
                 clock,
                 static (source, clock, observer) => source.SubscribeSafeAsync(AsyncObserver.Timestamp(observer, clock)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Timestamp.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Timestamp.cs
@@ -23,7 +23,11 @@ namespace System.Reactive.Linq
             if (clock == null)
                 throw new ArgumentNullException(nameof(clock));
 
-            return Create<Timestamped<TSource>>(observer => source.SubscribeSafeAsync(AsyncObserver.Timestamp(observer, clock)));
+            return Create(
+                source,
+                clock,
+                default(Timestamped<TSource>),
+                (source, clock, observer) => source.SubscribeSafeAsync(AsyncObserver.Timestamp(observer, clock)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Timestamp.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Timestamp.cs
@@ -27,7 +27,7 @@ namespace System.Reactive.Linq
                 source,
                 clock,
                 default(Timestamped<TSource>),
-                (source, clock, observer) => source.SubscribeSafeAsync(AsyncObserver.Timestamp(observer, clock)));
+                static (source, clock, observer) => source.SubscribeSafeAsync(AsyncObserver.Timestamp(observer, clock)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Timestamp.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Timestamp.cs
@@ -23,10 +23,9 @@ namespace System.Reactive.Linq
             if (clock == null)
                 throw new ArgumentNullException(nameof(clock));
 
-            return Create(
+            return Build<Timestamped<TSource>>.From(
                 source,
                 clock,
-                default(Timestamped<TSource>),
                 static (source, clock, observer) => source.SubscribeSafeAsync(AsyncObserver.Timestamp(observer, clock)));
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ToDictionary.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ToDictionary.cs
@@ -18,10 +18,9 @@ namespace System.Reactive.Linq
             if (valueSelector == null)
                 throw new ArgumentNullException(nameof(valueSelector));
 
-            return Create(
+            return Build<IDictionary<TKey, TValue>>.From(
                 source,
                 (keySelector, valueSelector),
-                default(IDictionary<TKey, TValue>),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToDictionary(observer, state.keySelector, state.valueSelector)));
         }
 
@@ -36,10 +35,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build<IDictionary<TKey, TValue>>.From(
                 source,
                 (keySelector, valueSelector, comparer),
-                default(IDictionary<TKey, TValue>),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToDictionary(observer, state.keySelector, state.valueSelector, state.comparer))); ;
         }
 
@@ -52,10 +50,9 @@ namespace System.Reactive.Linq
             if (valueSelector == null)
                 throw new ArgumentNullException(nameof(valueSelector));
 
-            return Create(
+            return Build<IDictionary<TKey, TValue>>.From(
                 source,
                 (keySelector, valueSelector),
-                default(IDictionary<TKey, TValue>),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToDictionary(observer, state.keySelector, state.valueSelector)));
         }
 
@@ -70,10 +67,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build<IDictionary<TKey, TValue>>.From(
                 source,
                 (keySelector, valueSelector, comparer),
-                default(IDictionary<TKey, TValue>),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToDictionary(observer, state.keySelector, state.valueSelector, state.comparer)));
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ToDictionary.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ToDictionary.cs
@@ -22,7 +22,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, valueSelector),
                 default(IDictionary<TKey, TValue>),
-                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToDictionary(observer, state.keySelector, state.valueSelector)));
+                static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToDictionary(observer, state.keySelector, state.valueSelector)));
         }
 
         public static IAsyncObservable<IDictionary<TKey, TValue>> ToDictionary<TSource, TKey, TValue>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> valueSelector, IEqualityComparer<TKey> comparer)
@@ -40,7 +40,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, valueSelector, comparer),
                 default(IDictionary<TKey, TValue>),
-                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToDictionary(observer, state.keySelector, state.valueSelector, state.comparer))); ;
+                static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToDictionary(observer, state.keySelector, state.valueSelector, state.comparer))); ;
         }
 
         public static IAsyncObservable<IDictionary<TKey, TValue>> ToDictionary<TSource, TKey, TValue>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TValue>> valueSelector)
@@ -56,7 +56,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, valueSelector),
                 default(IDictionary<TKey, TValue>),
-                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToDictionary(observer, state.keySelector, state.valueSelector)));
+                static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToDictionary(observer, state.keySelector, state.valueSelector)));
         }
 
         public static IAsyncObservable<IDictionary<TKey, TValue>> ToDictionary<TSource, TKey, TValue>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TValue>> valueSelector, IEqualityComparer<TKey> comparer)
@@ -74,7 +74,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, valueSelector, comparer),
                 default(IDictionary<TKey, TValue>),
-                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToDictionary(observer, state.keySelector, state.valueSelector, state.comparer)));
+                static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToDictionary(observer, state.keySelector, state.valueSelector, state.comparer)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ToDictionary.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ToDictionary.cs
@@ -18,7 +18,11 @@ namespace System.Reactive.Linq
             if (valueSelector == null)
                 throw new ArgumentNullException(nameof(valueSelector));
 
-            return Create<IDictionary<TKey, TValue>>(observer => source.SubscribeSafeAsync(AsyncObserver.ToDictionary(observer, keySelector, valueSelector)));
+            return Create(
+                source,
+                (keySelector, valueSelector),
+                default(IDictionary<TKey, TValue>),
+                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToDictionary(observer, state.keySelector, state.valueSelector)));
         }
 
         public static IAsyncObservable<IDictionary<TKey, TValue>> ToDictionary<TSource, TKey, TValue>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> valueSelector, IEqualityComparer<TKey> comparer)
@@ -32,7 +36,11 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<IDictionary<TKey, TValue>>(observer => source.SubscribeSafeAsync(AsyncObserver.ToDictionary(observer, keySelector, valueSelector, comparer)));
+            return Create(
+                source,
+                (keySelector, valueSelector, comparer),
+                default(IDictionary<TKey, TValue>),
+                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToDictionary(observer, state.keySelector, state.valueSelector, state.comparer))); ;
         }
 
         public static IAsyncObservable<IDictionary<TKey, TValue>> ToDictionary<TSource, TKey, TValue>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TValue>> valueSelector)
@@ -44,7 +52,11 @@ namespace System.Reactive.Linq
             if (valueSelector == null)
                 throw new ArgumentNullException(nameof(valueSelector));
 
-            return Create<IDictionary<TKey, TValue>>(observer => source.SubscribeSafeAsync(AsyncObserver.ToDictionary(observer, keySelector, valueSelector)));
+            return Create(
+                source,
+                (keySelector, valueSelector),
+                default(IDictionary<TKey, TValue>),
+                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToDictionary(observer, state.keySelector, state.valueSelector)));
         }
 
         public static IAsyncObservable<IDictionary<TKey, TValue>> ToDictionary<TSource, TKey, TValue>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TValue>> valueSelector, IEqualityComparer<TKey> comparer)
@@ -58,7 +70,11 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<IDictionary<TKey, TValue>>(observer => source.SubscribeSafeAsync(AsyncObserver.ToDictionary(observer, keySelector, valueSelector, comparer)));
+            return Create(
+                source,
+                (keySelector, valueSelector, comparer),
+                default(IDictionary<TKey, TValue>),
+                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToDictionary(observer, state.keySelector, state.valueSelector, state.comparer)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ToDictionary.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ToDictionary.cs
@@ -18,7 +18,7 @@ namespace System.Reactive.Linq
             if (valueSelector == null)
                 throw new ArgumentNullException(nameof(valueSelector));
 
-            return Build<IDictionary<TKey, TValue>>.From(
+            return CreateAsyncObservable<IDictionary<TKey, TValue>>.From(
                 source,
                 (keySelector, valueSelector),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToDictionary(observer, state.keySelector, state.valueSelector)));
@@ -35,7 +35,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build<IDictionary<TKey, TValue>>.From(
+            return CreateAsyncObservable<IDictionary<TKey, TValue>>.From(
                 source,
                 (keySelector, valueSelector, comparer),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToDictionary(observer, state.keySelector, state.valueSelector, state.comparer))); ;
@@ -50,7 +50,7 @@ namespace System.Reactive.Linq
             if (valueSelector == null)
                 throw new ArgumentNullException(nameof(valueSelector));
 
-            return Build<IDictionary<TKey, TValue>>.From(
+            return CreateAsyncObservable<IDictionary<TKey, TValue>>.From(
                 source,
                 (keySelector, valueSelector),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToDictionary(observer, state.keySelector, state.valueSelector)));
@@ -67,7 +67,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build<IDictionary<TKey, TValue>>.From(
+            return CreateAsyncObservable<IDictionary<TKey, TValue>>.From(
                 source,
                 (keySelector, valueSelector, comparer),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToDictionary(observer, state.keySelector, state.valueSelector, state.comparer)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ToHashSet.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ToHashSet.cs
@@ -27,7 +27,7 @@ namespace System.Reactive.Linq
                 source,
                 comparer,
                 default(HashSet<TSource>),
-                (source, comparer, observer) => source.SubscribeSafeAsync(AsyncObserver.ToHashSet(observer, comparer)));
+                static (source, comparer, observer) => source.SubscribeSafeAsync(AsyncObserver.ToHashSet(observer, comparer)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ToHashSet.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ToHashSet.cs
@@ -23,7 +23,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build<HashSet<TSource>>.From(
+            return CreateAsyncObservable<HashSet<TSource>>.From(
                 source,
                 comparer,
                 static (source, comparer, observer) => source.SubscribeSafeAsync(AsyncObserver.ToHashSet(observer, comparer)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ToHashSet.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ToHashSet.cs
@@ -23,7 +23,11 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<HashSet<TSource>>(observer => source.SubscribeSafeAsync(AsyncObserver.ToHashSet(observer, comparer)));
+            return Create(
+                source,
+                comparer,
+                default(HashSet<TSource>),
+                (source, comparer, observer) => source.SubscribeSafeAsync(AsyncObserver.ToHashSet(observer, comparer)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ToHashSet.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ToHashSet.cs
@@ -23,10 +23,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build<HashSet<TSource>>.From(
                 source,
                 comparer,
-                default(HashSet<TSource>),
                 static (source, comparer, observer) => source.SubscribeSafeAsync(AsyncObserver.ToHashSet(observer, comparer)));
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ToLookup.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ToLookup.cs
@@ -19,7 +19,7 @@ namespace System.Reactive.Linq
             if (valueSelector == null)
                 throw new ArgumentNullException(nameof(valueSelector));
 
-            return Build<ILookup<TKey, TValue>>.From(
+            return CreateAsyncObservable<ILookup<TKey, TValue>>.From(
                 source,
                 (keySelector, valueSelector),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToLookup(observer, state.keySelector, state.valueSelector)));
@@ -36,7 +36,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build<ILookup<TKey, TValue>>.From(
+            return CreateAsyncObservable<ILookup<TKey, TValue>>.From(
                 source,
                 (keySelector, valueSelector, comparer),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToLookup(observer, state.keySelector, state.valueSelector, state.comparer)));
@@ -51,7 +51,7 @@ namespace System.Reactive.Linq
             if (valueSelector == null)
                 throw new ArgumentNullException(nameof(valueSelector));
 
-            return Build<ILookup<TKey, TValue>>.From(
+            return CreateAsyncObservable<ILookup<TKey, TValue>>.From(
                 source,
                 (keySelector, valueSelector),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToLookup(observer, state.keySelector, state.valueSelector)));
@@ -68,7 +68,7 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Build<ILookup<TKey, TValue>>.From(
+            return CreateAsyncObservable<ILookup<TKey, TValue>>.From(
                 source,
                 (keySelector, valueSelector, comparer),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToLookup(observer, state.keySelector, state.valueSelector, state.comparer)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ToLookup.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ToLookup.cs
@@ -19,7 +19,11 @@ namespace System.Reactive.Linq
             if (valueSelector == null)
                 throw new ArgumentNullException(nameof(valueSelector));
 
-            return Create<ILookup<TKey, TValue>>(observer => source.SubscribeSafeAsync(AsyncObserver.ToLookup(observer, keySelector, valueSelector)));
+            return Create(
+                source,
+                (keySelector, valueSelector),
+                default(ILookup<TKey, TValue>),
+                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToLookup(observer, state.keySelector, state.valueSelector)));
         }
 
         public static IAsyncObservable<ILookup<TKey, TValue>> ToLookup<TSource, TKey, TValue>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> valueSelector, IEqualityComparer<TKey> comparer)
@@ -33,7 +37,11 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<ILookup<TKey, TValue>>(observer => source.SubscribeSafeAsync(AsyncObserver.ToLookup(observer, keySelector, valueSelector, comparer)));
+            return Create(
+                source,
+                (keySelector, valueSelector, comparer),
+                default(ILookup<TKey, TValue>),
+                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToLookup(observer, state.keySelector, state.valueSelector, state.comparer)));
         }
 
         public static IAsyncObservable<ILookup<TKey, TValue>> ToLookup<TSource, TKey, TValue>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TValue>> valueSelector)
@@ -45,7 +53,11 @@ namespace System.Reactive.Linq
             if (valueSelector == null)
                 throw new ArgumentNullException(nameof(valueSelector));
 
-            return Create<ILookup<TKey, TValue>>(observer => source.SubscribeSafeAsync(AsyncObserver.ToLookup(observer, keySelector, valueSelector)));
+            return Create(
+                source,
+                (keySelector, valueSelector),
+                default(ILookup<TKey, TValue>),
+                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToLookup(observer, state.keySelector, state.valueSelector)));
         }
 
         public static IAsyncObservable<ILookup<TKey, TValue>> ToLookup<TSource, TKey, TValue>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TValue>> valueSelector, IEqualityComparer<TKey> comparer)
@@ -59,7 +71,11 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create<ILookup<TKey, TValue>>(observer => source.SubscribeSafeAsync(AsyncObserver.ToLookup(observer, keySelector, valueSelector, comparer)));
+            return Create(
+                source,
+                (keySelector, valueSelector, comparer),
+                default(ILookup<TKey, TValue>),
+                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToLookup(observer, state.keySelector, state.valueSelector, state.comparer)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ToLookup.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ToLookup.cs
@@ -23,7 +23,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, valueSelector),
                 default(ILookup<TKey, TValue>),
-                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToLookup(observer, state.keySelector, state.valueSelector)));
+                static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToLookup(observer, state.keySelector, state.valueSelector)));
         }
 
         public static IAsyncObservable<ILookup<TKey, TValue>> ToLookup<TSource, TKey, TValue>(this IAsyncObservable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> valueSelector, IEqualityComparer<TKey> comparer)
@@ -41,7 +41,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, valueSelector, comparer),
                 default(ILookup<TKey, TValue>),
-                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToLookup(observer, state.keySelector, state.valueSelector, state.comparer)));
+                static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToLookup(observer, state.keySelector, state.valueSelector, state.comparer)));
         }
 
         public static IAsyncObservable<ILookup<TKey, TValue>> ToLookup<TSource, TKey, TValue>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TValue>> valueSelector)
@@ -57,7 +57,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, valueSelector),
                 default(ILookup<TKey, TValue>),
-                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToLookup(observer, state.keySelector, state.valueSelector)));
+                static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToLookup(observer, state.keySelector, state.valueSelector)));
         }
 
         public static IAsyncObservable<ILookup<TKey, TValue>> ToLookup<TSource, TKey, TValue>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<TKey>> keySelector, Func<TSource, ValueTask<TValue>> valueSelector, IEqualityComparer<TKey> comparer)
@@ -75,7 +75,7 @@ namespace System.Reactive.Linq
                 source,
                 (keySelector, valueSelector, comparer),
                 default(ILookup<TKey, TValue>),
-                (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToLookup(observer, state.keySelector, state.valueSelector, state.comparer)));
+                static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToLookup(observer, state.keySelector, state.valueSelector, state.comparer)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ToLookup.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/ToLookup.cs
@@ -19,10 +19,9 @@ namespace System.Reactive.Linq
             if (valueSelector == null)
                 throw new ArgumentNullException(nameof(valueSelector));
 
-            return Create(
+            return Build<ILookup<TKey, TValue>>.From(
                 source,
                 (keySelector, valueSelector),
-                default(ILookup<TKey, TValue>),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToLookup(observer, state.keySelector, state.valueSelector)));
         }
 
@@ -37,10 +36,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build<ILookup<TKey, TValue>>.From(
                 source,
                 (keySelector, valueSelector, comparer),
-                default(ILookup<TKey, TValue>),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToLookup(observer, state.keySelector, state.valueSelector, state.comparer)));
         }
 
@@ -53,10 +51,9 @@ namespace System.Reactive.Linq
             if (valueSelector == null)
                 throw new ArgumentNullException(nameof(valueSelector));
 
-            return Create(
+            return Build<ILookup<TKey, TValue>>.From(
                 source,
                 (keySelector, valueSelector),
-                default(ILookup<TKey, TValue>),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToLookup(observer, state.keySelector, state.valueSelector)));
         }
 
@@ -71,10 +68,9 @@ namespace System.Reactive.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return Build<ILookup<TKey, TValue>>.From(
                 source,
                 (keySelector, valueSelector, comparer),
-                default(ILookup<TKey, TValue>),
                 static (source, state, observer) => source.SubscribeSafeAsync(AsyncObserver.ToLookup(observer, state.keySelector, state.valueSelector, state.comparer)));
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Where.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Where.cs
@@ -19,7 +19,7 @@ namespace System.Reactive.Linq
                 source,
                 predicate,
                 default(TSource),
-                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Where(observer, predicate)));
+                static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Where(observer, predicate)));
         }
 
         public static IAsyncObservable<TSource> Where<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
@@ -33,7 +33,7 @@ namespace System.Reactive.Linq
                 source,
                 predicate,
                 default(TSource),
-                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Where(observer, predicate)));
+                static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Where(observer, predicate)));
         }
 
         public static IAsyncObservable<TSource> Where<TSource>(this IAsyncObservable<TSource> source, Func<TSource, int, bool> predicate)
@@ -47,7 +47,7 @@ namespace System.Reactive.Linq
                 source,
                 predicate,
                 default(TSource),
-                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Where(observer, predicate)));
+                static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Where(observer, predicate)));
         }
 
         public static IAsyncObservable<TSource> Where<TSource>(this IAsyncObservable<TSource> source, Func<TSource, int, ValueTask<bool>> predicate)
@@ -61,7 +61,7 @@ namespace System.Reactive.Linq
                 source,
                 predicate,
                 default(TSource),
-                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Where(observer, predicate)));
+                static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Where(observer, predicate)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Where.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Where.cs
@@ -15,10 +15,9 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 predicate,
-                default(TSource),
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Where(observer, predicate)));
         }
 
@@ -29,10 +28,9 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 predicate,
-                default(TSource),
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Where(observer, predicate)));
         }
 
@@ -43,10 +41,9 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 predicate,
-                default(TSource),
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Where(observer, predicate)));
         }
 
@@ -57,10 +54,9 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(
+            return Build<TSource>.From(
                 source,
                 predicate,
-                default(TSource),
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Where(observer, predicate)));
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Where.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Where.cs
@@ -15,7 +15,7 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 predicate,
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Where(observer, predicate)));
@@ -28,7 +28,7 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 predicate,
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Where(observer, predicate)));
@@ -41,7 +41,7 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 predicate,
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Where(observer, predicate)));
@@ -54,7 +54,7 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Build<TSource>.From(
+            return CreateAsyncObservable<TSource>.From(
                 source,
                 predicate,
                 static (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Where(observer, predicate)));

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Where.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Where.cs
@@ -15,7 +15,11 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.Where(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                default(TSource),
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Where(observer, predicate)));
         }
 
         public static IAsyncObservable<TSource> Where<TSource>(this IAsyncObservable<TSource> source, Func<TSource, ValueTask<bool>> predicate)
@@ -25,7 +29,11 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.Where(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                default(TSource),
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Where(observer, predicate)));
         }
 
         public static IAsyncObservable<TSource> Where<TSource>(this IAsyncObservable<TSource> source, Func<TSource, int, bool> predicate)
@@ -35,7 +43,11 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.Where(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                default(TSource),
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Where(observer, predicate)));
         }
 
         public static IAsyncObservable<TSource> Where<TSource>(this IAsyncObservable<TSource> source, Func<TSource, int, ValueTask<bool>> predicate)
@@ -45,7 +57,11 @@ namespace System.Reactive.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create<TSource>(observer => source.SubscribeSafeAsync(AsyncObserver.Where(observer, predicate)));
+            return Create(
+                source,
+                predicate,
+                default(TSource),
+                (source, predicate, observer) => source.SubscribeSafeAsync(AsyncObserver.Where(observer, predicate)));
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Window.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Window.cs
@@ -20,7 +20,11 @@ namespace System.Reactive.Linq
             if (count <= 0)
                 throw new ArgumentOutOfRangeException(nameof(count));
 
-            return Create<IAsyncObservable<TSource>>(observer => WindowCore(source, observer, (o, d) => AsyncObserver.Window(o, d, count)));
+            return Create(
+                source,
+                count,
+                default(IAsyncObservable<TSource>),
+                (source, count, observer) => WindowCore(source, observer, (o, d) => AsyncObserver.Window(o, d, count)));
         }
 
         public static IAsyncObservable<IAsyncObservable<TSource>> Window<TSource>(this IAsyncObservable<TSource> source, int count, int skip)
@@ -32,7 +36,11 @@ namespace System.Reactive.Linq
             if (skip <= 0)
                 throw new ArgumentOutOfRangeException(nameof(skip));
 
-            return Create<IAsyncObservable<TSource>>(observer => WindowCore(source, observer, (o, d) => AsyncObserver.Window(o, d, count, skip)));
+            return Create(
+                source,
+                (count, skip),
+                default(IAsyncObservable<TSource>),
+                (source, state, observer) => WindowCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.count, state.skip)));
         }
 
         public static IAsyncObservable<IAsyncObservable<TSource>> Window<TSource>(this IAsyncObservable<TSource> source, TimeSpan timeSpan)
@@ -42,7 +50,11 @@ namespace System.Reactive.Linq
             if (timeSpan < TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException(nameof(timeSpan));
 
-            return Create<IAsyncObservable<TSource>>(observer => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, timeSpan)));
+            return Create(
+                source,
+                timeSpan,
+                default(IAsyncObservable<TSource>),
+                (source, timeSpan, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, timeSpan)));
         }
 
         public static IAsyncObservable<IAsyncObservable<TSource>> Window<TSource>(this IAsyncObservable<TSource> source, TimeSpan timeSpan, IAsyncScheduler scheduler)
@@ -54,7 +66,11 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Create<IAsyncObservable<TSource>>(observer => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, timeSpan, scheduler)));
+            return Create(
+                source,
+                (timeSpan, scheduler),
+                default(IAsyncObservable<TSource>),
+                (source, state, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.timeSpan, state.scheduler)));
         }
 
         public static IAsyncObservable<IAsyncObservable<TSource>> Window<TSource>(this IAsyncObservable<TSource> source, TimeSpan timeSpan, TimeSpan timeShift)
@@ -66,7 +82,11 @@ namespace System.Reactive.Linq
             if (timeShift < TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException(nameof(timeShift));
 
-            return Create<IAsyncObservable<TSource>>(observer => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, timeSpan, timeShift)));
+            return Create(
+                source,
+                (timeSpan, timeShift),
+                default(IAsyncObservable<TSource>),
+                (source, state, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.timeSpan, state.timeShift)));
         }
 
         public static IAsyncObservable<IAsyncObservable<TSource>> Window<TSource>(this IAsyncObservable<TSource> source, TimeSpan timeSpan, TimeSpan timeShift, IAsyncScheduler scheduler)
@@ -80,7 +100,11 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Create<IAsyncObservable<TSource>>(observer => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, timeSpan, timeShift, scheduler)));
+            return Create(
+                source,
+                (timeSpan, timeShift, scheduler),
+                default(IAsyncObservable<TSource>),
+                (source, state, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.timeSpan, state.timeShift, state.scheduler)));
         }
 
         public static IAsyncObservable<IAsyncObservable<TSource>> Window<TSource>(this IAsyncObservable<TSource> source, TimeSpan timeSpan, int count)
@@ -92,7 +116,11 @@ namespace System.Reactive.Linq
             if (count <= 0)
                 throw new ArgumentOutOfRangeException(nameof(count));
 
-            return Create<IAsyncObservable<TSource>>(observer => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, timeSpan, count)));
+            return Create(
+                source,
+                (timeSpan, count),
+                default(IAsyncObservable<TSource>),
+                (source, state, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.timeSpan, state.count)));
         }
 
         public static IAsyncObservable<IAsyncObservable<TSource>> Window<TSource>(this IAsyncObservable<TSource> source, TimeSpan timeSpan, int count, IAsyncScheduler scheduler)
@@ -106,7 +134,11 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Create<IAsyncObservable<TSource>>(observer => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, timeSpan, count, scheduler)));
+            return Create(
+                source,
+                (timeSpan, count, scheduler),
+                default(IAsyncObservable<TSource>),
+                (source, state, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.timeSpan, state.count, state.scheduler)));
         }
 
         public static IAsyncObservable<IAsyncObservable<TSource>> Window<TSource, TWindowBoundary>(this IAsyncObservable<TSource> source, IAsyncObservable<TWindowBoundary> windowBoundaries)
@@ -116,20 +148,24 @@ namespace System.Reactive.Linq
             if (windowBoundaries == null)
                 throw new ArgumentNullException(nameof(windowBoundaries));
 
-            return Create<IAsyncObservable<TSource>>(async observer =>
-            {
-                var d = new CompositeAsyncDisposable();
+            return Create(
+                source,
+                windowBoundaries,
+                default(IAsyncObservable<TSource>),
+                async (source, windowBoundaries, observer) =>
+                {
+                    var d = new CompositeAsyncDisposable();
 
-                var (sourceObserver, boundariesObserver, subscription) = await AsyncObserver.Window<TSource, TWindowBoundary>(observer, d).ConfigureAwait(false);
+                    var (sourceObserver, boundariesObserver, subscription) = await AsyncObserver.Window<TSource, TWindowBoundary>(observer, d).ConfigureAwait(false);
 
-                var sourceSubscription = await source.SubscribeSafeAsync(sourceObserver).ConfigureAwait(false);
-                await d.AddAsync(sourceSubscription).ConfigureAwait(false);
+                    var sourceSubscription = await source.SubscribeSafeAsync(sourceObserver).ConfigureAwait(false);
+                    await d.AddAsync(sourceSubscription).ConfigureAwait(false);
 
-                var boundariesSubscription = await windowBoundaries.SubscribeSafeAsync(boundariesObserver).ConfigureAwait(false);
-                await d.AddAsync(boundariesSubscription).ConfigureAwait(false);
+                    var boundariesSubscription = await windowBoundaries.SubscribeSafeAsync(boundariesObserver).ConfigureAwait(false);
+                    await d.AddAsync(boundariesSubscription).ConfigureAwait(false);
 
-                return subscription;
-            });
+                    return subscription;
+                });
         }
 
         // REVIEW: This overload is inherited from Rx but arguably a bit esoteric as it doesn't provide context to the closing selector.
@@ -141,19 +177,23 @@ namespace System.Reactive.Linq
             if (windowClosingSelector == null)
                 throw new ArgumentNullException(nameof(windowClosingSelector));
 
-            return Create<IAsyncObservable<TSource>>(async observer =>
-            {
-                var d = new CompositeAsyncDisposable();
+            return Create(
+                source,
+                windowClosingSelector,
+                default(IAsyncObservable<TSource>),
+                async (source, windowClosingSelector, observer) =>
+                {
+                    var d = new CompositeAsyncDisposable();
 
-                var (sourceObserver, closingSubscription, subscription) = await AsyncObserver.Window<TSource, TWindowClosing>(observer, windowClosingSelector, d).ConfigureAwait(false);
+                    var (sourceObserver, closingSubscription, subscription) = await AsyncObserver.Window<TSource, TWindowClosing>(observer, windowClosingSelector, d).ConfigureAwait(false);
 
-                await d.AddAsync(closingSubscription).ConfigureAwait(false);
+                    await d.AddAsync(closingSubscription).ConfigureAwait(false);
 
-                var sourceSubscription = await source.SubscribeSafeAsync(sourceObserver).ConfigureAwait(false);
-                await d.AddAsync(sourceSubscription).ConfigureAwait(false);
+                    var sourceSubscription = await source.SubscribeSafeAsync(sourceObserver).ConfigureAwait(false);
+                    await d.AddAsync(sourceSubscription).ConfigureAwait(false);
 
-                return subscription;
-            });
+                    return subscription;
+                });
         }
 
         private static async ValueTask<IAsyncDisposable> WindowCore<TSource>(IAsyncObservable<TSource> source, IAsyncObserver<IAsyncObservable<TSource>> observer, Func<IAsyncObserver<IAsyncObservable<TSource>>, IAsyncDisposable, (IAsyncObserver<TSource>, IAsyncDisposable)> createObserver)

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Window.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Window.cs
@@ -20,7 +20,7 @@ namespace System.Reactive.Linq
             if (count <= 0)
                 throw new ArgumentOutOfRangeException(nameof(count));
 
-            return Build<IAsyncObservable<TSource>>.From(
+            return CreateAsyncObservable<IAsyncObservable<TSource>>.From(
                 source,
                 count,
                 static (source, count, observer) => WindowCore(source, observer, (o, d) => AsyncObserver.Window(o, d, count)));
@@ -35,7 +35,7 @@ namespace System.Reactive.Linq
             if (skip <= 0)
                 throw new ArgumentOutOfRangeException(nameof(skip));
 
-            return Build<IAsyncObservable<TSource>>.From(
+            return CreateAsyncObservable<IAsyncObservable<TSource>>.From(
                 source,
                 (count, skip),
                 static (source, state, observer) => WindowCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.count, state.skip)));
@@ -48,7 +48,7 @@ namespace System.Reactive.Linq
             if (timeSpan < TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException(nameof(timeSpan));
 
-            return Build<IAsyncObservable<TSource>>.From(
+            return CreateAsyncObservable<IAsyncObservable<TSource>>.From(
                 source,
                 timeSpan,
                 static (source, timeSpan, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, timeSpan)));
@@ -63,7 +63,7 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Build<IAsyncObservable<TSource>>.From(
+            return CreateAsyncObservable<IAsyncObservable<TSource>>.From(
                 source,
                 (timeSpan, scheduler),
                 static (source, state, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.timeSpan, state.scheduler)));
@@ -78,7 +78,7 @@ namespace System.Reactive.Linq
             if (timeShift < TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException(nameof(timeShift));
 
-            return Build<IAsyncObservable<TSource>>.From(
+            return CreateAsyncObservable<IAsyncObservable<TSource>>.From(
                 source,
                 (timeSpan, timeShift),
                 static (source, state, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.timeSpan, state.timeShift)));
@@ -95,7 +95,7 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Build<IAsyncObservable<TSource>>.From(
+            return CreateAsyncObservable<IAsyncObservable<TSource>>.From(
                 source,
                 (timeSpan, timeShift, scheduler),
                 static (source, state, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.timeSpan, state.timeShift, state.scheduler)));
@@ -110,7 +110,7 @@ namespace System.Reactive.Linq
             if (count <= 0)
                 throw new ArgumentOutOfRangeException(nameof(count));
 
-            return Build<IAsyncObservable<TSource>>.From(
+            return CreateAsyncObservable<IAsyncObservable<TSource>>.From(
                 source,
                 (timeSpan, count),
                 static (source, state, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.timeSpan, state.count)));
@@ -127,7 +127,7 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Build<IAsyncObservable<TSource>>.From(
+            return CreateAsyncObservable<IAsyncObservable<TSource>>.From(
                 source,
                 (timeSpan, count, scheduler),
                 static (source, state, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.timeSpan, state.count, state.scheduler)));
@@ -140,7 +140,7 @@ namespace System.Reactive.Linq
             if (windowBoundaries == null)
                 throw new ArgumentNullException(nameof(windowBoundaries));
 
-            return Build<IAsyncObservable<TSource>>.From(
+            return CreateAsyncObservable<IAsyncObservable<TSource>>.From(
                 source,
                 windowBoundaries,
                 static async (source, windowBoundaries, observer) =>
@@ -168,7 +168,7 @@ namespace System.Reactive.Linq
             if (windowClosingSelector == null)
                 throw new ArgumentNullException(nameof(windowClosingSelector));
 
-            return Build<IAsyncObservable<TSource>>.From(
+            return CreateAsyncObservable<IAsyncObservable<TSource>>.From(
                 source,
                 windowClosingSelector,
                 static async (source, windowClosingSelector, observer) =>

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Window.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Window.cs
@@ -20,10 +20,9 @@ namespace System.Reactive.Linq
             if (count <= 0)
                 throw new ArgumentOutOfRangeException(nameof(count));
 
-            return Create(
+            return Build<IAsyncObservable<TSource>>.From(
                 source,
                 count,
-                default(IAsyncObservable<TSource>),
                 static (source, count, observer) => WindowCore(source, observer, (o, d) => AsyncObserver.Window(o, d, count)));
         }
 
@@ -36,10 +35,9 @@ namespace System.Reactive.Linq
             if (skip <= 0)
                 throw new ArgumentOutOfRangeException(nameof(skip));
 
-            return Create(
+            return Build<IAsyncObservable<TSource>>.From(
                 source,
                 (count, skip),
-                default(IAsyncObservable<TSource>),
                 static (source, state, observer) => WindowCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.count, state.skip)));
         }
 
@@ -50,10 +48,9 @@ namespace System.Reactive.Linq
             if (timeSpan < TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException(nameof(timeSpan));
 
-            return Create(
+            return Build<IAsyncObservable<TSource>>.From(
                 source,
                 timeSpan,
-                default(IAsyncObservable<TSource>),
                 static (source, timeSpan, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, timeSpan)));
         }
 
@@ -66,10 +63,9 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Create(
+            return Build<IAsyncObservable<TSource>>.From(
                 source,
                 (timeSpan, scheduler),
-                default(IAsyncObservable<TSource>),
                 static (source, state, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.timeSpan, state.scheduler)));
         }
 
@@ -82,10 +78,9 @@ namespace System.Reactive.Linq
             if (timeShift < TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException(nameof(timeShift));
 
-            return Create(
+            return Build<IAsyncObservable<TSource>>.From(
                 source,
                 (timeSpan, timeShift),
-                default(IAsyncObservable<TSource>),
                 static (source, state, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.timeSpan, state.timeShift)));
         }
 
@@ -100,10 +95,9 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Create(
+            return Build<IAsyncObservable<TSource>>.From(
                 source,
                 (timeSpan, timeShift, scheduler),
-                default(IAsyncObservable<TSource>),
                 static (source, state, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.timeSpan, state.timeShift, state.scheduler)));
         }
 
@@ -116,10 +110,9 @@ namespace System.Reactive.Linq
             if (count <= 0)
                 throw new ArgumentOutOfRangeException(nameof(count));
 
-            return Create(
+            return Build<IAsyncObservable<TSource>>.From(
                 source,
                 (timeSpan, count),
-                default(IAsyncObservable<TSource>),
                 static (source, state, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.timeSpan, state.count)));
         }
 
@@ -134,10 +127,9 @@ namespace System.Reactive.Linq
             if (scheduler == null)
                 throw new ArgumentNullException(nameof(scheduler));
 
-            return Create(
+            return Build<IAsyncObservable<TSource>>.From(
                 source,
                 (timeSpan, count, scheduler),
-                default(IAsyncObservable<TSource>),
                 static (source, state, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.timeSpan, state.count, state.scheduler)));
         }
 
@@ -148,10 +140,9 @@ namespace System.Reactive.Linq
             if (windowBoundaries == null)
                 throw new ArgumentNullException(nameof(windowBoundaries));
 
-            return Create(
+            return Build<IAsyncObservable<TSource>>.From(
                 source,
                 windowBoundaries,
-                default(IAsyncObservable<TSource>),
                 static async (source, windowBoundaries, observer) =>
                 {
                     var d = new CompositeAsyncDisposable();
@@ -177,10 +168,9 @@ namespace System.Reactive.Linq
             if (windowClosingSelector == null)
                 throw new ArgumentNullException(nameof(windowClosingSelector));
 
-            return Create(
+            return Build<IAsyncObservable<TSource>>.From(
                 source,
                 windowClosingSelector,
-                default(IAsyncObservable<TSource>),
                 static async (source, windowClosingSelector, observer) =>
                 {
                     var d = new CompositeAsyncDisposable();

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Window.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/Window.cs
@@ -24,7 +24,7 @@ namespace System.Reactive.Linq
                 source,
                 count,
                 default(IAsyncObservable<TSource>),
-                (source, count, observer) => WindowCore(source, observer, (o, d) => AsyncObserver.Window(o, d, count)));
+                static (source, count, observer) => WindowCore(source, observer, (o, d) => AsyncObserver.Window(o, d, count)));
         }
 
         public static IAsyncObservable<IAsyncObservable<TSource>> Window<TSource>(this IAsyncObservable<TSource> source, int count, int skip)
@@ -40,7 +40,7 @@ namespace System.Reactive.Linq
                 source,
                 (count, skip),
                 default(IAsyncObservable<TSource>),
-                (source, state, observer) => WindowCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.count, state.skip)));
+                static (source, state, observer) => WindowCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.count, state.skip)));
         }
 
         public static IAsyncObservable<IAsyncObservable<TSource>> Window<TSource>(this IAsyncObservable<TSource> source, TimeSpan timeSpan)
@@ -54,7 +54,7 @@ namespace System.Reactive.Linq
                 source,
                 timeSpan,
                 default(IAsyncObservable<TSource>),
-                (source, timeSpan, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, timeSpan)));
+                static (source, timeSpan, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, timeSpan)));
         }
 
         public static IAsyncObservable<IAsyncObservable<TSource>> Window<TSource>(this IAsyncObservable<TSource> source, TimeSpan timeSpan, IAsyncScheduler scheduler)
@@ -70,7 +70,7 @@ namespace System.Reactive.Linq
                 source,
                 (timeSpan, scheduler),
                 default(IAsyncObservable<TSource>),
-                (source, state, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.timeSpan, state.scheduler)));
+                static (source, state, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.timeSpan, state.scheduler)));
         }
 
         public static IAsyncObservable<IAsyncObservable<TSource>> Window<TSource>(this IAsyncObservable<TSource> source, TimeSpan timeSpan, TimeSpan timeShift)
@@ -86,7 +86,7 @@ namespace System.Reactive.Linq
                 source,
                 (timeSpan, timeShift),
                 default(IAsyncObservable<TSource>),
-                (source, state, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.timeSpan, state.timeShift)));
+                static (source, state, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.timeSpan, state.timeShift)));
         }
 
         public static IAsyncObservable<IAsyncObservable<TSource>> Window<TSource>(this IAsyncObservable<TSource> source, TimeSpan timeSpan, TimeSpan timeShift, IAsyncScheduler scheduler)
@@ -104,7 +104,7 @@ namespace System.Reactive.Linq
                 source,
                 (timeSpan, timeShift, scheduler),
                 default(IAsyncObservable<TSource>),
-                (source, state, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.timeSpan, state.timeShift, state.scheduler)));
+                static (source, state, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.timeSpan, state.timeShift, state.scheduler)));
         }
 
         public static IAsyncObservable<IAsyncObservable<TSource>> Window<TSource>(this IAsyncObservable<TSource> source, TimeSpan timeSpan, int count)
@@ -120,7 +120,7 @@ namespace System.Reactive.Linq
                 source,
                 (timeSpan, count),
                 default(IAsyncObservable<TSource>),
-                (source, state, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.timeSpan, state.count)));
+                static (source, state, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.timeSpan, state.count)));
         }
 
         public static IAsyncObservable<IAsyncObservable<TSource>> Window<TSource>(this IAsyncObservable<TSource> source, TimeSpan timeSpan, int count, IAsyncScheduler scheduler)
@@ -138,7 +138,7 @@ namespace System.Reactive.Linq
                 source,
                 (timeSpan, count, scheduler),
                 default(IAsyncObservable<TSource>),
-                (source, state, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.timeSpan, state.count, state.scheduler)));
+                static (source, state, observer) => WindowAsyncCore(source, observer, (o, d) => AsyncObserver.Window(o, d, state.timeSpan, state.count, state.scheduler)));
         }
 
         public static IAsyncObservable<IAsyncObservable<TSource>> Window<TSource, TWindowBoundary>(this IAsyncObservable<TSource> source, IAsyncObservable<TWindowBoundary> windowBoundaries)
@@ -152,7 +152,7 @@ namespace System.Reactive.Linq
                 source,
                 windowBoundaries,
                 default(IAsyncObservable<TSource>),
-                async (source, windowBoundaries, observer) =>
+                static async (source, windowBoundaries, observer) =>
                 {
                     var d = new CompositeAsyncDisposable();
 
@@ -181,7 +181,7 @@ namespace System.Reactive.Linq
                 source,
                 windowClosingSelector,
                 default(IAsyncObservable<TSource>),
-                async (source, windowClosingSelector, observer) =>
+                static async (source, windowClosingSelector, observer) =>
                 {
                     var d = new CompositeAsyncDisposable();
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/WithLatestFrom.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/WithLatestFrom.cs
@@ -17,10 +17,9 @@ namespace System.Reactive.Linq
             if (second == null)
                 throw new ArgumentNullException(nameof(second));
 
-            return Create(
+            return Build<(TFirst first, TSecond second)>.From(
                 first,
                 second,
-                default((TFirst first, TSecond second)),
                 static async (first, second, observer) =>
                 {
                     var (firstObserver, secondObserver) = AsyncObserver.WithLatestFrom(observer);
@@ -43,10 +42,9 @@ namespace System.Reactive.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            return Create(
+            return Build<TResult>.From(
                 first,
                 (second, resultSelector),
-                default(TResult),
                 static async (first, state, observer) =>
                 {
                     var (firstObserver, secondObserver) = AsyncObserver.WithLatestFrom(observer, state.resultSelector);
@@ -69,10 +67,9 @@ namespace System.Reactive.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            return Create(
+            return Build<TResult>.From(
                 first,
                 (second, resultSelector),
-                default(TResult),
                 static async (first, state, observer) =>
                 {
                     var (firstObserver, secondObserver) = AsyncObserver.WithLatestFrom(observer, state.resultSelector);

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/WithLatestFrom.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/WithLatestFrom.cs
@@ -17,7 +17,7 @@ namespace System.Reactive.Linq
             if (second == null)
                 throw new ArgumentNullException(nameof(second));
 
-            return Build<(TFirst first, TSecond second)>.From(
+            return CreateAsyncObservable<(TFirst first, TSecond second)>.From(
                 first,
                 second,
                 static async (first, second, observer) =>
@@ -42,7 +42,7 @@ namespace System.Reactive.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            return Build<TResult>.From(
+            return CreateAsyncObservable<TResult>.From(
                 first,
                 (second, resultSelector),
                 static async (first, state, observer) =>
@@ -67,7 +67,7 @@ namespace System.Reactive.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            return Build<TResult>.From(
+            return CreateAsyncObservable<TResult>.From(
                 first,
                 (second, resultSelector),
                 static async (first, state, observer) =>

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/WithLatestFrom.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/WithLatestFrom.cs
@@ -17,17 +17,21 @@ namespace System.Reactive.Linq
             if (second == null)
                 throw new ArgumentNullException(nameof(second));
 
-            return Create<(TFirst first, TSecond second)>(async observer =>
-            {
-                var (firstObserver, secondObserver) = AsyncObserver.WithLatestFrom(observer);
+            return Create(
+                first,
+                second,
+                default((TFirst first, TSecond second)),
+                async (first, second, observer) =>
+                {
+                    var (firstObserver, secondObserver) = AsyncObserver.WithLatestFrom(observer);
 
-                // REVIEW: Consider concurrent subscriptions.
+                    // REVIEW: Consider concurrent subscriptions.
 
-                var firstSubscription = await first.SubscribeSafeAsync(firstObserver).ConfigureAwait(false);
-                var secondSubscription = await second.SubscribeSafeAsync(secondObserver).ConfigureAwait(false);
+                    var firstSubscription = await first.SubscribeSafeAsync(firstObserver).ConfigureAwait(false);
+                    var secondSubscription = await second.SubscribeSafeAsync(secondObserver).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(firstSubscription, secondSubscription);
-            });
+                    return StableCompositeAsyncDisposable.Create(firstSubscription, secondSubscription);
+                });
         }
 
         public static IAsyncObservable<TResult> WithLatestFrom<TFirst, TSecond, TResult>(this IAsyncObservable<TFirst> first, IAsyncObservable<TSecond> second, Func<TFirst, TSecond, TResult> resultSelector)
@@ -39,17 +43,21 @@ namespace System.Reactive.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            return Create<TResult>(async observer =>
-            {
-                var (firstObserver, secondObserver) = AsyncObserver.WithLatestFrom(observer, resultSelector);
+            return Create(
+                first,
+                (second, resultSelector),
+                default(TResult),
+                async (first, state, observer) =>
+                {
+                    var (firstObserver, secondObserver) = AsyncObserver.WithLatestFrom(observer, state.resultSelector);
 
-                // REVIEW: Consider concurrent subscriptions.
+                    // REVIEW: Consider concurrent subscriptions.
 
-                var firstSubscription = await first.SubscribeSafeAsync(firstObserver).ConfigureAwait(false);
-                var secondSubscription = await second.SubscribeSafeAsync(secondObserver).ConfigureAwait(false);
+                    var firstSubscription = await first.SubscribeSafeAsync(firstObserver).ConfigureAwait(false);
+                    var secondSubscription = await state.second.SubscribeSafeAsync(secondObserver).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(firstSubscription, secondSubscription);
-            });
+                    return StableCompositeAsyncDisposable.Create(firstSubscription, secondSubscription);
+                });
         }
 
         public static IAsyncObservable<TResult> WithLatestFrom<TFirst, TSecond, TResult>(this IAsyncObservable<TFirst> first, IAsyncObservable<TSecond> second, Func<TFirst, TSecond, ValueTask<TResult>> resultSelector)
@@ -61,17 +69,21 @@ namespace System.Reactive.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            return Create<TResult>(async observer =>
-            {
-                var (firstObserver, secondObserver) = AsyncObserver.WithLatestFrom(observer, resultSelector);
+            return Create(
+                first,
+                (second, resultSelector),
+                default(TResult),
+                async (first, state, observer) =>
+                {
+                    var (firstObserver, secondObserver) = AsyncObserver.WithLatestFrom(observer, state.resultSelector);
 
-                // REVIEW: Consider concurrent subscriptions.
+                    // REVIEW: Consider concurrent subscriptions.
 
-                var firstSubscription = await first.SubscribeSafeAsync(firstObserver).ConfigureAwait(false);
-                var secondSubscription = await second.SubscribeSafeAsync(secondObserver).ConfigureAwait(false);
+                    var firstSubscription = await first.SubscribeSafeAsync(firstObserver).ConfigureAwait(false);
+                    var secondSubscription = await state.second.SubscribeSafeAsync(secondObserver).ConfigureAwait(false);
 
-                return StableCompositeAsyncDisposable.Create(firstSubscription, secondSubscription);
-            });
+                    return StableCompositeAsyncDisposable.Create(firstSubscription, secondSubscription);
+                });
         }
     }
 

--- a/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/WithLatestFrom.cs
+++ b/AsyncRx.NET/System.Reactive.Async.Linq/System/Reactive/Linq/Operators/WithLatestFrom.cs
@@ -21,7 +21,7 @@ namespace System.Reactive.Linq
                 first,
                 second,
                 default((TFirst first, TSecond second)),
-                async (first, second, observer) =>
+                static async (first, second, observer) =>
                 {
                     var (firstObserver, secondObserver) = AsyncObserver.WithLatestFrom(observer);
 
@@ -47,7 +47,7 @@ namespace System.Reactive.Linq
                 first,
                 (second, resultSelector),
                 default(TResult),
-                async (first, state, observer) =>
+                static async (first, state, observer) =>
                 {
                     var (firstObserver, secondObserver) = AsyncObserver.WithLatestFrom(observer, state.resultSelector);
 
@@ -73,7 +73,7 @@ namespace System.Reactive.Linq
                 first,
                 (second, resultSelector),
                 default(TResult),
-                async (first, state, observer) =>
+                static async (first, state, observer) =>
                 {
                     var (firstObserver, secondObserver) = AsyncObserver.WithLatestFrom(observer, state.resultSelector);
 


### PR DESCRIPTION
There's more room for improvement, especially wrt the T4-generated operators.
