### PR TITLE
Add a "ChunkAsync" extension method for IAsyncEnumerable

### DIFF
--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Chunk.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Chunk.cs
@@ -1,0 +1,89 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT License.
+// See the LICENSE file in the project root for more information. 
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace Tests
+{
+    public class Chunk : AsyncEnumerableTests
+    {
+        [Fact]
+        public async Task Chunk_Null()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                IAsyncEnumerable<int>? xs = null;
+                var ys = xs!.ChunkAsync(24);
+
+                var e = ys.GetAsyncEnumerator();
+                await e.MoveNextAsync();
+            });
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public async Task Chunk_NonPositiveSize(int size)
+        {
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>("size", async () =>
+            {
+                var xs = new[] { 24 }.ToAsyncEnumerable();
+                var ys = xs.ChunkAsync(size);
+
+                var e = ys.GetAsyncEnumerator();
+                await e.MoveNextAsync();
+            });
+        }
+
+        [Fact]
+        public async Task Chunk_Simple_Evenly()
+        {
+            var xs = new[] { 1, 1, 4, 5, 1, 4 }.ToAsyncEnumerable();
+            var ys = xs.ChunkAsync(3);
+
+            var e = ys.GetAsyncEnumerator();
+            await HasNextAsync(e, new[] { 1, 1, 4 });
+            await HasNextAsync(e, new[] { 5, 1, 4 });
+            await NoNextAsync(e);
+        }
+
+        [Fact]
+        public async Task Chunk_Simple_Unevenly()
+        {
+            var xs = new[] { 1, 9, 1, 9, 8, 1, 0 }.ToAsyncEnumerable();
+            var ys = xs.ChunkAsync(4);
+
+            var e = ys.GetAsyncEnumerator();
+            await HasNextAsync(e, new[] { 1, 9, 1, 9 });
+            await HasNextAsync(e, new[] { 8, 1, 0 });
+            await NoNextAsync(e);
+        }
+
+        [Fact]
+        public async Task Chunk_SourceSmallerThanChunkSize()
+        {
+            var xs = new[] { 8, 9, 3 }.ToAsyncEnumerable();
+            var ys = xs.ChunkAsync(4);
+
+            var e = ys.GetAsyncEnumerator();
+            await HasNextAsync(e, new[] { 8, 9, 3 });
+            await NoNextAsync(e);
+        }
+
+        [Fact]
+        public async Task Chunk_EmptySource()
+        {
+            var xs = new int[0].ToAsyncEnumerable();
+            var ys = xs.ChunkAsync(24);
+
+            var e = ys.GetAsyncEnumerator();
+            await NoNextAsync(e);
+        }
+    }
+}

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/Chunk.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/Chunk.cs
@@ -1,0 +1,71 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT License.
+// See the LICENSE file in the project root for more information. 
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Linq
+{
+    public static partial class AsyncEnumerable
+    {
+        /// <summary>
+        /// Split the elements of an async-enumerable sequence into chunks of size at most <paramref name="size"/>.
+        /// </summary>
+        /// <remarks>
+        /// Every chunk except the last will be of size <paramref name="size"/>.
+        /// The last chunk will contain the remaining elements and may be of a smaller size.
+        /// </remarks>
+        /// <param name="source">
+        /// An <see cref="IAsyncEnumerable{T}"/> whose elements to chunk.
+        /// </param>
+        /// <param name="size">
+        /// Maximum size of each chunk.
+        /// </param>
+        /// <typeparam name="TSource">
+        /// The type of the elements of source.
+        /// </typeparam>
+        /// <returns>
+        /// An <see cref="IAsyncEnumerable{T}"/> that contains the elements the input sequence split into chunks of size <paramref name="size"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="source"/> is null.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="size"/> is below 1.
+        /// </exception>
+        public static async IAsyncEnumerable<TSource[]> ChunkAsync<TSource>(this IAsyncEnumerable<TSource> source, int size)
+        {
+            if (source == null)
+                throw Error.ArgumentNull(nameof(source));
+
+            if (size < 1)
+                throw Error.ArgumentOutOfRange(nameof(size));
+
+            await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator();
+
+            if (await e.MoveNextAsync())
+            {
+                List<TSource> chunkBuilder = new();
+                while (true)
+                {
+                    do
+                    {
+                        chunkBuilder.Add(e.Current);
+                    }
+                    while (chunkBuilder.Count < size && await e.MoveNextAsync());
+
+                    yield return chunkBuilder.ToArray();
+
+                    if (chunkBuilder.Count < size || !await e.MoveNextAsync())
+                    {
+                        yield break;
+                    }
+                    chunkBuilder.Clear();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
An async version of .NET 6's `IEnumerable.Chunk(int size)` [(Link)](https://github.com/dotnet/runtime/blob/1e41844947bc68735ddbf3e6aec724f78f03bc2a/src/libraries/System.Linq/src/System/Linq/Chunk.cs). 

It splits an `IAsyncEnumerable<T>` into `T[]`s of `size`.