### PR TITLE
Add AsyncRx.NET build pipeline

### DIFF
--- a/AsyncRx.NET/ApiCompare/ApiCompare.csproj
+++ b/AsyncRx.NET/ApiCompare/ApiCompare.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <!-- You wouldn't think we'd need this with an Exe, but it seems this is getting published as a package without this! -->
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AsyncRx.NET/ApiCompare/ApiCompare.csproj
+++ b/AsyncRx.NET/ApiCompare/ApiCompare.csproj
@@ -6,6 +6,7 @@
 
     <!-- You wouldn't think we'd need this with an Exe, but it seems this is getting published as a package without this! -->
     <IsPackable>false</IsPackable>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AsyncRx.NET/Directory.build.props
+++ b/AsyncRx.NET/Directory.build.props
@@ -14,7 +14,6 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <IncludeSymbols>false</IncludeSymbols>
     <IsTestProject>$(MSBuildProjectName.Contains('Tests'))</IsTestProject>
-    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)Rx.ruleset</CodeAnalysisRuleSet>
     <GeneratePackageOnBuild Condition=" '$(IsTestProject)' != 'true' and '$(CreatePackage)' == 'true' ">true</GeneratePackageOnBuild>
     <PackageOutputPath>$(MSBuildThisFileDirectory)artifacts</PackageOutputPath>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/AsyncRx.NET/Playground/Playground.csproj
+++ b/AsyncRx.NET/Playground/Playground.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <!-- You wouldn't think we'd need this with an Exe, but it seems this is getting published as a package without this! -->
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/AsyncRx.NET/Playground/Playground.csproj
+++ b/AsyncRx.NET/Playground/Playground.csproj
@@ -6,6 +6,7 @@
 
     <!-- You wouldn't think we'd need this with an Exe, but it seems this is getting published as a package without this! -->
     <IsPackable>false</IsPackable>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/AsyncRx.NET/build/signclient.json
+++ b/AsyncRx.NET/build/signclient.json
@@ -1,0 +1,13 @@
+{
+  "SignClient": {
+    "AzureAd": {
+      "AADInstance": "https://login.microsoftonline.com/",
+      "ClientId": "c248d68a-ba6f-4aa9-8a68-71fe872063f8",
+      "TenantId": "16076fdc-fcc1-4a15-b1ca-32c9a255900e"
+    },
+    "Service": {
+      "Url": "https://codesign.dotnetfoundation.org/",
+      "ResourceId": "https://SignService/3c30251f-36f3-490b-a955-520addb85001"
+    }
+  }
+}

--- a/AsyncRx.NET/version.json
+++ b/AsyncRx.NET/version.json
@@ -1,0 +1,11 @@
+{
+  "version": "6.0.0-alpha.{height}",
+  "publicReleaseRefSpec": [
+    "^refs/heads/main$", // we release out of main
+    "^refs/heads/rel/v\\d+\\.\\d+", // we also release branches starting with rel/vN.N
+    "^refs/heads/rel/rx-v\\d+\\.\\d+" // we also release branches starting with rel/vN.N
+  ],
+  "nugetPackageVersion":{
+    "semVer": 2
+  }
+}

--- a/azure-pipelines.asyncrx.yml
+++ b/azure-pipelines.asyncrx.yml
@@ -71,6 +71,10 @@ stages:
       artifact: config
       displayName: Publish signing config
 
+    - publish: $(Build.ArtifactStagingDirectory)\artifacts
+      displayName: Publish artifacts
+      artifact: BuildPackages
+
 # Rx.NET has an IntegrationTests stage. Consider this once we have tests
 
 - stage: CodeSign

--- a/azure-pipelines.asyncrx.yml
+++ b/azure-pipelines.asyncrx.yml
@@ -1,0 +1,113 @@
+trigger:
+  branches:
+    include:
+      - main
+      - rel/*
+  paths:
+    include:
+      - AsyncRx.NET/*
+      - .editorconfig
+      - azure-pipelines.asyncrx.yml
+
+pr:
+  branches:
+    include:
+    - main
+    - rel/*
+  paths:
+    include:
+      - AsyncRx.NET/*
+      - .editorconfig
+      - azure-pipelines.asyncrx.yml
+
+stages:
+- stage: Build
+  jobs:
+  - job: Build
+    pool:
+      vmImage: windows-latest
+
+    variables:
+      BuildConfiguration: Release
+      BuildPlatform: Any CPU
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+
+    steps:
+    - task: UseDotNet@2
+      displayName: Use .NET Core 7.0.x SDK
+      inputs:
+        version: 7.0.x
+        performMultiLevelLookup: true
+
+    - task: DotNetCoreCLI@2
+      inputs:
+        command: custom
+        custom: tool
+        arguments: install --tool-path . nbgv
+      displayName: Install NBGV tool
+
+    - script: nbgv cloud -a -p AsyncRx.NET
+      displayName: Set Version
+
+    - task: MSBuild@1
+      displayName: Build AsyncRx.NET.sln
+      inputs:
+        solution: AsyncRx.NET/AsyncRx.NET.sln
+        msbuildArguments: /restore /t:build /p:CreatePackage=true /p:NoPackageAnalysis=true /p:PackageOutputPath=$(Build.ArtifactStagingDirectory)\artifacts
+        configuration: $(BuildConfiguration)
+        maximumCpuCount: false
+
+    - task: DotNetCoreCLI@2
+      inputs:
+        command: custom
+        custom: tool
+        arguments: install --tool-path . dotnet-reportgenerator-globaltool
+      displayName: Install ReportGenerator tool
+
+    # Normally we'd run tests here, but AsyncRx.NET doesn't have any yet!
+    # Once we're ready to stablize, we'd also add API surface area tests too
+  
+    - publish:  AsyncRx.NET/build
+      artifact: config
+      displayName: Publish signing config
+
+# Rx.NET has an IntegrationTests stage. Consider this once we have tests
+
+- stage: CodeSign
+  # In Rx, the condition includes:
+  #   succeeded('IntegrationTests')
+  condition: not(eq(variables['build.reason'], 'PullRequest'))
+  jobs:
+  - deployment: CodeSign
+    displayName: Code Signing
+    pool:
+      vmImage: windows-latest
+    environment: Code Sign
+    variables:
+    - group: SignClient Credentials
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+          - task: DotNetCoreCLI@2
+            inputs:
+              command: custom
+              custom: tool
+              arguments: install --tool-path . SignClient
+            displayName: Install SignTool tool
+
+          - pwsh: |
+              .\SignClient "Sign" `
+              --baseDirectory "$(Pipeline.Workspace)\BuildPackages" `
+              --input "**/*.nupkg" `
+              --config "$(Pipeline.Workspace)\config\signclient.json" `
+              --user "$(SignClientUser)" `
+              --secret "$(SignClientSecret)" `
+              --name "Rx.NET" `
+              --description "Rx.NET" `
+              --descriptionUrl "https://github.com/dotnet/reactive"
+            displayName: Sign packages
+
+          - publish: $(Pipeline.Workspace)/BuildPackages
+            displayName: Publish Signed Packages
+            artifact: SignedPackages


### PR DESCRIPTION
This is a prerequisite for being able to publish AsyncRx.NET packages to NuGet.