### PR TITLE
Remove redundant NuGet package references.

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
+++ b/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
@@ -35,18 +35,7 @@
     <None Update="Platforms\Windows\Strings_WindowsThreading.resx" CustomToolNamespace="System.Reactive" Generator="ResXFileCodeGenerator" LastGenOutput="Strings_WindowsThreading.Designer.cs" />
   </ItemGroup>
 
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Runtime.InteropServices.WindowsRuntime" Version="4.3.0" />
-  </ItemGroup>
-
   <!-- UWP -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="System.ComponentModel" Version="4.3.0" />
-    <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
-    <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
-  </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('uap10.0')) or $(TargetFramework.StartsWith('net5.0-windows'))">
     <Compile Include="Platforms\UWP\**\*.cs" />
   </ItemGroup>


### PR DESCRIPTION
`System.Runtime.InteropServices.WindowsRuntime` was added 3 and a half years ago in https://github.com/dotnet/reactive/commit/9534e68caf0d877ba0c010da8e0ba4eeda76fffe with no clear reason why. The package itself hasn't been updated since November 2016. Its presence bloats the package dependency graph and might pose problems for those who need their package dependencies to have SPDX license expressions.