### PR TITLE
Fix duplicate emission in Delay with immediate selector

### DIFF
--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/DelayTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/DelayTest.cs
@@ -1406,6 +1406,18 @@ namespace ReactiveTests.Tests
         }
 
         [Fact]
+        public void Delay_Duration_Selector_Immediately()
+        {
+            var list = new List<int>();
+
+            Observable.Range(1, 5)
+                .Delay(_ => Observable.Return(1))
+                .Subscribe(list.Add);
+
+            Assert.Equal(new List<int>() { 1, 2, 3, 4, 5 }, list);
+        }
+
+        [Fact]
         public void Delay_Duration_InnerDone()
         {
             var scheduler = new TestScheduler();


### PR DESCRIPTION
The `Delay` with selector operator could emit the same item twice in case the inner source ignored the `Dispose` call after the emission (usually before emitting `OnCompleted`).

This PR adds a flag and check so that the emission path is only executed once per such inner source.

Fixes #1625