### PR TITLE
Fix compiler diagnostics in AsyncRx.NET

### DIFF
--- a/AsyncRx.NET/ApiCompare/Program.cs
+++ b/AsyncRx.NET/ApiCompare/Program.cs
@@ -9,9 +9,9 @@ using System.Reflection;
 
 namespace ApiCompare
 {
-    class Program
+    internal class Program
     {
-        static void Main()
+        private static void Main()
         {
             var observable = typeof(Observable).GetMethods(BindingFlags.Public | BindingFlags.Static).Select(m => m.Name).Distinct();
             var asyncObservable = typeof(AsyncObservable).GetMethods(BindingFlags.Public | BindingFlags.Static).Select(m => m.Name).Distinct();

--- a/AsyncRx.NET/Playground/Program.cs
+++ b/AsyncRx.NET/Playground/Program.cs
@@ -2,6 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
+// The intention is that people will uncomment whichever method call in Main they want to try.
+// The following suppressions prevent warnings due to 'unused' members, and the fact that all of
+// the await statements in Main are commented out to start with
+#pragma warning disable IDE0051, CS1998
+
 using System;
 using System.Linq;
 using System.Reactive;
@@ -12,16 +17,9 @@ using System.Threading.Tasks;
 
 namespace Playground
 {
-    static class Program
+    internal static class Program
     {
-        static void Main()
-        {
-            MainAsync().GetAwaiter().GetResult();
-
-            Console.ReadLine();
-        }
-
-        static async Task MainAsync()
+        private static async Task Main()
         {
             //await AggregateAsync();
             //await AllAsync();
@@ -45,34 +43,36 @@ namespace Playground
             //await TakeUntilAsync();
             //await TimerAsync();
             //await WhileAsync();
+
+            Console.ReadLine();
         }
 
-        static async Task AggregateAsync()
+        private static async Task AggregateAsync()
         {
             await AsyncObservable.Range(0, 10).Aggregate(0, (sum, x) => sum + x).SubscribeAsync(Print<int>());
         }
 
-        static async Task AllAsync()
+        private static async Task AllAsync()
         {
             await AsyncObservable.Range(0, 10).All(x => x < 10).SubscribeAsync(Print<bool>());
         }
 
-        static async Task AnyAsync()
+        private static async Task AnyAsync()
         {
             await AsyncObservable.Range(0, 10).Any(x => x == 5).SubscribeAsync(Print<bool>());
         }
 
-        static async Task AppendAsync()
+        private static async Task AppendAsync()
         {
             await AsyncObservable.Range(0, 10).Append(42).SubscribeAsync(Print<int>());
         }
 
-        static async Task AwaitAsync()
+        private static async Task AwaitAsync()
         {
             Console.WriteLine(await AsyncObservable.Range(0, 10));
         }
 
-        static async Task BufferTimeHoppingAsync()
+        private static async Task BufferTimeHoppingAsync()
         {
             await
                 AsyncObservable
@@ -82,7 +82,7 @@ namespace Playground
                     .SubscribeAsync(Print<string>()); // TODO: Use ForEachAsync.
         }
 
-        static async Task BufferTimeSlidingAsync()
+        private static async Task BufferTimeSlidingAsync()
         {
             await
                 AsyncObservable
@@ -93,7 +93,7 @@ namespace Playground
                     .SubscribeAsync(Print<string>()); // TODO: Use ForEachAsync.
         }
 
-        static async Task CombineLatestAsync()
+        private static async Task CombineLatestAsync()
         {
             await
                 AsyncObservable.CombineLatest(
@@ -104,7 +104,7 @@ namespace Playground
                 .SubscribeAsync(Print<string>()); // TODO: Use ForEachAsync.
         }
 
-        static async Task ConcatAsync()
+        private static async Task ConcatAsync()
         {
             await
                 AsyncObservable.Concat(
@@ -116,7 +116,7 @@ namespace Playground
                 .SubscribeAsync(Print<int>()); // TODO: Use ForEachAsync.
         }
 
-        static async Task DelayAsync()
+        private static async Task DelayAsync()
         {
             await
                 AsyncObservable.Timer(TimeSpan.Zero, TimeSpan.FromSeconds(1))
@@ -127,7 +127,7 @@ namespace Playground
                     .SubscribeAsync(Print<string>()); // TODO: Use ForEachAsync.
         }
 
-        static async Task GroupByAsync()
+        private static async Task GroupByAsync()
         {
             await
                 AsyncObservable.Interval(TimeSpan.FromMilliseconds(250))
@@ -140,7 +140,7 @@ namespace Playground
                     });
         }
 
-        static async Task GroupBySelectManyAsync()
+        private static async Task GroupBySelectManyAsync()
         {
             await
                 AsyncObservable.Interval(TimeSpan.FromMilliseconds(250))
@@ -151,7 +151,7 @@ namespace Playground
                     .SubscribeAsync(Print<string>());
         }
 
-        static async Task MergeAsync()
+        private static async Task MergeAsync()
         {
             var subject = new SequentialSimpleAsyncSubject<IAsyncObservable<int>>();
 
@@ -167,17 +167,17 @@ namespace Playground
             await subject.OnCompletedAsync();
         }
 
-        static async Task PrependAsync()
+        private static async Task PrependAsync()
         {
             await AsyncObservable.Range(0, 10).Prepend(42).SubscribeAsync(Print<int>());
         }
 
-        static async Task RangeAsync()
+        private static async Task RangeAsync()
         {
             await AsyncObservable.Range(0, 10).SubscribeAsync(PrintAsync<int>()); // TODO: Use ForEachAsync.
         }
 
-        static async Task ReplaySubjectAsync()
+        private static async Task ReplaySubjectAsync()
         {
             var sub = new SequentialReplayAsyncSubject<int>(5);
 
@@ -208,12 +208,12 @@ namespace Playground
             await sub.OnNextAsync(47);
         }
 
-        static async Task ReturnAsync()
+        private static async Task ReturnAsync()
         {
             await AsyncObservable.Return(42).SubscribeAsync(Print<int>());
         }
 
-        static async Task SelectManyAsync()
+        private static async Task SelectManyAsync()
         {
             var res = from i in AsyncObservable.Range(0, 10)
                       from j in AsyncObservable.Range(i * 10, 10)
@@ -222,7 +222,7 @@ namespace Playground
             await res.SubscribeAsync(Print<string>());
         }
 
-        static async Task SubjectAsync()
+        private static async Task SubjectAsync()
         {
             var subject = new SequentialSimpleAsyncSubject<int>();
 
@@ -238,24 +238,24 @@ namespace Playground
             await subject.OnCompletedAsync();
         }
 
-        static async Task TakeUntilAsync()
+        private static async Task TakeUntilAsync()
         {
             await AsyncObservable.Range(0, int.MaxValue).TakeUntil(DateTimeOffset.Now.AddSeconds(5)).SubscribeAsync(Print<int>()); // TODO: Use ForEachAsync.
         }
 
-        static async Task TimerAsync()
+        private static async Task TimerAsync()
         {
             await AsyncObservable.Timer(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2)).Take(5).Select(_ => DateTimeOffset.Now).SubscribeAsync(Print<DateTimeOffset>()); // TODO: Use ForEachAsync.
         }
 
-        static async Task WhileAsync()
+        private static async Task WhileAsync()
         {
             var i = 0;
 
             await AsyncObservable.While(() => ++i < 5, AsyncObservable.Range(0, 5)).SubscribeAsync(Print<int>()); // TODO: Use ForEachAsync.
         }
 
-        static IAsyncObserver<T> Print<T>()
+        private static IAsyncObserver<T> Print<T>()
         {
             return AsyncObserver.Create<T>(
                 x =>
@@ -276,7 +276,7 @@ namespace Playground
             );
         }
 
-        static IAsyncObserver<T> PrintAsync<T>()
+        private static IAsyncObserver<T> PrintAsync<T>()
         {
             return AsyncObserver.Create<T>(
                 async x =>

--- a/AsyncRx.NET/System.Reactive.Async/AsyncObservableBase.cs
+++ b/AsyncRx.NET/System.Reactive.Async/AsyncObservableBase.cs
@@ -27,7 +27,7 @@ namespace System.Reactive
         private sealed class AutoDetachAsyncObserver : AsyncObserverBase<T>, IAsyncDisposable
         {
             private readonly IAsyncObserver<T> _observer;
-            private readonly object _gate = new object();
+            private readonly object _gate = new();
 
             private IAsyncDisposable _subscription;
             private ValueTask _task;
@@ -62,7 +62,7 @@ namespace System.Reactive
 
             public async ValueTask DisposeAsync()
             {
-                var task = default(ValueTask);
+                ValueTask task;
                 var subscription = default(IAsyncDisposable);
 
                 lock (_gate)

--- a/AsyncRx.NET/System.Reactive.Async/Concurrency/AsyncScheduler.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Concurrency/AsyncScheduler.cs
@@ -208,7 +208,7 @@ namespace System.Reactive.Concurrency
                 _token = token;
             }
 
-            public RendezVousAwaiter GetAwaiter() => new RendezVousAwaiter(_scheduler, _token);
+            public RendezVousAwaiter GetAwaiter() => new(_scheduler, _token);
 
             public sealed class RendezVousAwaiter : INotifyCompletion
             {

--- a/AsyncRx.NET/System.Reactive.Async/Concurrency/AsyncSchedulerBase.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Concurrency/AsyncSchedulerBase.cs
@@ -66,7 +66,7 @@ namespace System.Reactive.Concurrency
 
         private sealed class CancellationAsyncDisposable : IAsyncDisposable
         {
-            private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+            private readonly CancellationTokenSource _cts = new();
 
             public CancellationToken Token => _cts.Token;
 

--- a/AsyncRx.NET/System.Reactive.Async/Concurrency/ImmediateAsyncScheduler.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Concurrency/ImmediateAsyncScheduler.cs
@@ -13,7 +13,7 @@ namespace System.Reactive.Concurrency
 
         private ImmediateAsyncScheduler() { }
 
-        protected override ValueTask Delay(TimeSpan dueTime, CancellationToken token) => new ValueTask(Task.Delay(dueTime));
+        protected override ValueTask Delay(TimeSpan dueTime, CancellationToken token) => new(Task.Delay(dueTime));
 
         protected override ValueTask ScheduleAsyncCore(Func<CancellationToken, ValueTask> action, CancellationToken token) => action(token);
     }

--- a/AsyncRx.NET/System.Reactive.Async/Concurrency/SynchronizationContextAsyncScheduler.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Concurrency/SynchronizationContextAsyncScheduler.cs
@@ -16,7 +16,7 @@ namespace System.Reactive.Concurrency
             _context = context ?? throw new ArgumentNullException(nameof(context));
         }
 
-        protected override ValueTask Delay(TimeSpan dueTime, CancellationToken token) => new ValueTask(Task.Delay(dueTime, token));
+        protected override ValueTask Delay(TimeSpan dueTime, CancellationToken token) => new(Task.Delay(dueTime, token));
 
         protected override ValueTask ScheduleAsyncCore(Func<CancellationToken, ValueTask> action, CancellationToken token)
         {

--- a/AsyncRx.NET/System.Reactive.Async/Concurrency/TaskPoolAsyncScheduler.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Concurrency/TaskPoolAsyncScheduler.cs
@@ -27,7 +27,7 @@ namespace System.Reactive.Concurrency
             _factory = factory ?? throw new ArgumentNullException(nameof(factory));
         }
 
-        protected override ValueTask Delay(TimeSpan dueTime, CancellationToken token) => new ValueTask(Task.Delay(dueTime, token));
+        protected override ValueTask Delay(TimeSpan dueTime, CancellationToken token) => new(Task.Delay(dueTime, token));
 
         protected override ValueTask ScheduleAsyncCore(Func<CancellationToken, ValueTask> action, CancellationToken token)
         {

--- a/AsyncRx.NET/System.Reactive.Async/Disposables/CompositeAsyncDisposable.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Disposables/CompositeAsyncDisposable.cs
@@ -11,7 +11,7 @@ namespace System.Reactive.Disposables
 {
     public sealed class CompositeAsyncDisposable : IAsyncDisposable
     {
-        private readonly AsyncGate _gate = new AsyncGate();
+        private readonly AsyncGate _gate = new();
         private readonly List<IAsyncDisposable> _disposables;
         private bool _disposed;
 

--- a/AsyncRx.NET/System.Reactive.Async/Disposables/RefCountAsyncDisposable.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Disposables/RefCountAsyncDisposable.cs
@@ -9,7 +9,7 @@ namespace System.Reactive.Disposables
 {
     public sealed class RefCountAsyncDisposable : IAsyncDisposable
     {
-        private readonly AsyncGate _gate = new AsyncGate();
+        private readonly AsyncGate _gate = new();
         private IAsyncDisposable _disposable;
         private bool _primaryDisposed;
         private int _count;

--- a/AsyncRx.NET/System.Reactive.Async/Disposables/SerialAsyncDisposable.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Disposables/SerialAsyncDisposable.cs
@@ -9,7 +9,7 @@ namespace System.Reactive.Disposables
 {
     public sealed class SerialAsyncDisposable : IAsyncDisposable
     {
-        private readonly AsyncGate _gate = new AsyncGate();
+        private readonly AsyncGate _gate = new();
 
         private IAsyncDisposable _disposable;
         private bool _disposed;

--- a/AsyncRx.NET/System.Reactive.Async/Internal/AsyncQueueLockAsyncObserver.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Internal/AsyncQueueLockAsyncObserver.cs
@@ -9,7 +9,7 @@ namespace System.Reactive
 {
     internal sealed class AsyncQueueLockAsyncObserver<T> : AsyncObserverBase<T>
     {
-        private readonly AsyncQueueLock _gate = new AsyncQueueLock();
+        private readonly AsyncQueueLock _gate = new();
         private readonly IAsyncObserver<T> _observer;
 
         public AsyncQueueLockAsyncObserver(IAsyncObserver<T> observer)

--- a/AsyncRx.NET/System.Reactive.Async/Internal/EventPatternSourceBaseInternal.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Internal/EventPatternSourceBaseInternal.cs
@@ -120,10 +120,7 @@ namespace System.Reactive
                 }
             }
 
-            if (d != null)
-            {
-                d.DisposeAsync().GetAwaiter().GetResult();
-            }
+            d?.DisposeAsync().GetAwaiter().GetResult();
         }
     }
 }

--- a/AsyncRx.NET/System.Reactive.Async/Internal/EventSource.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Internal/EventSource.cs
@@ -91,10 +91,7 @@ namespace System.Reactive
                 }
             }
 
-            if (d != null)
-            {
-                d.DisposeAsync().GetAwaiter().GetResult();
-            }
+            d?.DisposeAsync().GetAwaiter().GetResult();
         }
     }
 }

--- a/AsyncRx.NET/System.Reactive.Async/Internal/FastImmediateAsyncObserver.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Internal/FastImmediateAsyncObserver.cs
@@ -10,7 +10,7 @@ namespace System.Reactive
 {
     internal sealed class FastImmediateAsyncObserver<T> : ScheduledAsyncObserverBase<T>
     {
-        private readonly CancellationAsyncDisposable _disposable = new CancellationAsyncDisposable();
+        private readonly CancellationAsyncDisposable _disposable = new();
 
         public FastImmediateAsyncObserver(IAsyncObserver<T> observer)
             : base(observer)
@@ -19,9 +19,9 @@ namespace System.Reactive
 
         public override ValueTask DisposeAsync() => _disposable.DisposeAsync();
 
-        protected override ValueTaskAwaitable RendezVous(ValueTask task) => new ValueTaskAwaitable(task, continueOnCapturedContext: false, scheduler: null, CancellationToken.None);
+        protected override ValueTaskAwaitable RendezVous(ValueTask task) => new(task, continueOnCapturedContext: false, scheduler: null, CancellationToken.None);
 
-        protected override ValueTaskAwaitable<R> RendezVous<R>(ValueTask<R> task) => new ValueTaskAwaitable<R>(task, continueOnCapturedContext: false, scheduler: null, CancellationToken.None);
+        protected override ValueTaskAwaitable<R> RendezVous<R>(ValueTask<R> task) => new(task, continueOnCapturedContext: false, scheduler: null, CancellationToken.None);
 
         protected override ValueTask ScheduleAsync() => RunAsync(_disposable.Token);
     }

--- a/AsyncRx.NET/System.Reactive.Async/Internal/Lookup.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Internal/Lookup.cs
@@ -10,30 +10,30 @@ namespace System.Reactive
 {
     internal sealed class Lookup<K, E> : ILookup<K, E>
     {
-        private readonly Dictionary<K, List<E>> d;
+        private readonly Dictionary<K, List<E>> _d;
 
         public Lookup(IEqualityComparer<K> comparer)
         {
-            d = new Dictionary<K, List<E>>(comparer);
+            _d = new Dictionary<K, List<E>>(comparer);
         }
 
         public void Add(K key, E element)
         {
-            if (!d.TryGetValue(key, out var list))
-                d[key] = list = new List<E>();
+            if (!_d.TryGetValue(key, out var list))
+                _d[key] = list = new List<E>();
 
             list.Add(element);
         }
 
-        public bool Contains(K key) => d.ContainsKey(key);
+        public bool Contains(K key) => _d.ContainsKey(key);
 
-        public int Count => d.Count;
+        public int Count => _d.Count;
 
         public IEnumerable<E> this[K key]
         {
             get
             {
-                if (!d.TryGetValue(key, out var list))
+                if (!_d.TryGetValue(key, out var list))
                     return Enumerable.Empty<E>();
 
                 return Hide(list);
@@ -48,22 +48,22 @@ namespace System.Reactive
 
         public IEnumerator<IGrouping<K, E>> GetEnumerator()
         {
-            foreach (var kv in d)
+            foreach (var kv in _d)
                 yield return new Grouping(kv);
         }
 
         private sealed class Grouping : IGrouping<K, E>
         {
-            private readonly KeyValuePair<K, List<E>> kv;
+            private readonly KeyValuePair<K, List<E>> _kv;
 
             public Grouping(KeyValuePair<K, List<E>> kv)
             {
-                this.kv = kv;
+                _kv = kv;
             }
 
-            public K Key => kv.Key;
+            public K Key => _kv.Key;
 
-            public IEnumerator<E> GetEnumerator() => kv.Value.GetEnumerator();
+            public IEnumerator<E> GetEnumerator() => _kv.Value.GetEnumerator();
 
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         }

--- a/AsyncRx.NET/System.Reactive.Async/Internal/ScheduledAsyncObserver.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Internal/ScheduledAsyncObserver.cs
@@ -13,7 +13,7 @@ namespace System.Reactive
     {
         private readonly IAsyncScheduler _scheduler;
 
-        private readonly SerialAsyncDisposable _disposable = new SerialAsyncDisposable();
+        private readonly SerialAsyncDisposable _disposable = new();
 
         public ScheduledAsyncObserver(IAsyncObserver<T> observer, IAsyncScheduler scheduler)
             : base(observer)
@@ -23,9 +23,9 @@ namespace System.Reactive
 
         public override ValueTask DisposeAsync() => _disposable.DisposeAsync();
 
-        protected override ValueTaskAwaitable RendezVous(ValueTask task) => new ValueTaskAwaitable(task, continueOnCapturedContext: false, _scheduler, CancellationToken.None);
+        protected override ValueTaskAwaitable RendezVous(ValueTask task) => new(task, continueOnCapturedContext: false, _scheduler, CancellationToken.None);
 
-        protected override ValueTaskAwaitable<R> RendezVous<R>(ValueTask<R> task) => new ValueTaskAwaitable<R>(task, continueOnCapturedContext: false, _scheduler, CancellationToken.None);
+        protected override ValueTaskAwaitable<R> RendezVous<R>(ValueTask<R> task) => new(task, continueOnCapturedContext: false, _scheduler, CancellationToken.None);
 
         protected override async ValueTask ScheduleAsync()
         {

--- a/AsyncRx.NET/System.Reactive.Async/Internal/ScheduledAsyncObserverBase.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Internal/ScheduledAsyncObserverBase.cs
@@ -12,8 +12,8 @@ namespace System.Reactive
     {
         private readonly IAsyncObserver<T> _observer;
 
-        private readonly AsyncGate _lock = new AsyncGate();
-        private readonly Queue<T> _queue = new Queue<T>();
+        private readonly AsyncGate _lock = new();
+        private readonly Queue<T> _queue = new();
 
         private bool _hasFaulted = false;
         private bool _busy = false;

--- a/AsyncRx.NET/System.Reactive.Async/Internal/UnsafeAsyncObserver.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Internal/UnsafeAsyncObserver.cs
@@ -14,16 +14,9 @@ namespace System.Reactive
 
         public UnsafeAsyncObserver(Func<T, ValueTask> onNextAsync, Func<Exception, ValueTask> onErrorAsync, Func<ValueTask> onCompletedAsync)
         {
-            if (onNextAsync == null)
-                throw new ArgumentNullException(nameof(onNextAsync));
-            if (onErrorAsync == null)
-                throw new ArgumentNullException(nameof(onErrorAsync));
-            if (onCompletedAsync == null)
-                throw new ArgumentNullException(nameof(onCompletedAsync));
-
-            _onNextAsync = onNextAsync;
-            _onErrorAsync = onErrorAsync;
-            _onCompletedAsync = onCompletedAsync;
+            _onNextAsync = onNextAsync ?? throw new ArgumentNullException(nameof(onNextAsync));
+            _onErrorAsync = onErrorAsync ?? throw new ArgumentNullException(nameof(onErrorAsync));
+            _onCompletedAsync = onCompletedAsync ?? throw new ArgumentNullException(nameof(onCompletedAsync));
         }
 
         public ValueTask OnCompletedAsync() => _onCompletedAsync();

--- a/AsyncRx.NET/System.Reactive.Async/Joins/ActiveAsyncPlan.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Joins/ActiveAsyncPlan.cs
@@ -9,18 +9,18 @@ namespace System.Reactive.Joins
 {
     internal abstract class ActiveAsyncPlan
     {
-        private readonly Dictionary<IAsyncJoinObserver, IAsyncJoinObserver> joinObservers = new Dictionary<IAsyncJoinObserver, IAsyncJoinObserver>();
+        private readonly Dictionary<IAsyncJoinObserver, IAsyncJoinObserver> _joinObservers = new();
 
         internal abstract Task Match();
 
         protected void AddJoinObserver(IAsyncJoinObserver joinObserver)
         {
-            joinObservers.Add(joinObserver, joinObserver);
+            _joinObservers.Add(joinObserver, joinObserver);
         }
 
         protected void Dequeue()
         {
-            foreach (var observer in joinObservers.Values)
+            foreach (var observer in _joinObservers.Values)
             {
                 observer.Dequeue();
             }

--- a/AsyncRx.NET/System.Reactive.Async/Joins/AsyncJoinObserver.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Joins/AsyncJoinObserver.cs
@@ -15,8 +15,8 @@ namespace System.Reactive.Joins
         private readonly IAsyncObservable<T> _source;
         private readonly Func<Exception, ValueTask> _onError;
 
-        private readonly List<ActiveAsyncPlan> _activePlans = new List<ActiveAsyncPlan>();
-        private readonly SingleAssignmentAsyncDisposable _subscription = new SingleAssignmentAsyncDisposable();
+        private readonly List<ActiveAsyncPlan> _activePlans = new();
+        private readonly SingleAssignmentAsyncDisposable _subscription = new();
 
         private AsyncGate _gate;
         private bool _isDisposed;

--- a/AsyncRx.NET/System.Reactive.Async/Runtime/CompilerServices/AsyncMethodBuilderAttribute.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Runtime/CompilerServices/AsyncMethodBuilderAttribute.cs
@@ -13,7 +13,9 @@ namespace System.Runtime.CompilerServices
         /// Creates a new instance of the attribute using the specified <paramref name="type"/>.
         /// </summary>
         /// <param name="type">The type implementing the asynchronous method builder.</param>
+#pragma warning disable IDE0060 // Remove unused parameter - this attribute is understood intrinsically by the compiler, so it doesn't need to use its argument.
         public AsyncMethodBuilderAttribute(Type type)
+#pragma warning restore IDE0060 // Remove unused parameter
         {
         }
     }

--- a/AsyncRx.NET/System.Reactive.Async/Runtime/CompilerServices/AsyncObservableMethodBuilder.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Runtime/CompilerServices/AsyncObservableMethodBuilder.cs
@@ -205,7 +205,6 @@ namespace System.Runtime.CompilerServices
         /// }
         /// </code>
         /// </remarks>
-        /// <typeparam name="T">The type of the elements in the sequence.</typeparam>
         internal sealed class TaskObservable : IAsyncObservable<T>, INotifyCompletion
         {
             /// <summary>

--- a/AsyncRx.NET/System.Reactive.Async/Subjects/AsyncAsyncSubject.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Subjects/AsyncAsyncSubject.cs
@@ -13,8 +13,8 @@ namespace System.Reactive.Subjects
 {
     public abstract class AsyncAsyncSubject<T> : IAsyncSubject<T>, INotifyCompletion
     {
-        private readonly object _gate = new object();
-        private readonly List<IAsyncObserver<T>> _observers = new List<IAsyncObserver<T>>();
+        private readonly object _gate = new();
+        private readonly List<IAsyncObserver<T>> _observers = new();
         private bool _hasValue;
         private T _value;
         private bool _done;

--- a/AsyncRx.NET/System.Reactive.Async/Subjects/BehaviorAsyncSubject.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Subjects/BehaviorAsyncSubject.cs
@@ -11,8 +11,8 @@ namespace System.Reactive.Subjects
 {
     public abstract class BehaviorAsyncSubject<T> : IAsyncSubject<T>
     {
-        private readonly AsyncGate _gate = new AsyncGate();
-        private readonly List<IAsyncObserver<T>> _observers = new List<IAsyncObserver<T>>();
+        private readonly AsyncGate _gate = new();
+        private readonly List<IAsyncObserver<T>> _observers = new();
         private T _value;
         private bool _done;
         private Exception _error;

--- a/AsyncRx.NET/System.Reactive.Async/Subjects/ConcurrentAsyncAsyncSubject.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Subjects/ConcurrentAsyncAsyncSubject.cs
@@ -10,10 +10,10 @@ namespace System.Reactive.Subjects
 {
     public sealed class ConcurrentAsyncAsyncSubject<T> : AsyncAsyncSubject<T>
     {
-        protected override ValueTask OnCompletedAsyncCore(IEnumerable<IAsyncObserver<T>> observers) => new ValueTask(Task.WhenAll(observers.Select(observer => observer.OnCompletedAsync().AsTask())));
+        protected override ValueTask OnCompletedAsyncCore(IEnumerable<IAsyncObserver<T>> observers) => new(Task.WhenAll(observers.Select(observer => observer.OnCompletedAsync().AsTask())));
 
-        protected override ValueTask OnErrorAsyncCore(IEnumerable<IAsyncObserver<T>> observers, Exception error) => new ValueTask(Task.WhenAll(observers.Select(observer => observer.OnErrorAsync(error).AsTask())));
+        protected override ValueTask OnErrorAsyncCore(IEnumerable<IAsyncObserver<T>> observers, Exception error) => new(Task.WhenAll(observers.Select(observer => observer.OnErrorAsync(error).AsTask())));
 
-        protected override ValueTask OnNextAsyncCore(IEnumerable<IAsyncObserver<T>> observers, T value) => new ValueTask(Task.WhenAll(observers.Select(observer => observer.OnNextAsync(value).AsTask())));
+        protected override ValueTask OnNextAsyncCore(IEnumerable<IAsyncObserver<T>> observers, T value) => new(Task.WhenAll(observers.Select(observer => observer.OnNextAsync(value).AsTask())));
     }
 }

--- a/AsyncRx.NET/System.Reactive.Async/Subjects/ConcurrentBehaviorAsyncSubject.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Subjects/ConcurrentBehaviorAsyncSubject.cs
@@ -15,10 +15,10 @@ namespace System.Reactive.Subjects
         {
         }
 
-        protected override ValueTask OnCompletedAsyncCore(IEnumerable<IAsyncObserver<T>> observers) => new ValueTask(Task.WhenAll(observers.Select(observer => observer.OnCompletedAsync().AsTask())));
+        protected override ValueTask OnCompletedAsyncCore(IEnumerable<IAsyncObserver<T>> observers) => new(Task.WhenAll(observers.Select(observer => observer.OnCompletedAsync().AsTask())));
 
-        protected override ValueTask OnErrorAsyncCore(IEnumerable<IAsyncObserver<T>> observers, Exception error) => new ValueTask(Task.WhenAll(observers.Select(observer => observer.OnErrorAsync(error).AsTask())));
+        protected override ValueTask OnErrorAsyncCore(IEnumerable<IAsyncObserver<T>> observers, Exception error) => new(Task.WhenAll(observers.Select(observer => observer.OnErrorAsync(error).AsTask())));
 
-        protected override ValueTask OnNextAsyncCore(IEnumerable<IAsyncObserver<T>> observers, T value) => new ValueTask(Task.WhenAll(observers.Select(observer => observer.OnNextAsync(value).AsTask())));
+        protected override ValueTask OnNextAsyncCore(IEnumerable<IAsyncObserver<T>> observers, T value) => new(Task.WhenAll(observers.Select(observer => observer.OnNextAsync(value).AsTask())));
     }
 }

--- a/AsyncRx.NET/System.Reactive.Async/Subjects/ConcurrentSimpleAsyncSubject.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Subjects/ConcurrentSimpleAsyncSubject.cs
@@ -10,10 +10,10 @@ namespace System.Reactive.Subjects
 {
     public sealed class ConcurrentSimpleAsyncSubject<T> : SimpleAsyncSubject<T>
     {
-        protected override ValueTask OnCompletedAsyncCore(IEnumerable<IAsyncObserver<T>> observers) => new ValueTask(Task.WhenAll(observers.Select(observer => observer.OnCompletedAsync().AsTask())));
+        protected override ValueTask OnCompletedAsyncCore(IEnumerable<IAsyncObserver<T>> observers) => new(Task.WhenAll(observers.Select(observer => observer.OnCompletedAsync().AsTask())));
 
-        protected override ValueTask OnErrorAsyncCore(IEnumerable<IAsyncObserver<T>> observers, Exception error) => new ValueTask(Task.WhenAll(observers.Select(observer => observer.OnErrorAsync(error).AsTask())));
+        protected override ValueTask OnErrorAsyncCore(IEnumerable<IAsyncObserver<T>> observers, Exception error) => new(Task.WhenAll(observers.Select(observer => observer.OnErrorAsync(error).AsTask())));
 
-        protected override ValueTask OnNextAsyncCore(IEnumerable<IAsyncObserver<T>> observers, T value) => new ValueTask(Task.WhenAll(observers.Select(observer => observer.OnNextAsync(value).AsTask())));
+        protected override ValueTask OnNextAsyncCore(IEnumerable<IAsyncObserver<T>> observers, T value) => new(Task.WhenAll(observers.Select(observer => observer.OnNextAsync(value).AsTask())));
     }
 }

--- a/AsyncRx.NET/System.Reactive.Async/Subjects/ReplayAsyncSubject.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Subjects/ReplayAsyncSubject.cs
@@ -120,8 +120,8 @@ namespace System.Reactive.Subjects
         private abstract class ReplayBase : IAsyncSubject<T>
         {
             private readonly bool _concurrent;
-            private readonly AsyncGate _lock = new AsyncGate();
-            private readonly List<IScheduledAsyncObserver<T>> _observers = new List<IScheduledAsyncObserver<T>>(); // TODO: immutable array
+            private readonly AsyncGate _lock = new();
+            private readonly List<IScheduledAsyncObserver<T>> _observers = new(); // TODO: immutable array
             private bool _done;
             private Exception _error;
 
@@ -361,7 +361,7 @@ namespace System.Reactive.Subjects
 
         private abstract class ReplayManyBase : ReplayBufferBase
         {
-            protected readonly Queue<T> Values = new Queue<T>();
+            protected readonly Queue<T> Values = new();
 
             public ReplayManyBase(bool concurrent, Func<IAsyncObserver<T>, IScheduledAsyncObserver<T>> createObserver)
                 : base(concurrent, createObserver)
@@ -422,7 +422,7 @@ namespace System.Reactive.Subjects
             private readonly IAsyncScheduler _scheduler;
             private readonly int _bufferSize;
             private readonly TimeSpan _window;
-            private readonly Queue<Timestamped<T>> _values = new Queue<Timestamped<T>>();
+            private readonly Queue<Timestamped<T>> _values = new();
 
             public ReplayTime(bool concurrent, IAsyncScheduler scheduler, int bufferSize, TimeSpan window, Func<IAsyncObserver<T>, IScheduledAsyncObserver<T>> createObserver)
                 : base(concurrent, createObserver)

--- a/AsyncRx.NET/System.Reactive.Async/Subjects/SimpleAsyncSubject.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Subjects/SimpleAsyncSubject.cs
@@ -10,8 +10,8 @@ namespace System.Reactive.Subjects
 {
     public abstract class SimpleAsyncSubject<T> : IAsyncSubject<T>
     {
-        private readonly object _gate = new object();
-        private readonly List<IAsyncObserver<T>> _observers = new List<IAsyncObserver<T>>();
+        private readonly object _gate = new();
+        private readonly List<IAsyncObserver<T>> _observers = new();
         private bool _done;
         private Exception _error;
 

--- a/AsyncRx.NET/System.Reactive.Async/Threading/AsyncGate.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Threading/AsyncGate.cs
@@ -9,9 +9,9 @@ namespace System.Threading
 {
     public sealed class AsyncGate
     {
-        private readonly object _gate = new object();
-        private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
-        private readonly AsyncLocal<int> _recursionCount = new AsyncLocal<int>();
+        private readonly object _gate = new();
+        private readonly SemaphoreSlim _semaphore = new(1, 1);
+        private readonly AsyncLocal<int> _recursionCount = new();
 
         public ValueTask<Releaser> LockAsync()
         {
@@ -51,7 +51,7 @@ namespace System.Threading
             }
         }
 
-        public struct Releaser : IDisposable
+        public readonly struct Releaser : IDisposable
         {
             private readonly AsyncGate _parent;
 

--- a/AsyncRx.NET/System.Reactive.Async/Threading/AsyncQueueLock.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Threading/AsyncQueueLock.cs
@@ -9,8 +9,8 @@ namespace System.Threading
 {
     public sealed class AsyncQueueLock : IAsyncDisposable
     {
-        private readonly Queue<Func<ValueTask>> _queue = new Queue<Func<ValueTask>>();
-        private readonly AsyncGate _gate = new AsyncGate();
+        private readonly Queue<Func<ValueTask>> _queue = new();
+        private readonly AsyncGate _gate = new();
 
         private bool _isAcquired;
         private bool _hasFaulted;

--- a/AsyncRx.NET/System.Reactive.Async/Threading/Tasks/TaskAwaitable.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Threading/Tasks/TaskAwaitable.cs
@@ -22,7 +22,7 @@ namespace System.Threading.Tasks
             _token = token;
         }
 
-        public TaskAwaiter GetAwaiter() => new TaskAwaiter(_task.ConfigureAwait(_continueOnCapturedContext).GetAwaiter(), _scheduler, _token);
+        public TaskAwaiter GetAwaiter() => new(_task.ConfigureAwait(_continueOnCapturedContext).GetAwaiter(), _scheduler, _token);
 
         public readonly struct TaskAwaiter : INotifyCompletion
         {
@@ -111,7 +111,7 @@ namespace System.Threading.Tasks
             _token = token;
         }
 
-        public TaskAwaiter GetAwaiter() => new TaskAwaiter(_task.ConfigureAwait(_continueOnCapturedContext).GetAwaiter(), _scheduler, _token);
+        public TaskAwaiter GetAwaiter() => new(_task.ConfigureAwait(_continueOnCapturedContext).GetAwaiter(), _scheduler, _token);
 
         public readonly struct TaskAwaiter : INotifyCompletion
         {

--- a/AsyncRx.NET/System.Reactive.Async/Threading/Tasks/ValueTaskAwaitable.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Threading/Tasks/ValueTaskAwaitable.cs
@@ -22,7 +22,7 @@ namespace System.Threading.Tasks
             _token = token;
         }
 
-        public ValueTaskAwaiter GetAwaiter() => new ValueTaskAwaiter(_task.ConfigureAwait(_continueOnCapturedContext).GetAwaiter(), _scheduler, _token);
+        public ValueTaskAwaiter GetAwaiter() => new(_task.ConfigureAwait(_continueOnCapturedContext).GetAwaiter(), _scheduler, _token);
 
         public readonly struct ValueTaskAwaiter : INotifyCompletion
         {
@@ -111,7 +111,7 @@ namespace System.Threading.Tasks
             _token = token;
         }
 
-        public ValueTaskAwaiter GetAwaiter() => new ValueTaskAwaiter(_task.ConfigureAwait(_continueOnCapturedContext).GetAwaiter(), _scheduler, _token);
+        public ValueTaskAwaiter GetAwaiter() => new(_task.ConfigureAwait(_continueOnCapturedContext).GetAwaiter(), _scheduler, _token);
 
         public readonly struct ValueTaskAwaiter : INotifyCompletion
         {


### PR DESCRIPTION
There were various warnings and messages due either to inconsistent style, or because in modern C#, newer idioms are preferred. This changes the code to be consistent with current standards.

In a couple of cases, the warnings were spurious, and have been suppressed.