### PR TITLE
Fix IAsyncEnumerable SkipLast for count = 0

### DIFF
--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/SkipLast.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/SkipLast.cs
@@ -1,6 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
-// See the LICENSE file in the project root for more information. 
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;
@@ -64,12 +64,13 @@ namespace Tests
         }
 
         [Fact]
-        public void SkipLast_Zero_NoAlias()
+        public async Task SkipLast_Zero_NoAlias()
         {
             var xs = Xs();
             var ys = xs.SkipLast(0);
 
             Assert.NotSame(xs, ys);
+            await NoNextAsync(ys.GetAsyncEnumerator());
         }
 
         private async IAsyncEnumerable<int> Xs()

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/SkipLast.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/SkipLast.cs
@@ -70,7 +70,8 @@ namespace Tests
             var ys = xs.SkipLast(0);
 
             Assert.NotSame(xs, ys);
-            await NoNextAsync(ys.GetAsyncEnumerator());
+            var e = ys.GetAsyncEnumerator();
+            await HasNextAsync(e, 1);
         }
 
         private async IAsyncEnumerable<int> Xs()

--- a/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/SkipLast.cs
+++ b/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/SkipLast.cs
@@ -1,6 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT License.
-// See the LICENSE file in the project root for more information. 
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -55,7 +55,8 @@ namespace System.Linq
                     {
                         do
                         {
-                            yield return queue.Dequeue();
+                            if (queue.Count > 0)
+                                yield return queue.Dequeue();
                             queue.Enqueue(e.Current);
                         }
                         while (await e.MoveNextAsync());


### PR DESCRIPTION
#### Bugfix

Fixes bug where calling `SkipLast(0)` over a custom sequence (not being a `AsyncIteratorBase` :https://github.com/dotnet/reactive/blob/85f1eb7c53e27cccdbeee3e0b044916168843fcc/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/SkipLast.cs#L36)
would result in `Core`calling `Dequeue` over an empty queue, as `queue.Count == count` (both value being equal to 0)
https://github.com/dotnet/reactive/blob/85f1eb7c53e27cccdbeee3e0b044916168843fcc/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/SkipLast.cs#L58

As a fix, I rewrote the `Core` method using `await foreach` and matching its synchronous implementation for `IEnumerable` **https://github.com/dotnet/reactive/blob/93386a90d9e7a78c2a0c3aaa16d31e1328f71b72/Ix.NET/Source/System.Interactive/System/Linq/Operators/SkipLast.cs#L33

I have also edited the unit test `SkipLast_Zero_NoAlias` so this one fails with current version of the code.