### PR TITLE
fix: OfType now accepts a collection of object?

### DIFF
--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/OfType.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/OfType.cs
@@ -1,6 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
-// See the LICENSE file in the project root for more information. 
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;
@@ -37,6 +37,18 @@ namespace Tests
 
             var e = ys.GetAsyncEnumerator();
             await HasNextAsync(e, "bar");
+            await HasNextAsync(e, "foo");
+            await NoNextAsync(e);
+        }
+
+        [Fact]
+        public async Task OfType_NotNullObject()
+        {
+            var xs = new object?[] { 42, null, "foo", null }.ToAsyncEnumerable();
+            var ys = xs.OfType<object>();
+
+            var e = ys.GetAsyncEnumerator();
+            await HasNextAsync(e, 42);
             await HasNextAsync(e, "foo");
             await NoNextAsync(e);
         }

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/OfType.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/OfType.cs
@@ -1,6 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
-// See the LICENSE file in the project root for more information. 
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Threading;
@@ -25,14 +25,14 @@ namespace System.Linq
         /// <param name="source">The async-enumerable sequence that contains the elements to be filtered.</param>
         /// <returns>An async-enumerable sequence that contains elements from the input sequence of type TResult.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
-        public static IAsyncEnumerable<TResult> OfType<TResult>(this IAsyncEnumerable<object> source)
+        public static IAsyncEnumerable<TResult> OfType<TResult>(this IAsyncEnumerable<object?> source)
         {
             if (source == null)
                 throw Error.ArgumentNull(nameof(source));
 
             return Core(source);
 
-            static async IAsyncEnumerable<TResult> Core(IAsyncEnumerable<object> source, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+            static async IAsyncEnumerable<TResult> Core(IAsyncEnumerable<object?> source, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
             {
                 await foreach (var obj in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {


### PR DESCRIPTION
What is the nature of your contribution?

#### Bugfix

When using `OfType<T>` on an `IAsyncEnumerable<T?>` the compiler raised CS8620 warning:

```
Argument of type 'IAsyncEnumerable<object?>' cannot be used for parameter 'source' of type 'IAsyncEnumerable<object>'
in 'IAsyncEnumerable<object> AsyncEnumerable.OfType<object>(IAsyncEnumerable<object> source)'
due to differences in the nullability of reference types.
```


The warning appeared in the unit test I've added, before I've changed `OfType` declaration.

The expected behavior is that the compiler doesn't raise a warning, because we're explicitly asking for our collection to be filtered for not-null objects (null has no type in terms of type checks).

The fix is to change the nullability of type parameter for extension method receiver (`this IAsyncEnumerable<object>`) to be nullable (`object?`) instead.

This PR fixes #1525, which was the original report of the above issue.
