### PR TITLE
Even less Disposable.Utils

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Disposables/MultipleAssignmentDisposableValue.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/MultipleAssignmentDisposableValue.cs
@@ -32,6 +32,8 @@ namespace System.Reactive.Disposables
             set => Disposables.Disposable.TrySetMultiple(ref _current, value);
         }
 
+        public bool TrySetFirst(IDisposable disposable) => Disposables.Disposable.TrySetSingle(ref _current, disposable) == TrySetSingleResult.Success;
+
         /// <summary>
         /// Disposes the underlying disposable as well as all future replacements.
         /// </summary>

--- a/Rx.NET/Source/src/System.Reactive/Disposables/SerialDisposableValue.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/SerialDisposableValue.cs
@@ -32,6 +32,8 @@ namespace System.Reactive.Disposables
             set => Disposables.Disposable.TrySetSerial(ref _current, value);
         }
 
+        public bool TrySetFirst(IDisposable disposable) => Disposables.Disposable.TrySetSingle(ref _current, disposable) == TrySetSingleResult.Success;
+
         /// <summary>
         /// Disposes the underlying disposable as well as all future replacements.
         /// </summary>

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/AppendPrepend.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/AppendPrepend.cs
@@ -367,7 +367,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 private readonly Node<TSource>? _appends;
                 private readonly ISchedulerLongRunning _scheduler;
 
-                private IDisposable? _schedulerDisposable;
+                private SerialDisposableValue _schedulerDisposable;
 
                 public _(LongRunning parent, IObserver<TSource> observer)
                     : base(observer)
@@ -387,7 +387,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     else
                     {
                         var disposable = _scheduler.ScheduleLongRunning(this, static (@this, cancel) => @this.PrependValues(cancel));
-                        Disposable.TrySetSingle(ref _schedulerDisposable, disposable);
+                        _schedulerDisposable.TrySetFirst(disposable);
                     }
                 }
 
@@ -400,7 +400,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     else
                     {
                         var disposable = _scheduler.ScheduleLongRunning(this, static (@this, cancel) => @this.AppendValues(cancel));
-                        Disposable.TrySetSerial(ref _schedulerDisposable, disposable);
+                        _schedulerDisposable.Disposable = disposable;
                     }
                 }
 
@@ -408,7 +408,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 {
                     if (disposing)
                     {
-                        Disposable.Dispose(ref _schedulerDisposable);
+                        _schedulerDisposable.Dispose();
                     }
 
                     base.Dispose(disposing);

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Catch.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Catch.cs
@@ -97,18 +97,18 @@ namespace System.Reactive.Linq.ObservableImpl
             }
 
             private bool _once;
-            private IDisposable? _subscription;
+            private SerialDisposableValue _subscription;
 
             public override void Run(IObservable<TSource> source)
             {
-                Disposable.TrySetSingle(ref _subscription, source.SubscribeSafe(this));
+                _subscription.TrySetFirst(source.SubscribeSafe(this));
             }
 
             protected override void Dispose(bool disposing)
             {
                 if (disposing)
                 {
-                    Disposable.Dispose(ref _subscription);
+                    _subscription.Dispose();
                 }
 
                 base.Dispose(disposing);
@@ -130,7 +130,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     }
 
                     Volatile.Write(ref _once, true);
-                    Disposable.TrySetSerial(ref _subscription, result.SubscribeSafe(this));
+                    _subscription.Disposable = result.SubscribeSafe(this);
                 }
                 else
                 {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Range.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Range.cs
@@ -28,7 +28,7 @@ namespace System.Reactive.Linq.ObservableImpl
         {
             private readonly int _end;
             private int _index;
-            private IDisposable? _task;
+            private MultipleAssignmentDisposableValue _task;
 
             public RangeSink(int start, int count, IObserver<int> observer)
                 : base(observer)
@@ -40,7 +40,7 @@ namespace System.Reactive.Linq.ObservableImpl
             public void Run(IScheduler scheduler)
             {
                 var first = scheduler.Schedule(this, static (innerScheduler, @this) => @this.LoopRec(innerScheduler));
-                Disposable.TrySetSingle(ref _task, first);
+                _task.TrySetFirst(first);
             }
 
             protected override void Dispose(bool disposing)
@@ -48,7 +48,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 base.Dispose(disposing);
                 if (disposing)
                 {
-                    Disposable.Dispose(ref _task);
+                    _task.Dispose();
                 }
             }
 
@@ -61,7 +61,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     _index = idx + 1;
                     ForwardOnNext(idx);
                     var next = scheduler.Schedule(this, static (innerScheduler, @this) => @this.LoopRec(innerScheduler));
-                    Disposable.TrySetMultiple(ref _task, next);
+                    _task.Disposable = next;
                 }
                 else
                 {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Repeat.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Repeat.cs
@@ -28,7 +28,7 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 private readonly TResult _value;
 
-                private IDisposable? _task;
+                private MultipleAssignmentDisposableValue _task;
 
                 public _(TResult value, IObserver<TResult> observer)
                     : base(observer)
@@ -39,7 +39,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 public void Run(IScheduler scheduler)
                 {
                     var first = scheduler.Schedule(this, static (innerScheduler, @this) => @this.LoopRecInf(innerScheduler));
-                    Disposable.TrySetSingle(ref _task, first);
+                    _task.TrySetFirst(first);
                 }
 
                 protected override void Dispose(bool disposing)
@@ -48,7 +48,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                     if (disposing)
                     {
-                        Disposable.Dispose(ref _task);
+                        _task.Dispose();
                     }
                 }
 
@@ -57,7 +57,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     ForwardOnNext(_value);
 
                     var next = scheduler.Schedule(this, static (innerScheduler, @this) => @this.LoopRecInf(innerScheduler));
-                    Disposable.TrySetMultiple(ref _task, next);
+                    _task.Disposable = next;
 
                     return Disposable.Empty;
                 }
@@ -130,7 +130,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 private int _remaining;
 
-                private IDisposable? _task;
+                private MultipleAssignmentDisposableValue _task;
 
                 public _(TResult value, int repeatCount, IObserver<TResult> observer)
                     : base(observer)
@@ -142,7 +142,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 public void Run(IScheduler scheduler)
                 {
                     var first = scheduler.Schedule(this, static (innerScheduler, @this) => @this.LoopRec(innerScheduler));
-                    Disposable.TrySetSingle(ref _task, first);
+                    _task.TrySetFirst(first);
                 }
 
                 protected override void Dispose(bool disposing)
@@ -151,7 +151,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                     if (disposing)
                     {
-                        Disposable.Dispose(ref _task);
+                        _task.Dispose();
                     }
                 }
 
@@ -171,7 +171,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     else
                     {
                         var next = scheduler.Schedule(this, static (innerScheduler, @this) => @this.LoopRec(innerScheduler));
-                        Disposable.TrySetMultiple(ref _task, next);
+                        _task.Disposable = next;
                     }
 
                     return Disposable.Empty;


### PR DESCRIPTION
Contains previous unmerged work.

Introduces TrySetFirst methods on (Serial, Multiple)DisposableValue to make mixed usage scenarios possible.
What remains are usages that mostly observe the Try... return value or do custom Interlocked logic. This can possibly be mitigated too but it's not as mechanic as these previous changes.

GetValue - 1 reference (was 1)
GetValueOrDefault - 2 references (was 2)
SetSingle - no references (was none)
TrySetSingle - 6 references (was 19)
TrySetMultiple - 5 references (was 11)
TrySetSerial - 6 references (was 14)
GetIsDisposed - no references (was none )
Dispose - 12 references (was 25)