### PR TITLE
Back out #1449

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
+++ b/Rx.NET/Source/src/System.Reactive/System.Reactive.csproj
@@ -147,7 +147,6 @@
   <ItemGroup>
     <None Include="build\_._" PackagePath="build\net6.0;build\net6.0-windows10.0.19041" Pack="true" />
     <None Include="build\_._" PackagePath="buildTransitive\net6.0;buildTransitive\net6.0-windows10.0.19041" Pack="true" />
-    <None Include="build\System.Reactive.net6.0-windows.targets" PackagePath="build\net6.0-windows7\$(PackageId).targets;buildTransitive\net6.0-windows7\$(PackageId).targets" Pack="true" />
     <None Include="Linq\QbservableEx.NAry.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/Rx.NET/Source/src/System.Reactive/build/System.Reactive.net6.0-windows.targets
+++ b/Rx.NET/Source/src/System.Reactive/build/System.Reactive.net6.0-windows.targets
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-   
-  <Target Name="_RXNETWindowsTFMCheck" BeforeTargets="ResolveAssemblyReferences;Build;Rebuild">
-    <Error 
-        Text = "The 'System.Reactive' nuget package cannot be used to target '$(TargetFramework)'. Target 'net6.0-windows10.0.19041' or later instead." />
-  </Target>
-  
-</Project>


### PR DESCRIPTION
Resolves #1893. Resolves #1889

PR #1449 seems to cause more problems than it solves - see #1893

Once we separate the UI frameworks back out into their own packages, the issue that PR was intended to solve will go away in any case.