### PR TITLE
exposing SingleAssignmentDisposableValue and making it ICancelable

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Disposables/SingleAssignmentDisposableValue.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/SingleAssignmentDisposableValue.cs
@@ -10,7 +10,7 @@ namespace System.Reactive.Disposables
     /// Represents a disposable resource which only allows a single assignment of its underlying disposable resource.
     /// If an underlying disposable resource has already been set, future attempts to set the underlying disposable resource will throw an <see cref="InvalidOperationException"/>.
     /// </summary>
-    public struct SingleAssignmentDisposableValue : ICancelable
+    public struct SingleAssignmentDisposableValue
     {
         private IDisposable? _current;
 

--- a/Rx.NET/Source/src/System.Reactive/Disposables/SingleAssignmentDisposableValue.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/SingleAssignmentDisposableValue.cs
@@ -10,7 +10,7 @@ namespace System.Reactive.Disposables
     /// Represents a disposable resource which only allows a single assignment of its underlying disposable resource.
     /// If an underlying disposable resource has already been set, future attempts to set the underlying disposable resource will throw an <see cref="InvalidOperationException"/>.
     /// </summary>
-    internal struct SingleAssignmentDisposableValue
+    public struct SingleAssignmentDisposableValue : ICancelable
     {
         private IDisposable? _current;
 

--- a/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Api/ApiApprovalTests.Core.verified.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Api/ApiApprovalTests.Core.verified.cs
@@ -635,7 +635,7 @@ namespace System.Reactive.Disposables
         public bool IsDisposed { get; }
         public void Dispose() { }
     }
-    public struct SingleAssignmentDisposableValue : System.IDisposable, System.Reactive.Disposables.ICancelable
+    public struct SingleAssignmentDisposableValue
     {
         public System.IDisposable? Disposable { get; set; }
         public bool IsDisposed { get; }

--- a/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Api/ApiApprovalTests.Core.verified.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Api/ApiApprovalTests.Core.verified.cs
@@ -635,6 +635,12 @@ namespace System.Reactive.Disposables
         public bool IsDisposed { get; }
         public void Dispose() { }
     }
+    public struct SingleAssignmentDisposableValue : System.IDisposable, System.Reactive.Disposables.ICancelable
+    {
+        public System.IDisposable? Disposable { get; set; }
+        public bool IsDisposed { get; }
+        public void Dispose() { }
+    }
     public abstract class StableCompositeDisposable : System.IDisposable, System.Reactive.Disposables.ICancelable
     {
         protected StableCompositeDisposable() { }


### PR DESCRIPTION
When implementing various things outside of this library like a custom IScheduler or a custom rx operator the _SingleAssignmentDisposableValue_ can be quite useful. Since it is already well documented and it seams to me like it can't be used wrong, I'd like to make it public and make implement _ICancelable_ also.
Would that be ok with you?

Also please let me know if I have to bump versions manually.