### PR TITLE
Change signature of Observable.FirstOrDefaultAsync to a IObservable<TSource?> return type.

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Linq/IQueryLanguage.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/IQueryLanguage.cs
@@ -54,8 +54,8 @@ namespace System.Reactive.Linq
         IObservable<TSource> ElementAtOrDefault<TSource>(IObservable<TSource> source, int index);
         IObservable<TSource> FirstAsync<TSource>(IObservable<TSource> source);
         IObservable<TSource> FirstAsync<TSource>(IObservable<TSource> source, Func<TSource, bool> predicate);
-        IObservable<TSource> FirstOrDefaultAsync<TSource>(IObservable<TSource> source);
-        IObservable<TSource> FirstOrDefaultAsync<TSource>(IObservable<TSource> source, Func<TSource, bool> predicate);
+        IObservable<TSource?> FirstOrDefaultAsync<TSource>(IObservable<TSource> source);
+        IObservable<TSource?> FirstOrDefaultAsync<TSource>(IObservable<TSource> source, Func<TSource, bool> predicate);
         IObservable<bool> IsEmpty<TSource>(IObservable<TSource> source);
         IObservable<TSource> LastAsync<TSource>(IObservable<TSource> source);
         IObservable<TSource> LastAsync<TSource>(IObservable<TSource> source, Func<TSource, bool> predicate);

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable.Aggregates.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable.Aggregates.cs
@@ -827,7 +827,7 @@ namespace System.Reactive.Linq
         /// <param name="source">Source observable sequence.</param>
         /// <returns>Sequence containing the first element in the observable sequence, or a default value if no such element exists.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
-        public static IObservable<TSource> FirstOrDefaultAsync<TSource>(this IObservable<TSource> source)
+        public static IObservable<TSource?> FirstOrDefaultAsync<TSource>(this IObservable<TSource> source)
         {
             if (source == null)
             {
@@ -845,7 +845,7 @@ namespace System.Reactive.Linq
         /// <param name="predicate">A predicate function to evaluate for elements in the source sequence.</param>
         /// <returns>Sequence containing the first element in the observable sequence that satisfies the condition in the predicate, or a default value if no such element exists.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="predicate"/> is null.</exception>
-        public static IObservable<TSource> FirstOrDefaultAsync<TSource>(this IObservable<TSource> source, Func<TSource, bool> predicate)
+        public static IObservable<TSource?> FirstOrDefaultAsync<TSource>(this IObservable<TSource> source, Func<TSource, bool> predicate)
         {
             if (source == null)
             {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/FirstOrDefaultAsync.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/FirstOrDefaultAsync.cs
@@ -6,7 +6,7 @@ namespace System.Reactive.Linq.ObservableImpl
 {
     internal static class FirstOrDefaultAsync<TSource>
     {
-        internal sealed class Sequence : Producer<TSource, Sequence._>
+        internal sealed class Sequence : Producer<TSource?, Sequence._>
         {
             private readonly IObservable<TSource> _source;
 
@@ -15,13 +15,13 @@ namespace System.Reactive.Linq.ObservableImpl
                 _source = source;
             }
 
-            protected override _ CreateSink(IObserver<TSource> observer) => new _(observer);
+            protected override _ CreateSink(IObserver<TSource?> observer) => new _(observer);
 
             protected override void Run(_ sink) => sink.Run(_source);
 
-            internal sealed class _ : IdentitySink<TSource>
+            internal sealed class _ : Sink<TSource, TSource?>
             {
-                public _(IObserver<TSource> observer)
+                public _(IObserver<TSource?> observer)
                     : base(observer)
                 {
                 }
@@ -34,13 +34,13 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public override void OnCompleted()
                 {
-                    ForwardOnNext(default!);
+                    ForwardOnNext(default);
                     ForwardOnCompleted();
                 }
             }
         }
 
-        internal sealed class Predicate : Producer<TSource, Predicate._>
+        internal sealed class Predicate : Producer<TSource?, Predicate._>
         {
             private readonly IObservable<TSource> _source;
             private readonly Func<TSource, bool> _predicate;
@@ -51,15 +51,15 @@ namespace System.Reactive.Linq.ObservableImpl
                 _predicate = predicate;
             }
 
-            protected override _ CreateSink(IObserver<TSource> observer) => new _(_predicate, observer);
+            protected override _ CreateSink(IObserver<TSource?> observer) => new _(_predicate, observer);
 
             protected override void Run(_ sink) => sink.Run(_source);
 
-            internal sealed class _ : IdentitySink<TSource>
+            internal sealed class _ : Sink<TSource, TSource?>
             {
                 private readonly Func<TSource, bool> _predicate;
 
-                public _(Func<TSource, bool> predicate, IObserver<TSource> observer)
+                public _(Func<TSource, bool> predicate, IObserver<TSource?> observer)
                     : base(observer)
                 {
                     _predicate = predicate;
@@ -88,7 +88,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public override void OnCompleted()
                 {
-                    ForwardOnNext(default!);
+                    ForwardOnNext(default);
                     ForwardOnCompleted();
                 }
             }

--- a/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Aggregates.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Aggregates.cs
@@ -219,12 +219,12 @@ namespace System.Reactive.Linq
 
         #region + FirstAsyncOrDefaultAsync +
 
-        public virtual IObservable<TSource> FirstOrDefaultAsync<TSource>(IObservable<TSource> source)
+        public virtual IObservable<TSource?> FirstOrDefaultAsync<TSource>(IObservable<TSource> source)
         {
             return new FirstOrDefaultAsync<TSource>.Sequence(source);
         }
 
-        public virtual IObservable<TSource> FirstOrDefaultAsync<TSource>(IObservable<TSource> source, Func<TSource, bool> predicate)
+        public virtual IObservable<TSource?> FirstOrDefaultAsync<TSource>(IObservable<TSource> source, Func<TSource, bool> predicate)
         {
             return new FirstOrDefaultAsync<TSource>.Predicate(source, predicate);
         }

--- a/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Api/ApiApprovalTests.Core.verified.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Api/ApiApprovalTests.Core.verified.cs
@@ -1035,8 +1035,8 @@ namespace System.Reactive.Linq
         [System.Obsolete(@"This blocking operation is no longer supported. Instead, use the async version in combination with C# and Visual Basic async/await support. In case you need a blocking operation, use Wait or convert the resulting observable sequence to a Task object and block.")]
         [return: System.Diagnostics.CodeAnalysis.MaybeNull]
         public static TSource FirstOrDefault<TSource>(this System.IObservable<TSource> source, System.Func<TSource, bool> predicate) { }
-        public static System.IObservable<TSource> FirstOrDefaultAsync<TSource>(this System.IObservable<TSource> source) { }
-        public static System.IObservable<TSource> FirstOrDefaultAsync<TSource>(this System.IObservable<TSource> source, System.Func<TSource, bool> predicate) { }
+        public static System.IObservable<TSource?> FirstOrDefaultAsync<TSource>(this System.IObservable<TSource> source) { }
+        public static System.IObservable<TSource?> FirstOrDefaultAsync<TSource>(this System.IObservable<TSource> source, System.Func<TSource, bool> predicate) { }
         public static System.IObservable<TResult> For<TSource, TResult>(System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, System.IObservable<TResult>> resultSelector) { }
         [System.Obsolete(@"This blocking operation is no longer supported. Instead, use the async version in combination with C# and Visual Basic async/await support. In case you need a blocking operation, use Wait or convert the resulting observable sequence to a Task object and block.")]
         public static void ForEach<TSource>(this System.IObservable<TSource> source, System.Action<TSource> onNext) { }


### PR DESCRIPTION
API approval file has changed! Not sure if nullability on the surface is already considered breaking. But this is the only correct method signature.

More to come.