### PR TITLE
Add build error to help users know they need to retarget to 19041 when targeting net5.0-windows

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
+++ b/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
@@ -184,10 +184,11 @@
 
   <ItemGroup>
     <None Include="build\_._" PackagePath="lib\netcoreapp3.1" Pack="true" />
-    <None Include="build\_._" PackagePath="build\net5.0" Pack="true" />
-    <None Include="build\_._" PackagePath="buildTransitive\net5.0" Pack="true" />
+    <None Include="build\_._" PackagePath="build\net5.0;build\net5.0-windows10.0.19041" Pack="true" />
+    <None Include="build\_._" PackagePath="buildTransitive\net5.0;buildTransitive\net5.0-windows10.0.19041" Pack="true" />
     <None Include="build\System.Reactive.targets" PackagePath="buildTransitive\netcoreapp3.1" Pack="true" />
     <None Include="build\System.Reactive.targets" PackagePath="build\netcoreapp3.1" Pack="true" />
+	<None Include="build\System.Reactive.net5.0-windows.targets" PackagePath="build\net5.0-windows\$(PackageId).targets;buildTransitive\net5.0-windows\$(PackageId).targets" Pack="true" />
     <None Include="Linq\QbservableEx.NAry.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/Rx.NET/Source/src/System.Reactive/build/System.Reactive.net5.0-windows.targets
+++ b/Rx.NET/Source/src/System.Reactive/build/System.Reactive.net5.0-windows.targets
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+   
+  <Target Name="_RXNETWindowsTFMCheck" BeforeTargets="ResolveAssemblyReferences;Build;Rebuild">
+    <Error 
+        Text = "The 'System.Reactive' nuget package cannot be used to target '$(TargetFramework)'. Target 'net5.0-windows10.0.19041' or later instead." />
+  </Target>
+  
+</Project>


### PR DESCRIPTION
#### Enhancement

When users target .net5-windows, they won't get the right assembly added. This change helps them realize that they need to target `net5.0-windows10.0.19041` by introducing a build error for anything between `[net5.0-windows..net5.0-windows10.0.19041[`.

Submitted by request from @clairernovotny

![image](https://user-images.githubusercontent.com/1378165/99990663-f4b0ac80-2d68-11eb-9b78-d164fda91e9a.png)
![image](https://user-images.githubusercontent.com/1378165/99990715-042ff580-2d69-11eb-9abe-365122c341aa.png)
