### PR TITLE
Ix: Correct .Scan() to use matching behavior

### DIFF
--- a/Ix.NET/Source/System.Interactive.Async.Tests/System/Linq/Operators/Scan.cs
+++ b/Ix.NET/Source/System.Interactive.Async.Tests/System/Linq/Operators/Scan.cs
@@ -28,6 +28,7 @@ namespace Tests
             var xs = new[] { 1, 2, 3 }.ToAsyncEnumerable().Scan(8, (x, y) => x + y);
 
             var e = xs.GetAsyncEnumerator();
+            await HasNextAsync(e, 8);
             await HasNextAsync(e, 9);
             await HasNextAsync(e, 11);
             await HasNextAsync(e, 14);
@@ -40,6 +41,7 @@ namespace Tests
             var xs = new[] { 1, 2, 3 }.ToAsyncEnumerable().Scan((x, y) => x + y);
 
             var e = xs.GetAsyncEnumerator();
+            await HasNextAsync(e, 1);
             await HasNextAsync(e, 3);
             await HasNextAsync(e, 6);
             await NoNextAsync(e);

--- a/Ix.NET/Source/System.Interactive.Async/System/Linq/Operators/Scan.cs
+++ b/Ix.NET/Source/System.Interactive.Async/System/Linq/Operators/Scan.cs
@@ -10,10 +10,6 @@ namespace System.Linq
 {
     public static partial class AsyncEnumerableEx
     {
-        // NB: Implementations of Scan never yield the first element, unlike the behavior of Aggregate on a sequence with one
-        //     element, which returns the first element (or the seed if given an empty sequence). This is compatible with Rx
-        //     but one could argue whether it was the right default.
-
         /// <summary>
         /// Applies an accumulator function over an async-enumerable sequence and returns each intermediate result.
         /// For aggregation behavior with no intermediate results, see <see cref="AsyncEnumerable.AggregateAsync{TSource}"/>.
@@ -42,6 +38,8 @@ namespace System.Linq
                 }
 
                 var res = e.Current;
+
+                yield return res;
 
                 while (await e.MoveNextAsync())
                 {
@@ -75,6 +73,8 @@ namespace System.Linq
             static async IAsyncEnumerable<TAccumulate> Core(IAsyncEnumerable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, TAccumulate> accumulator, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
             {
                 var res = seed;
+
+                yield return res;
 
                 await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
@@ -113,6 +113,8 @@ namespace System.Linq
                 }
 
                 var res = e.Current;
+
+                yield return res;
 
                 while (await e.MoveNextAsync())
                 {
@@ -153,6 +155,8 @@ namespace System.Linq
 
                 var res = e.Current;
 
+                yield return res;
+
                 while (await e.MoveNextAsync())
                 {
                     res = await accumulator(res, e.Current, cancellationToken).ConfigureAwait(false);
@@ -187,6 +191,8 @@ namespace System.Linq
             {
                 var res = seed;
 
+                yield return res;
+
                 await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {
                     res = await accumulator(res, item).ConfigureAwait(false);
@@ -220,6 +226,8 @@ namespace System.Linq
             static async IAsyncEnumerable<TAccumulate> Core(IAsyncEnumerable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, CancellationToken, ValueTask<TAccumulate>> accumulator, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
             {
                 var res = seed;
+
+                yield return res;
 
                 await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
                 {

--- a/Ix.NET/Source/System.Interactive.Tests/System/Linq/Operators/Scan.cs
+++ b/Ix.NET/Source/System.Interactive.Tests/System/Linq/Operators/Scan.cs
@@ -23,14 +23,14 @@ namespace Tests
         public void Scan1()
         {
             var res = Enumerable.Range(0, 5).Scan((n, x) => n + x).ToList();
-            Assert.True(Enumerable.SequenceEqual(res, new[] { 1, 3, 6, 10 }));
+            Assert.True(Enumerable.SequenceEqual(res, new[] { 0, 1, 3, 6, 10 }));
         }
 
         [Fact]
         public void Scan2()
         {
             var res = Enumerable.Range(0, 5).Scan(10, (n, x) => n - x).ToList();
-            Assert.True(Enumerable.SequenceEqual(res, new[] { 10, 9, 7, 4, 0 }));
+            Assert.True(Enumerable.SequenceEqual(res, new[] { 10, 10, 9, 7, 4, 0 }));
         }
     }
 }

--- a/Ix.NET/Source/System.Interactive/System/Linq/Operators/Scan.cs
+++ b/Ix.NET/Source/System.Interactive/System/Linq/Operators/Scan.cs
@@ -54,6 +54,8 @@ namespace System.Linq
         {
             var acc = seed;
 
+            yield return acc;
+
             foreach (var item in source)
             {
                 acc = accumulator(acc, item);
@@ -73,10 +75,11 @@ namespace System.Linq
                 {
                     hasSeed = true;
                     acc = item;
-                    continue;
                 }
-
-                acc = accumulator(acc, item);
+                else
+                {
+                    acc = accumulator(acc, item);
+                }
 
                 yield return acc;
             }


### PR DESCRIPTION
The scan operator in most languages includes the seed or first element. This commit updates the Scan operator in System.Interactive to match both Rx.NET and other languages.

Fixes #1672