### PR TITLE
Allow opt-out from TaskScheduler.UnobservedExceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,8 @@ nuget.exe
 
 # JetBrains Rider adds these
 .idea/
+
+# Local NCrunch settings
+*.v3.ncrunchproject
+*.v3.ncrunchsolution
+/Rx.NET/Source/.NCrunch_*/StoredText

--- a/Rx.NET/Source/src/System.Reactive/Linq/IQueryLanguage.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/IQueryLanguage.cs
@@ -193,27 +193,27 @@ namespace System.Reactive.Linq
         IObservable<TSource> Start<TSource>(Func<TSource> function);
         IObservable<TSource> Start<TSource>(Func<TSource> function, IScheduler scheduler);
 
-        IObservable<TSource> StartAsync<TSource>(Func<Task<TSource>> functionAsync);
-        IObservable<TSource> StartAsync<TSource>(Func<CancellationToken, Task<TSource>> functionAsync);
-        IObservable<TSource> StartAsync<TSource>(Func<Task<TSource>> functionAsync, IScheduler scheduler);
-        IObservable<TSource> StartAsync<TSource>(Func<CancellationToken, Task<TSource>> functionAsync, IScheduler scheduler);
+        IObservable<TSource> StartAsync<TSource>(Func<Task<TSource>> functionAsync, bool ignoreExceptionsAfterUnsubscribe);
+        IObservable<TSource> StartAsync<TSource>(Func<CancellationToken, Task<TSource>> functionAsync, bool ignoreExceptionsAfterUnsubscribe);
+        IObservable<TSource> StartAsync<TSource>(Func<Task<TSource>> functionAsync, IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe);
+        IObservable<TSource> StartAsync<TSource>(Func<CancellationToken, Task<TSource>> functionAsync, IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe);
 
         IObservable<Unit> Start(Action action);
         IObservable<Unit> Start(Action action, IScheduler scheduler);
 
-        IObservable<Unit> StartAsync(Func<Task> actionAsync);
-        IObservable<Unit> StartAsync(Func<CancellationToken, Task> actionAsync);
-        IObservable<Unit> StartAsync(Func<Task> actionAsync, IScheduler scheduler);
-        IObservable<Unit> StartAsync(Func<CancellationToken, Task> actionAsync, IScheduler scheduler);
+        IObservable<Unit> StartAsync(Func<Task> actionAsync, bool ignoreExceptionsAfterUnsubscribe);
+        IObservable<Unit> StartAsync(Func<CancellationToken, Task> actionAsync, bool ignoreExceptionsAfterUnsubscribe);
+        IObservable<Unit> StartAsync(Func<Task> actionAsync, IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe);
+        IObservable<Unit> StartAsync(Func<CancellationToken, Task> actionAsync, IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe);
 
-        IObservable<TResult> FromAsync<TResult>(Func<Task<TResult>> functionAsync);
-        IObservable<TResult> FromAsync<TResult>(Func<CancellationToken, Task<TResult>> functionAsync);
-        IObservable<Unit> FromAsync(Func<Task> actionAsync);
-        IObservable<Unit> FromAsync(Func<CancellationToken, Task> actionAsync);
-        IObservable<TResult> FromAsync<TResult>(Func<Task<TResult>> functionAsync, IScheduler scheduler);
-        IObservable<TResult> FromAsync<TResult>(Func<CancellationToken, Task<TResult>> functionAsync, IScheduler scheduler);
-        IObservable<Unit> FromAsync(Func<Task> actionAsync, IScheduler scheduler);
-        IObservable<Unit> FromAsync(Func<CancellationToken, Task> actionAsync, IScheduler scheduler);
+        IObservable<TResult> FromAsync<TResult>(Func<Task<TResult>> functionAsync, bool ignoreExceptionsAfterUnsubscribe);
+        IObservable<TResult> FromAsync<TResult>(Func<CancellationToken, Task<TResult>> functionAsync, bool ignoreExceptionsAfterUnsubscribe);
+        IObservable<Unit> FromAsync(Func<Task> actionAsync, bool ignoreExceptionsAfterUnsubscribe);
+        IObservable<Unit> FromAsync(Func<CancellationToken, Task> actionAsync, bool ignoreExceptionsAfterUnsubscribe);
+        IObservable<TResult> FromAsync<TResult>(Func<Task<TResult>> functionAsync, IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe);
+        IObservable<TResult> FromAsync<TResult>(Func<CancellationToken, Task<TResult>> functionAsync, IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe);
+        IObservable<Unit> FromAsync(Func<Task> actionAsync, IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe);
+        IObservable<Unit> FromAsync(Func<CancellationToken, Task> actionAsync, IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe);
 
         Func<IObservable<TResult>> ToAsync<TResult>(Func<TResult> function);
         Func<IObservable<TResult>> ToAsync<TResult>(Func<TResult> function, IScheduler scheduler);
@@ -398,8 +398,8 @@ namespace System.Reactive.Linq
 
         IObservable<TValue> Defer<TValue>(Func<IObservable<TValue>> observableFactory);
 
-        IObservable<TValue> Defer<TValue>(Func<Task<IObservable<TValue>>> observableFactoryAsync);
-        IObservable<TValue> Defer<TValue>(Func<CancellationToken, Task<IObservable<TValue>>> observableFactoryAsync);
+        IObservable<TValue> Defer<TValue>(Func<Task<IObservable<TValue>>> observableFactoryAsync, bool ignoreExceptionsAfterUnsubscribe);
+        IObservable<TValue> Defer<TValue>(Func<CancellationToken, Task<IObservable<TValue>>> observableFactoryAsync, bool ignoreExceptionsAfterUnsubscribe);
 
         IObservable<TResult> Empty<TResult>();
         IObservable<TResult> Empty<TResult>(IScheduler scheduler);

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable.Async.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable.Async.cs
@@ -1066,7 +1066,7 @@ namespace System.Reactive.Linq
                 throw new ArgumentNullException(nameof(functionAsync));
             }
 
-            return s_impl.StartAsync(functionAsync);
+            return s_impl.StartAsync(functionAsync, ignoreExceptionsAfterUnsubscribe);
         }
 
         /// <summary>
@@ -1119,7 +1119,7 @@ namespace System.Reactive.Linq
                 throw new ArgumentNullException(nameof(scheduler));
             }
 
-            return s_impl.StartAsync(functionAsync, scheduler);
+            return s_impl.StartAsync(functionAsync, scheduler, ignoreExceptionsAfterUnsubscribe);
         }
 
         /// <summary>
@@ -1181,7 +1181,7 @@ namespace System.Reactive.Linq
                 throw new ArgumentNullException(nameof(functionAsync));
             }
 
-            return s_impl.StartAsync(functionAsync);
+            return s_impl.StartAsync(functionAsync, ignoreExceptionsAfterUnsubscribe);
         }
 
         /// <summary>
@@ -1250,7 +1250,7 @@ namespace System.Reactive.Linq
                 throw new ArgumentNullException(nameof(scheduler));
             }
 
-            return s_impl.StartAsync(functionAsync, scheduler);
+            return s_impl.StartAsync(functionAsync, scheduler, ignoreExceptionsAfterUnsubscribe);
         }
 
         #endregion
@@ -1348,7 +1348,7 @@ namespace System.Reactive.Linq
                 throw new ArgumentNullException(nameof(actionAsync));
             }
 
-            return s_impl.StartAsync(actionAsync);
+            return s_impl.StartAsync(actionAsync, ignoreExceptionsAfterUnsubscribe);
         }
 
         /// <summary>
@@ -1399,7 +1399,7 @@ namespace System.Reactive.Linq
                 throw new ArgumentNullException(nameof(scheduler));
             }
 
-            return s_impl.StartAsync(actionAsync, scheduler);
+            return s_impl.StartAsync(actionAsync, scheduler, ignoreExceptionsAfterUnsubscribe);
         }
 
         /// <summary>
@@ -1459,7 +1459,7 @@ namespace System.Reactive.Linq
                 throw new ArgumentNullException(nameof(actionAsync));
             }
 
-            return s_impl.StartAsync(actionAsync);
+            return s_impl.StartAsync(actionAsync, ignoreExceptionsAfterUnsubscribe);
         }
 
         /// <summary>
@@ -1526,7 +1526,7 @@ namespace System.Reactive.Linq
                 throw new ArgumentNullException(nameof(scheduler));
             }
 
-            return s_impl.StartAsync(actionAsync, scheduler);
+            return s_impl.StartAsync(actionAsync, scheduler, ignoreExceptionsAfterUnsubscribe);
         }
 
         #endregion
@@ -1569,7 +1569,7 @@ namespace System.Reactive.Linq
                 throw new ArgumentNullException(nameof(functionAsync));
             }
 
-            return s_impl.FromAsync(functionAsync);
+            return s_impl.FromAsync(functionAsync, ignoreExceptionsAfterUnsubscribe);
         }
 
         /// <summary>
@@ -1610,7 +1610,7 @@ namespace System.Reactive.Linq
                 throw new ArgumentNullException(nameof(scheduler));
             }
 
-            return s_impl.FromAsync(functionAsync, scheduler);
+            return s_impl.FromAsync(functionAsync, scheduler, ignoreExceptionsAfterUnsubscribe);
         }
 
         /// <summary>
@@ -1648,7 +1648,7 @@ namespace System.Reactive.Linq
                 throw new ArgumentNullException(nameof(functionAsync));
             }
 
-            return s_impl.FromAsync(functionAsync);
+            return s_impl.FromAsync(functionAsync, ignoreExceptionsAfterUnsubscribe);
         }
 
         /// <summary>
@@ -1693,7 +1693,7 @@ namespace System.Reactive.Linq
                 throw new ArgumentNullException(nameof(scheduler));
             }
 
-            return s_impl.FromAsync(functionAsync, scheduler);
+            return s_impl.FromAsync(functionAsync, scheduler, ignoreExceptionsAfterUnsubscribe);
         }
 
         #endregion
@@ -1729,7 +1729,7 @@ namespace System.Reactive.Linq
                 throw new ArgumentNullException(nameof(actionAsync));
             }
 
-            return s_impl.FromAsync(actionAsync);
+            return s_impl.FromAsync(actionAsync, ignoreExceptionsAfterUnsubscribe);
         }
 
         /// <summary>
@@ -1768,7 +1768,7 @@ namespace System.Reactive.Linq
                 throw new ArgumentNullException(nameof(scheduler));
             }
 
-            return s_impl.FromAsync(actionAsync, scheduler);
+            return s_impl.FromAsync(actionAsync, scheduler, ignoreExceptionsAfterUnsubscribe);
         }
 
         /// <summary>
@@ -1804,7 +1804,7 @@ namespace System.Reactive.Linq
                 throw new ArgumentNullException(nameof(actionAsync));
             }
 
-            return s_impl.FromAsync(actionAsync);
+            return s_impl.FromAsync(actionAsync, ignoreExceptionsAfterUnsubscribe);
         }
 
         /// <summary>
@@ -1847,7 +1847,7 @@ namespace System.Reactive.Linq
                 throw new ArgumentNullException(nameof(scheduler));
             }
 
-            return s_impl.FromAsync(actionAsync, scheduler);
+            return s_impl.FromAsync(actionAsync, scheduler, ignoreExceptionsAfterUnsubscribe);
         }
 
         #endregion

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable.Async.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable.Async.cs
@@ -1038,6 +1038,29 @@ namespace System.Reactive.Linq
         /// </remarks>
         public static IObservable<TResult> StartAsync<TResult>(Func<Task<TResult>> functionAsync)
         {
+            return StartAsync(functionAsync, ignoreExceptionsAfterUnsubscribe: false);
+        }
+
+        /// <summary>
+        /// Invokes the asynchronous function, surfacing the result through an observable sequence.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result returned by the asynchronous function.</typeparam>
+        /// <param name="functionAsync">Asynchronous function to run.</param>
+        /// <param name="ignoreExceptionsAfterUnsubscribe">
+        /// If true, exceptions that occur after cancellation has been initiated by unsubscribing from the observable
+        /// this method returns will be handled and silently ignored. If false, they will go unobserved, meaning they
+        /// will eventually emerge through <see cref="TaskScheduler.UnobservedTaskException"/>.
+        /// </param>
+        /// <returns>An observable sequence exposing the function's result value, or an exception.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="functionAsync"/> is null.</exception>
+        /// <remarks>
+        /// <list type="bullet">
+        /// <item><description>The function is started immediately, not during the subscription of the resulting sequence.</description></item>
+        /// <item><description>Multiple subscriptions to the resulting sequence can observe the function's result.</description></item>
+        /// </list>
+        /// </remarks>
+        public static IObservable<TResult> StartAsync<TResult>(Func<Task<TResult>> functionAsync, bool ignoreExceptionsAfterUnsubscribe)
+        {
             if (functionAsync == null)
             {
                 throw new ArgumentNullException(nameof(functionAsync));
@@ -1061,6 +1084,30 @@ namespace System.Reactive.Linq
         /// </list>
         /// </remarks>
         public static IObservable<TResult> StartAsync<TResult>(Func<Task<TResult>> functionAsync, IScheduler scheduler)
+        {
+            return StartAsync(functionAsync, scheduler, ignoreExceptionsAfterUnsubscribe: false);
+        }
+
+        /// <summary>
+        /// Invokes the asynchronous function, surfacing the result through an observable sequence.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result returned by the asynchronous function.</typeparam>
+        /// <param name="functionAsync">Asynchronous function to run.</param>
+        /// <param name="scheduler">Scheduler on which to notify observers.</param>
+        /// <param name="ignoreExceptionsAfterUnsubscribe">
+        /// If true, exceptions that occur after cancellation has been initiated by unsubscribing from the observable
+        /// this method returns will be handled and silently ignored. If false, they will go unobserved, meaning they
+        /// will eventually emerge through <see cref="TaskScheduler.UnobservedTaskException"/>.
+        /// </param>
+        /// <returns>An observable sequence exposing the function's result value, or an exception.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="functionAsync"/> is null or <paramref name="scheduler"/> is null.</exception>
+        /// <remarks>
+        /// <list type="bullet">
+        /// <item><description>The function is started immediately, not during the subscription of the resulting sequence.</description></item>
+        /// <item><description>Multiple subscriptions to the resulting sequence can observe the function's result.</description></item>
+        /// </list>
+        /// </remarks>
+        public static IObservable<TResult> StartAsync<TResult>(Func<Task<TResult>> functionAsync, IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe)
         {
             if (functionAsync == null)
             {
@@ -1098,6 +1145,37 @@ namespace System.Reactive.Linq
         /// </remarks>
         public static IObservable<TResult> StartAsync<TResult>(Func<CancellationToken, Task<TResult>> functionAsync)
         {
+            return StartAsync(functionAsync, ignoreExceptionsAfterUnsubscribe: false);
+        }
+
+        /// <summary>
+        /// Invokes the asynchronous function, surfacing the result through an observable sequence.
+        /// The CancellationToken is shared by all subscriptions on the resulting observable sequence. See the remarks section for more information.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result returned by the asynchronous function.</typeparam>
+        /// <param name="functionAsync">Asynchronous function to run.</param>
+        /// <returns>An observable sequence exposing the function's result value, or an exception.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="functionAsync"/> is null.</exception>
+        /// <remarks>
+        /// <param name="ignoreExceptionsAfterUnsubscribe">
+        /// If true, exceptions that occur after cancellation has been initiated by unsubscribing from the observable
+        /// this method returns will be handled and silently ignored. If false, they will go unobserved, meaning they
+        /// will eventually emerge through <see cref="TaskScheduler.UnobservedTaskException"/>.
+        /// </param>
+        /// <list type="bullet">
+        /// <item><description>The function is started immediately, not during the subscription of the resulting sequence.</description></item>
+        /// <item><description>Multiple subscriptions to the resulting sequence can observe the function's result.</description></item>
+        /// <item><description>
+        /// If any subscription to the resulting sequence is disposed, the CancellationToken is set. The observer associated to the disposed
+        /// subscription won't see the TaskCanceledException, but other observers will. You can protect against this using the Catch operator.
+        /// Be careful when handing out the resulting sequence because of this behavior. The most common use is to have a single subscription
+        /// to the resulting sequence, which controls the CancellationToken state. Alternatively, you can control subscription behavior using
+        /// multicast operators.
+        /// </description></item>
+        /// </list>
+        /// </remarks>
+        public static IObservable<TResult> StartAsync<TResult>(Func<CancellationToken, Task<TResult>> functionAsync, bool ignoreExceptionsAfterUnsubscribe)
+        {
             if (functionAsync == null)
             {
                 throw new ArgumentNullException(nameof(functionAsync));
@@ -1129,6 +1207,38 @@ namespace System.Reactive.Linq
         /// </list>
         /// </remarks>
         public static IObservable<TResult> StartAsync<TResult>(Func<CancellationToken, Task<TResult>> functionAsync, IScheduler scheduler)
+        {
+            return StartAsync(functionAsync, scheduler, ignoreExceptionsAfterUnsubscribe: false);
+        }
+
+        /// <summary>
+        /// Invokes the asynchronous function, surfacing the result through an observable sequence.
+        /// The CancellationToken is shared by all subscriptions on the resulting observable sequence. See the remarks section for more information.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result returned by the asynchronous function.</typeparam>
+        /// <param name="functionAsync">Asynchronous function to run.</param>
+        /// <param name="scheduler">Scheduler on which to notify observers.</param>
+        /// <param name="ignoreExceptionsAfterUnsubscribe">
+        /// If true, exceptions that occur after cancellation has been initiated by unsubscribing from the observable
+        /// this method returns will be handled and silently ignored. If false, they will go unobserved, meaning they
+        /// will eventually emerge through <see cref="TaskScheduler.UnobservedTaskException"/>.
+        /// </param>
+        /// <returns>An observable sequence exposing the function's result value, or an exception.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="functionAsync"/> is null or <paramref name="scheduler"/> is null.</exception>
+        /// <remarks>
+        /// <list type="bullet">
+        /// <item><description>The function is started immediately, not during the subscription of the resulting sequence.</description></item>
+        /// <item><description>Multiple subscriptions to the resulting sequence can observe the function's result.</description></item>
+        /// <item><description>
+        /// If any subscription to the resulting sequence is disposed, the CancellationToken is set. The observer associated to the disposed
+        /// subscription won't see the TaskCanceledException, but other observers will. You can protect against this using the Catch operator.
+        /// Be careful when handing out the resulting sequence because of this behavior. The most common use is to have a single subscription
+        /// to the resulting sequence, which controls the CancellationToken state. Alternatively, you can control subscription behavior using
+        /// multicast operators.
+        /// </description></item>
+        /// </list>
+        /// </remarks>
+        public static IObservable<TResult> StartAsync<TResult>(Func<CancellationToken, Task<TResult>> functionAsync, IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe)
         {
             if (functionAsync == null)
             {
@@ -1211,6 +1321,28 @@ namespace System.Reactive.Linq
         /// </remarks>
         public static IObservable<Unit> StartAsync(Func<Task> actionAsync)
         {
+            return StartAsync(actionAsync, ignoreExceptionsAfterUnsubscribe: false);
+        }
+
+        /// <summary>
+        /// Invokes the asynchronous action, surfacing the result through an observable sequence.
+        /// </summary>
+        /// <param name="actionAsync">Asynchronous action to run.</param>
+        /// <param name="ignoreExceptionsAfterUnsubscribe">
+        /// If true, exceptions that occur after cancellation has been initiated by unsubscribing from the observable
+        /// this method returns will be handled and silently ignored. If false, they will go unobserved, meaning they
+        /// will eventually emerge through <see cref="TaskScheduler.UnobservedTaskException"/>.
+        /// </param>
+        /// <returns>An observable sequence exposing a Unit value upon completion of the action, or an exception.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="actionAsync"/> is null.</exception>
+        /// <remarks>
+        /// <list type="bullet">
+        /// <item><description>The action is started immediately, not during the subscription of the resulting sequence.</description></item>
+        /// <item><description>Multiple subscriptions to the resulting sequence can observe the action's outcome.</description></item>
+        /// </list>
+        /// </remarks>
+        public static IObservable<Unit> StartAsync(Func<Task> actionAsync, bool ignoreExceptionsAfterUnsubscribe)
+        {
             if (actionAsync == null)
             {
                 throw new ArgumentNullException(nameof(actionAsync));
@@ -1233,6 +1365,29 @@ namespace System.Reactive.Linq
         /// </list>
         /// </remarks>
         public static IObservable<Unit> StartAsync(Func<Task> actionAsync, IScheduler scheduler)
+        {
+            return StartAsync(actionAsync, scheduler, ignoreExceptionsAfterUnsubscribe: false);
+        }
+
+        /// <summary>
+        /// Invokes the asynchronous action, surfacing the result through an observable sequence.
+        /// </summary>
+        /// <param name="actionAsync">Asynchronous action to run.</param>
+        /// <param name="scheduler">Scheduler on which to notify observers.</param>
+        /// <param name="ignoreExceptionsAfterUnsubscribe">
+        /// If true, exceptions that occur after cancellation has been initiated by unsubscribing from the observable
+        /// this method returns will be handled and silently ignored. If false, they will go unobserved, meaning they
+        /// will eventually emerge through <see cref="TaskScheduler.UnobservedTaskException"/>.
+        /// </param>
+        /// <returns>An observable sequence exposing a Unit value upon completion of the action, or an exception.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="actionAsync"/> is null or <paramref name="scheduler"/> is null.</exception>
+        /// <remarks>
+        /// <list type="bullet">
+        /// <item><description>The action is started immediately, not during the subscription of the resulting sequence.</description></item>
+        /// <item><description>Multiple subscriptions to the resulting sequence can observe the action's outcome.</description></item>
+        /// </list>
+        /// </remarks>
+        public static IObservable<Unit> StartAsync(Func<Task> actionAsync, IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe)
         {
             if (actionAsync == null)
             {
@@ -1269,6 +1424,36 @@ namespace System.Reactive.Linq
         /// </remarks>
         public static IObservable<Unit> StartAsync(Func<CancellationToken, Task> actionAsync)
         {
+            return StartAsync(actionAsync, ignoreExceptionsAfterUnsubscribe: false);
+        }
+
+        /// <summary>
+        /// Invokes the asynchronous action, surfacing the result through an observable sequence.
+        /// The CancellationToken is shared by all subscriptions on the resulting observable sequence. See the remarks section for more information.
+        /// </summary>
+        /// <param name="actionAsync">Asynchronous action to run.</param>
+        /// <param name="ignoreExceptionsAfterUnsubscribe">
+        /// If true, exceptions that occur after cancellation has been initiated by unsubscribing from the observable
+        /// this method returns will be handled and silently ignored. If false, they will go unobserved, meaning they
+        /// will eventually emerge through <see cref="TaskScheduler.UnobservedTaskException"/>.
+        /// </param>
+        /// <returns>An observable sequence exposing a Unit value upon completion of the action, or an exception.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="actionAsync"/> is null.</exception>
+        /// <remarks>
+        /// <list type="bullet">
+        /// <item><description>The action is started immediately, not during the subscription of the resulting sequence.</description></item>
+        /// <item><description>Multiple subscriptions to the resulting sequence can observe the action's outcome.</description></item>
+        /// <item><description>
+        /// If any subscription to the resulting sequence is disposed, the CancellationToken is set. The observer associated to the disposed
+        /// subscription won't see the TaskCanceledException, but other observers will. You can protect against this using the Catch operator.
+        /// Be careful when handing out the resulting sequence because of this behavior. The most common use is to have a single subscription
+        /// to the resulting sequence, which controls the CancellationToken state. Alternatively, you can control subscription behavior using
+        /// multicast operators.
+        /// </description></item>
+        /// </list>
+        /// </remarks>
+        public static IObservable<Unit> StartAsync(Func<CancellationToken, Task> actionAsync, bool ignoreExceptionsAfterUnsubscribe)
+        {
             if (actionAsync == null)
             {
                 throw new ArgumentNullException(nameof(actionAsync));
@@ -1299,6 +1484,37 @@ namespace System.Reactive.Linq
         /// </list>
         /// </remarks>
         public static IObservable<Unit> StartAsync(Func<CancellationToken, Task> actionAsync, IScheduler scheduler)
+        {
+            return StartAsync(actionAsync, scheduler, ignoreExceptionsAfterUnsubscribe: false);
+        }
+
+        /// <summary>
+        /// Invokes the asynchronous action, surfacing the result through an observable sequence.
+        /// The CancellationToken is shared by all subscriptions on the resulting observable sequence. See the remarks section for more information.
+        /// </summary>
+        /// <param name="actionAsync">Asynchronous action to run.</param>
+        /// <param name="scheduler">Scheduler on which to notify observers.</param>
+        /// <param name="ignoreExceptionsAfterUnsubscribe">
+        /// If true, exceptions that occur after cancellation has been initiated by unsubscribing from the observable
+        /// this method returns will be handled and silently ignored. If false, they will go unobserved, meaning they
+        /// will eventually emerge through <see cref="TaskScheduler.UnobservedTaskException"/>.
+        /// </param>
+        /// <returns>An observable sequence exposing a Unit value upon completion of the action, or an exception.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="actionAsync"/> is null or <paramref name="scheduler"/> is null.</exception>
+        /// <remarks>
+        /// <list type="bullet">
+        /// <item><description>The action is started immediately, not during the subscription of the resulting sequence.</description></item>
+        /// <item><description>Multiple subscriptions to the resulting sequence can observe the action's outcome.</description></item>
+        /// <item><description>
+        /// If any subscription to the resulting sequence is disposed, the CancellationToken is set. The observer associated to the disposed
+        /// subscription won't see the TaskCanceledException, but other observers will. You can protect against this using the Catch operator.
+        /// Be careful when handing out the resulting sequence because of this behavior. The most common use is to have a single subscription
+        /// to the resulting sequence, which controls the CancellationToken state. Alternatively, you can control subscription behavior using
+        /// multicast operators.
+        /// </description></item>
+        /// </list>
+        /// </remarks>
+        public static IObservable<Unit> StartAsync(Func<CancellationToken, Task> actionAsync, IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe)
         {
             if (actionAsync == null)
             {
@@ -1331,6 +1547,23 @@ namespace System.Reactive.Linq
         /// <exception cref="ArgumentNullException"><paramref name="functionAsync"/> is null.</exception>
         public static IObservable<TResult> FromAsync<TResult>(Func<Task<TResult>> functionAsync)
         {
+            return FromAsync(functionAsync, ignoreExceptionsAfterUnsubscribe: false);
+        }
+
+        /// <summary>
+        /// Converts an asynchronous function into an observable sequence. Each subscription to the resulting sequence causes the function to be started.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result returned by the asynchronous function.</typeparam>
+        /// <param name="functionAsync">Asynchronous function to convert.</param>
+        /// <param name="ignoreExceptionsAfterUnsubscribe">
+        /// If true, exceptions that occur after cancellation has been initiated by unsubscribing from the observable
+        /// this method returns will be handled and silently ignored. If false, they will go unobserved, meaning they
+        /// will eventually emerge through <see cref="TaskScheduler.UnobservedTaskException"/>.
+        /// </param>
+        /// <returns>An observable sequence exposing the result of invoking the function, or an exception.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="functionAsync"/> is null.</exception>
+        public static IObservable<TResult> FromAsync<TResult>(Func<Task<TResult>> functionAsync, bool ignoreExceptionsAfterUnsubscribe)
+        {
             if (functionAsync == null)
             {
                 throw new ArgumentNullException(nameof(functionAsync));
@@ -1348,6 +1581,24 @@ namespace System.Reactive.Linq
         /// <returns>An observable sequence exposing the result of invoking the function, or an exception.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="functionAsync"/> is null or <paramref name="scheduler"/> is null.</exception>
         public static IObservable<TResult> FromAsync<TResult>(Func<Task<TResult>> functionAsync, IScheduler scheduler)
+        {
+            return FromAsync(functionAsync, scheduler, ignoreExceptionsAfterUnsubscribe: false);
+        }
+
+        /// <summary>
+        /// Converts an asynchronous function into an observable sequence. Each subscription to the resulting sequence causes the function to be started.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result returned by the asynchronous function.</typeparam>
+        /// <param name="functionAsync">Asynchronous function to convert.</param>
+        /// <param name="scheduler">Scheduler on which to notify observers.</param>
+        /// <param name="ignoreExceptionsAfterUnsubscribe">
+        /// If true, exceptions that occur after cancellation has been initiated by unsubscribing from the observable
+        /// this method returns will be handled and silently ignored. If false, they will go unobserved, meaning they
+        /// will eventually emerge through <see cref="TaskScheduler.UnobservedTaskException"/>.
+        /// </param>
+        /// <returns>An observable sequence exposing the result of invoking the function, or an exception.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="functionAsync"/> is null or <paramref name="scheduler"/> is null.</exception>
+        public static IObservable<TResult> FromAsync<TResult>(Func<Task<TResult>> functionAsync, IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe)
         {
             if (functionAsync == null)
             {
@@ -1373,6 +1624,25 @@ namespace System.Reactive.Linq
         /// <remarks>When a subscription to the resulting sequence is disposed, the CancellationToken that was fed to the asynchronous function will be signaled.</remarks>
         public static IObservable<TResult> FromAsync<TResult>(Func<CancellationToken, Task<TResult>> functionAsync)
         {
+            return FromAsync(functionAsync, ignoreExceptionsAfterUnsubscribe: false);
+        }
+
+        /// <summary>
+        /// Converts an asynchronous function into an observable sequence. Each subscription to the resulting sequence causes the function to be started.
+        /// The CancellationToken passed to the asynchronous function is tied to the observable sequence's subscription that triggered the function's invocation and can be used for best-effort cancellation.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result returned by the asynchronous function.</typeparam>
+        /// <param name="functionAsync">Asynchronous function to convert.</param>
+        /// <param name="ignoreExceptionsAfterUnsubscribe">
+        /// If true, exceptions that occur after cancellation has been initiated by unsubscribing from the observable
+        /// this method returns will be handled and silently ignored. If false, they will go unobserved, meaning they
+        /// will eventually emerge through <see cref="TaskScheduler.UnobservedTaskException"/>.
+        /// </param>
+        /// <returns>An observable sequence exposing the result of invoking the function, or an exception.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="functionAsync"/> is null.</exception>
+        /// <remarks>When a subscription to the resulting sequence is disposed, the CancellationToken that was fed to the asynchronous function will be signaled.</remarks>
+        public static IObservable<TResult> FromAsync<TResult>(Func<CancellationToken, Task<TResult>> functionAsync, bool ignoreExceptionsAfterUnsubscribe)
+        {
             if (functionAsync == null)
             {
                 throw new ArgumentNullException(nameof(functionAsync));
@@ -1392,6 +1662,26 @@ namespace System.Reactive.Linq
         /// <exception cref="ArgumentNullException"><paramref name="functionAsync"/> is null or <paramref name="scheduler"/> is null.</exception>
         /// <remarks>When a subscription to the resulting sequence is disposed, the CancellationToken that was fed to the asynchronous function will be signaled.</remarks>
         public static IObservable<TResult> FromAsync<TResult>(Func<CancellationToken, Task<TResult>> functionAsync, IScheduler scheduler)
+        {
+            return FromAsync(functionAsync, scheduler, ignoreExceptionsAfterUnsubscribe: false);
+        }
+
+        /// <summary>
+        /// Converts an asynchronous function into an observable sequence. Each subscription to the resulting sequence causes the function to be started.
+        /// The CancellationToken passed to the asynchronous function is tied to the observable sequence's subscription that triggered the function's invocation and can be used for best-effort cancellation.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result returned by the asynchronous function.</typeparam>
+        /// <param name="functionAsync">Asynchronous function to convert.</param>
+        /// <param name="scheduler">Scheduler on which to notify observers.</param>
+        /// <param name="ignoreExceptionsAfterUnsubscribe">
+        /// If true, exceptions that occur after cancellation has been initiated by unsubscribing from the observable
+        /// this method returns will be handled and silently ignored. If false, they will go unobserved, meaning they
+        /// will eventually emerge through <see cref="TaskScheduler.UnobservedTaskException"/>.
+        /// </param>
+        /// <returns>An observable sequence exposing the result of invoking the function, or an exception.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="functionAsync"/> is null or <paramref name="scheduler"/> is null.</exception>
+        /// <remarks>When a subscription to the resulting sequence is disposed, the CancellationToken that was fed to the asynchronous function will be signaled.</remarks>
+        public static IObservable<TResult> FromAsync<TResult>(Func<CancellationToken, Task<TResult>> functionAsync, IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe)
         {
             if (functionAsync == null)
             {
@@ -1418,6 +1708,22 @@ namespace System.Reactive.Linq
         /// <exception cref="ArgumentNullException"><paramref name="actionAsync"/> is null.</exception>
         public static IObservable<Unit> FromAsync(Func<Task> actionAsync)
         {
+            return FromAsync(actionAsync, ignoreExceptionsAfterUnsubscribe: false);
+        }
+
+        /// <summary>
+        /// Converts an asynchronous action into an observable sequence. Each subscription to the resulting sequence causes the action to be started.
+        /// </summary>
+        /// <param name="actionAsync">Asynchronous action to convert.</param>
+        /// <param name="ignoreExceptionsAfterUnsubscribe">
+        /// If true, exceptions that occur after cancellation has been initiated by unsubscribing from the observable
+        /// this method returns will be handled and silently ignored. If false, they will go unobserved, meaning they
+        /// will eventually emerge through <see cref="TaskScheduler.UnobservedTaskException"/>.
+        /// </param>
+        /// <returns>An observable sequence exposing a Unit value upon completion of the action, or an exception.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="actionAsync"/> is null.</exception>
+        public static IObservable<Unit> FromAsync(Func<Task> actionAsync, bool ignoreExceptionsAfterUnsubscribe)
+        {
             if (actionAsync == null)
             {
                 throw new ArgumentNullException(nameof(actionAsync));
@@ -1434,6 +1740,23 @@ namespace System.Reactive.Linq
         /// <returns>An observable sequence exposing a Unit value upon completion of the action, or an exception.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="actionAsync"/> is null or <paramref name="scheduler"/> is null.</exception>
         public static IObservable<Unit> FromAsync(Func<Task> actionAsync, IScheduler scheduler)
+        {
+            return FromAsync(actionAsync, scheduler, ignoreExceptionsAfterUnsubscribe: false);
+        }
+
+        /// <summary>
+        /// Converts an asynchronous action into an observable sequence. Each subscription to the resulting sequence causes the action to be started.
+        /// </summary>
+        /// <param name="actionAsync">Asynchronous action to convert.</param>
+        /// <param name="scheduler">Scheduler on which to notify observers.</param>
+        /// <param name="ignoreExceptionsAfterUnsubscribe">
+        /// If true, exceptions that occur after cancellation has been initiated by unsubscribing from the observable
+        /// this method returns will be handled and silently ignored. If false, they will go unobserved, meaning they
+        /// will eventually emerge through <see cref="TaskScheduler.UnobservedTaskException"/>.
+        /// </param>
+        /// <returns>An observable sequence exposing a Unit value upon completion of the action, or an exception.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="actionAsync"/> is null or <paramref name="scheduler"/> is null.</exception>
+        public static IObservable<Unit> FromAsync(Func<Task> actionAsync, IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe)
         {
             if (actionAsync == null)
             {
@@ -1458,6 +1781,24 @@ namespace System.Reactive.Linq
         /// <exception cref="ArgumentNullException"><paramref name="actionAsync"/> is null.</exception>
         public static IObservable<Unit> FromAsync(Func<CancellationToken, Task> actionAsync)
         {
+            return FromAsync(actionAsync, ignoreExceptionsAfterUnsubscribe: false);
+        }
+
+        /// <summary>
+        /// Converts an asynchronous action into an observable sequence. Each subscription to the resulting sequence causes the action to be started.
+        /// The CancellationToken passed to the asynchronous action is tied to the observable sequence's subscription that triggered the action's invocation and can be used for best-effort cancellation.
+        /// </summary>
+        /// <param name="actionAsync">Asynchronous action to convert.</param>
+        /// <param name="ignoreExceptionsAfterUnsubscribe">
+        /// If true, exceptions that occur after cancellation has been initiated by unsubscribing from the observable
+        /// this method returns will be handled and silently ignored. If false, they will go unobserved, meaning they
+        /// will eventually emerge through <see cref="TaskScheduler.UnobservedTaskException"/>.
+        /// </param>
+        /// <returns>An observable sequence exposing a Unit value upon completion of the action, or an exception.</returns>
+        /// <remarks>When a subscription to the resulting sequence is disposed, the CancellationToken that was fed to the asynchronous function will be signaled.</remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="actionAsync"/> is null.</exception>
+        public static IObservable<Unit> FromAsync(Func<CancellationToken, Task> actionAsync, bool ignoreExceptionsAfterUnsubscribe)
+        {
             if (actionAsync == null)
             {
                 throw new ArgumentNullException(nameof(actionAsync));
@@ -1476,6 +1817,25 @@ namespace System.Reactive.Linq
         /// <remarks>When a subscription to the resulting sequence is disposed, the CancellationToken that was fed to the asynchronous function will be signaled.</remarks>
         /// <exception cref="ArgumentNullException"><paramref name="actionAsync"/> is null or <paramref name="scheduler"/> is null.</exception>
         public static IObservable<Unit> FromAsync(Func<CancellationToken, Task> actionAsync, IScheduler scheduler)
+        {
+            return FromAsync(actionAsync, scheduler, ignoreExceptionsAfterUnsubscribe: false);
+        }
+
+        /// <summary>
+        /// Converts an asynchronous action into an observable sequence. Each subscription to the resulting sequence causes the action to be started.
+        /// The CancellationToken passed to the asynchronous action is tied to the observable sequence's subscription that triggered the action's invocation and can be used for best-effort cancellation.
+        /// </summary>
+        /// <param name="actionAsync">Asynchronous action to convert.</param>
+        /// <param name="scheduler">Scheduler on which to notify observers.</param>
+        /// <param name="ignoreExceptionsAfterUnsubscribe">
+        /// If true, exceptions that occur after cancellation has been initiated by unsubscribing from the observable
+        /// this method returns will be handled and silently ignored. If false, they will go unobserved, meaning they
+        /// will eventually emerge through <see cref="TaskScheduler.UnobservedTaskException"/>.
+        /// </param>
+        /// <returns>An observable sequence exposing a Unit value upon completion of the action, or an exception.</returns>
+        /// <remarks>When a subscription to the resulting sequence is disposed, the CancellationToken that was fed to the asynchronous function will be signaled.</remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="actionAsync"/> is null or <paramref name="scheduler"/> is null.</exception>
+        public static IObservable<Unit> FromAsync(Func<CancellationToken, Task> actionAsync, IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe)
         {
             if (actionAsync == null)
             {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable.Creation.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable.Creation.cs
@@ -209,12 +209,30 @@ namespace System.Reactive.Linq
         /// <remarks>This operator is especially useful in conjunction with the asynchronous programming features introduced in C# 5.0 and Visual Basic 11.</remarks>
         public static IObservable<TResult> Defer<TResult>(Func<Task<IObservable<TResult>>> observableFactoryAsync)
         {
+            return Defer(observableFactoryAsync, ignoreExceptionsAfterUnsubscribe: false);
+        }
+
+        /// <summary>
+        /// Returns an observable sequence that starts the specified asynchronous factory function whenever a new observer subscribes.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the elements in the sequence returned by the factory function, and in the resulting sequence.</typeparam>
+        /// <param name="observableFactoryAsync">Asynchronous factory function to start for each observer that subscribes to the resulting sequence.</param>
+        /// <param name="ignoreExceptionsAfterUnsubscribe">
+        /// If true, exceptions that occur after cancellation has been initiated by unsubscribing from the observable
+        /// this method returns will be handled and silently ignored. If false, they will go unobserved, meaning they
+        /// will eventually emerge through <see cref="TaskScheduler.UnobservedTaskException"/>.
+        /// </param>
+        /// <returns>An observable sequence whose observers trigger the given asynchronous observable factory function to be started.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="observableFactoryAsync"/> is null.</exception>
+        /// <remarks>This operator is especially useful in conjunction with the asynchronous programming features introduced in C# 5.0 and Visual Basic 11.</remarks>
+        public static IObservable<TResult> Defer<TResult>(Func<Task<IObservable<TResult>>> observableFactoryAsync, bool ignoreExceptionsAfterUnsubscribe)
+        {
             if (observableFactoryAsync == null)
             {
                 throw new ArgumentNullException(nameof(observableFactoryAsync));
             }
 
-            return s_impl.Defer(observableFactoryAsync);
+            return s_impl.Defer(observableFactoryAsync, ignoreExceptionsAfterUnsubscribe);
         }
 
         /// <summary>
@@ -229,12 +247,32 @@ namespace System.Reactive.Linq
         /// <remarks>When a subscription to the resulting sequence is disposed, the CancellationToken that was fed to the asynchronous observable factory function will be signaled.</remarks>
         public static IObservable<TResult> DeferAsync<TResult>(Func<CancellationToken, Task<IObservable<TResult>>> observableFactoryAsync)
         {
+            return DeferAsync(observableFactoryAsync, ignoreExceptionsAfterUnsubscribe: false);
+        }
+
+        /// <summary>
+        /// Returns an observable sequence that starts the specified cancellable asynchronous factory function whenever a new observer subscribes.
+        /// The CancellationToken passed to the asynchronous factory function is tied to the returned disposable subscription, allowing best-effort cancellation.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the elements in the sequence returned by the factory function, and in the resulting sequence.</typeparam>
+        /// <param name="observableFactoryAsync">Asynchronous factory function to start for each observer that subscribes to the resulting sequence.</param>
+        /// <param name="ignoreExceptionsAfterUnsubscribe">
+        /// If true, exceptions that occur after cancellation has been initiated by unsubscribing from the observable
+        /// this method returns will be handled and silently ignored. If false, they will go unobserved, meaning they
+        /// will eventually emerge through <see cref="TaskScheduler.UnobservedTaskException"/>.
+        /// </param>
+        /// <returns>An observable sequence whose observers trigger the given asynchronous observable factory function to be started.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="observableFactoryAsync"/> is null.</exception>
+        /// <remarks>This operator is especially useful in conjunction with the asynchronous programming features introduced in C# 5.0 and Visual Basic 11.</remarks>
+        /// <remarks>When a subscription to the resulting sequence is disposed, the CancellationToken that was fed to the asynchronous observable factory function will be signaled.</remarks>
+        public static IObservable<TResult> DeferAsync<TResult>(Func<CancellationToken, Task<IObservable<TResult>>> observableFactoryAsync, bool ignoreExceptionsAfterUnsubscribe)
+        {
             if (observableFactoryAsync == null)
             {
                 throw new ArgumentNullException(nameof(observableFactoryAsync));
             }
 
-            return s_impl.Defer(observableFactoryAsync);
+            return s_impl.Defer(observableFactoryAsync, ignoreExceptionsAfterUnsubscribe);
         }
 
         #endregion

--- a/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Async.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Async.cs
@@ -658,17 +658,17 @@ namespace System.Reactive.Linq
             return ToAsync(function, scheduler)();
         }
 
-        public virtual IObservable<TSource> StartAsync<TSource>(Func<Task<TSource>> functionAsync)
+        public virtual IObservable<TSource> StartAsync<TSource>(Func<Task<TSource>> functionAsync, bool ignoreExceptionsAfterUnsubscribe)
         {
-            return StartAsyncImpl(functionAsync, null);
+            return StartAsyncImpl(functionAsync, null, ignoreExceptionsAfterUnsubscribe);
         }
 
-        public virtual IObservable<TSource> StartAsync<TSource>(Func<Task<TSource>> functionAsync, IScheduler scheduler)
+        public virtual IObservable<TSource> StartAsync<TSource>(Func<Task<TSource>> functionAsync, IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe)
         {
-            return StartAsyncImpl(functionAsync, scheduler);
+            return StartAsyncImpl(functionAsync, scheduler, ignoreExceptionsAfterUnsubscribe);
         }
 
-        private IObservable<TSource> StartAsyncImpl<TSource>(Func<Task<TSource>> functionAsync, IScheduler? scheduler)
+        private IObservable<TSource> StartAsyncImpl<TSource>(Func<Task<TSource>> functionAsync, IScheduler? scheduler, bool ignoreExceptionsAfterUnsubscribe)
         {
             Task<TSource> task;
             try
@@ -682,23 +682,23 @@ namespace System.Reactive.Linq
 
             if (scheduler != null)
             {
-                return task.ToObservable(scheduler);
+                return task.ToObservable(scheduler, ignoreExceptionsAfterUnsubscribe);
             }
             
-            return task.ToObservable();
+            return task.ToObservable(ignoreExceptionsAfterUnsubscribe);
         }
 
-        public virtual IObservable<TSource> StartAsync<TSource>(Func<CancellationToken, Task<TSource>> functionAsync)
+        public virtual IObservable<TSource> StartAsync<TSource>(Func<CancellationToken, Task<TSource>> functionAsync, bool ignoreExceptionsAfterUnsubscribe)
         {
-            return StartAsyncImpl(functionAsync, null);
+            return StartAsyncImpl(functionAsync, null, ignoreExceptionsAfterUnsubscribe);
         }
 
-        public virtual IObservable<TSource> StartAsync<TSource>(Func<CancellationToken, Task<TSource>> functionAsync, IScheduler scheduler)
+        public virtual IObservable<TSource> StartAsync<TSource>(Func<CancellationToken, Task<TSource>> functionAsync, IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe)
         {
-            return StartAsyncImpl(functionAsync, scheduler);
+            return StartAsyncImpl(functionAsync, scheduler, ignoreExceptionsAfterUnsubscribe);
         }
 
-        private IObservable<TSource> StartAsyncImpl<TSource>(Func<CancellationToken, Task<TSource>> functionAsync, IScheduler? scheduler)
+        private IObservable<TSource> StartAsyncImpl<TSource>(Func<CancellationToken, Task<TSource>> functionAsync, IScheduler? scheduler, bool ignoreExceptionsAfterUnsubscribe)
         {
             var cancellable = new CancellationDisposable();
 
@@ -716,11 +716,11 @@ namespace System.Reactive.Linq
 
             if (scheduler != null)
             {
-                result = task.ToObservable(scheduler);
+                result = task.ToObservable(scheduler, ignoreExceptionsAfterUnsubscribe);
             }
             else
             {
-                result = task.ToObservable();
+                result = task.ToObservable(ignoreExceptionsAfterUnsubscribe);
             }
 
             return new StartAsyncObservable<TSource>(cancellable, result);
@@ -761,17 +761,17 @@ namespace System.Reactive.Linq
             return ToAsync(action, scheduler)();
         }
 
-        public virtual IObservable<Unit> StartAsync(Func<Task> actionAsync)
+        public virtual IObservable<Unit> StartAsync(Func<Task> actionAsync, bool ignoreExceptionsAfterUnsubscribe)
         {
-            return StartAsyncImpl(actionAsync, null);
+            return StartAsyncImpl(actionAsync, null, ignoreExceptionsAfterUnsubscribe);
         }
 
-        public virtual IObservable<Unit> StartAsync(Func<Task> actionAsync, IScheduler scheduler)
+        public virtual IObservable<Unit> StartAsync(Func<Task> actionAsync, IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe)
         {
-            return StartAsyncImpl(actionAsync, scheduler);
+            return StartAsyncImpl(actionAsync, scheduler, ignoreExceptionsAfterUnsubscribe);
         }
 
-        private IObservable<Unit> StartAsyncImpl(Func<Task> actionAsync, IScheduler? scheduler)
+        private IObservable<Unit> StartAsyncImpl(Func<Task> actionAsync, IScheduler? scheduler, bool ignoreExceptionsAfterUnsubscribe)
         {
             Task task;
             try
@@ -785,23 +785,23 @@ namespace System.Reactive.Linq
 
             if (scheduler != null)
             {
-                return task.ToObservable(scheduler);
+                return task.ToObservable(scheduler, ignoreExceptionsAfterUnsubscribe);
             }
             
-            return task.ToObservable();
+            return task.ToObservable(ignoreExceptionsAfterUnsubscribe);
         }
 
-        public virtual IObservable<Unit> StartAsync(Func<CancellationToken, Task> actionAsync)
+        public virtual IObservable<Unit> StartAsync(Func<CancellationToken, Task> actionAsync, bool ignoreExceptionsAfterUnsubscribe)
         {
-            return StartAsyncImpl(actionAsync, null);
+            return StartAsyncImpl(actionAsync, null, ignoreExceptionsAfterUnsubscribe);
         }
 
-        public virtual IObservable<Unit> StartAsync(Func<CancellationToken, Task> actionAsync, IScheduler scheduler)
+        public virtual IObservable<Unit> StartAsync(Func<CancellationToken, Task> actionAsync, IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe)
         {
-            return StartAsyncImpl(actionAsync, scheduler);
+            return StartAsyncImpl(actionAsync, scheduler, ignoreExceptionsAfterUnsubscribe);
         }
 
-        private IObservable<Unit> StartAsyncImpl(Func<CancellationToken, Task> actionAsync, IScheduler? scheduler)
+        private IObservable<Unit> StartAsyncImpl(Func<CancellationToken, Task> actionAsync, IScheduler? scheduler, bool ignoreExceptionsAfterUnsubscribe)
         {
             var cancellable = new CancellationDisposable();
 
@@ -819,11 +819,11 @@ namespace System.Reactive.Linq
 
             if (scheduler != null)
             {
-                result = task.ToObservable(scheduler);
+                result = task.ToObservable(scheduler, ignoreExceptionsAfterUnsubscribe);
             }
             else
             {
-                result = task.ToObservable();
+                result = task.ToObservable(ignoreExceptionsAfterUnsubscribe);
             }
 
             return new StartAsyncObservable<Unit>(cancellable, result);
@@ -837,48 +837,48 @@ namespace System.Reactive.Linq
 
         #region Func
 
-        public virtual IObservable<TResult> FromAsync<TResult>(Func<Task<TResult>> functionAsync)
+        public virtual IObservable<TResult> FromAsync<TResult>(Func<Task<TResult>> functionAsync, bool ignoreExceptionsAfterUnsubscribe)
         {
-            return Defer(() => StartAsync(functionAsync));
+            return Defer(() => StartAsync(functionAsync, ignoreExceptionsAfterUnsubscribe));
         }
 
-        public virtual IObservable<TResult> FromAsync<TResult>(Func<CancellationToken, Task<TResult>> functionAsync)
+        public virtual IObservable<TResult> FromAsync<TResult>(Func<CancellationToken, Task<TResult>> functionAsync, bool ignoreExceptionsAfterUnsubscribe)
         {
-            return Defer(() => StartAsync(functionAsync));
+            return Defer(() => StartAsync(functionAsync, ignoreExceptionsAfterUnsubscribe));
         }
 
-        public virtual IObservable<TResult> FromAsync<TResult>(Func<Task<TResult>> functionAsync, IScheduler scheduler)
+        public virtual IObservable<TResult> FromAsync<TResult>(Func<Task<TResult>> functionAsync, IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe)
         {
-            return Defer(() => StartAsync(functionAsync, scheduler));
+            return Defer(() => StartAsync(functionAsync, scheduler, ignoreExceptionsAfterUnsubscribe));
         }
 
-        public virtual IObservable<TResult> FromAsync<TResult>(Func<CancellationToken, Task<TResult>> functionAsync, IScheduler scheduler)
+        public virtual IObservable<TResult> FromAsync<TResult>(Func<CancellationToken, Task<TResult>> functionAsync, IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe)
         {
-            return Defer(() => StartAsync(functionAsync, scheduler));
+            return Defer(() => StartAsync(functionAsync, scheduler, ignoreExceptionsAfterUnsubscribe));
         }
 
         #endregion
 
         #region Action
 
-        public virtual IObservable<Unit> FromAsync(Func<Task> actionAsync)
+        public virtual IObservable<Unit> FromAsync(Func<Task> actionAsync, bool ignoreExceptionsAfterUnsubscribe)
         {
-            return Defer(() => StartAsync(actionAsync));
+            return Defer(() => StartAsync(actionAsync, ignoreExceptionsAfterUnsubscribe));
         }
 
-        public virtual IObservable<Unit> FromAsync(Func<CancellationToken, Task> actionAsync)
+        public virtual IObservable<Unit> FromAsync(Func<CancellationToken, Task> actionAsync, bool ignoreExceptionsAfterUnsubscribe)
         {
-            return Defer(() => StartAsync(actionAsync));
+            return Defer(() => StartAsync(actionAsync, ignoreExceptionsAfterUnsubscribe));
         }
 
-        public virtual IObservable<Unit> FromAsync(Func<Task> actionAsync, IScheduler scheduler)
+        public virtual IObservable<Unit> FromAsync(Func<Task> actionAsync, IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe)
         {
-            return Defer(() => StartAsync(actionAsync, scheduler));
+            return Defer(() => StartAsync(actionAsync, scheduler, ignoreExceptionsAfterUnsubscribe));
         }
 
-        public virtual IObservable<Unit> FromAsync(Func<CancellationToken, Task> actionAsync, IScheduler scheduler)
+        public virtual IObservable<Unit> FromAsync(Func<CancellationToken, Task> actionAsync, IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe)
         {
-            return Defer(() => StartAsync(actionAsync, scheduler));
+            return Defer(() => StartAsync(actionAsync, scheduler, ignoreExceptionsAfterUnsubscribe));
         }
 
         #endregion

--- a/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Creation.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Creation.cs
@@ -299,14 +299,14 @@ namespace System.Reactive.Linq
 
         #region + DeferAsync +
 
-        public virtual IObservable<TValue> Defer<TValue>(Func<Task<IObservable<TValue>>> observableFactoryAsync)
+        public virtual IObservable<TValue> Defer<TValue>(Func<Task<IObservable<TValue>>> observableFactoryAsync, bool ignoreExceptionsAfterUnsubscribe)
         {
-            return Defer(() => StartAsync(observableFactoryAsync).Merge());
+            return Defer(() => StartAsync(observableFactoryAsync, ignoreExceptionsAfterUnsubscribe).Merge());
         }
 
-        public virtual IObservable<TValue> Defer<TValue>(Func<CancellationToken, Task<IObservable<TValue>>> observableFactoryAsync)
+        public virtual IObservable<TValue> Defer<TValue>(Func<CancellationToken, Task<IObservable<TValue>>> observableFactoryAsync, bool ignoreExceptionsAfterUnsubscribe)
         {
-            return Defer(() => StartAsync(observableFactoryAsync).Merge());
+            return Defer(() => StartAsync(observableFactoryAsync, ignoreExceptionsAfterUnsubscribe).Merge());
         }
 
         #endregion

--- a/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Api/ApiApprovalTests.Core.verified.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Api/ApiApprovalTests.Core.verified.cs
@@ -990,7 +990,9 @@ namespace System.Reactive.Linq
         public static System.IObservable<TSource> DefaultIfEmpty<TSource>(this System.IObservable<TSource> source, TSource defaultValue) { }
         public static System.IObservable<TResult> Defer<TResult>(System.Func<System.IObservable<TResult>> observableFactory) { }
         public static System.IObservable<TResult> Defer<TResult>(System.Func<System.Threading.Tasks.Task<System.IObservable<TResult>>> observableFactoryAsync) { }
+        public static System.IObservable<TResult> Defer<TResult>(System.Func<System.Threading.Tasks.Task<System.IObservable<TResult>>> observableFactoryAsync, bool ignoreExceptionsAfterUnsubscribe) { }
         public static System.IObservable<TResult> DeferAsync<TResult>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<TResult>>> observableFactoryAsync) { }
+        public static System.IObservable<TResult> DeferAsync<TResult>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<System.IObservable<TResult>>> observableFactoryAsync, bool ignoreExceptionsAfterUnsubscribe) { }
         public static System.IObservable<TSource> Delay<TSource>(this System.IObservable<TSource> source, System.DateTimeOffset dueTime) { }
         public static System.IObservable<TSource> Delay<TSource>(this System.IObservable<TSource> source, System.TimeSpan dueTime) { }
         public static System.IObservable<TSource> Delay<TSource>(this System.IObservable<TSource> source, System.DateTimeOffset dueTime, System.Reactive.Concurrency.IScheduler scheduler) { }
@@ -1048,15 +1050,19 @@ namespace System.Reactive.Linq
         public static System.Threading.Tasks.Task ForEachAsync<TSource>(this System.IObservable<TSource> source, System.Action<TSource, int> onNext, System.Threading.CancellationToken cancellationToken) { }
         public static System.IObservable<System.Reactive.Unit> FromAsync(System.Func<System.Threading.Tasks.Task> actionAsync) { }
         public static System.IObservable<System.Reactive.Unit> FromAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> actionAsync) { }
+        public static System.IObservable<System.Reactive.Unit> FromAsync(System.Func<System.Threading.Tasks.Task> actionAsync, bool ignoreExceptionsAfterUnsubscribe) { }
         public static System.IObservable<System.Reactive.Unit> FromAsync(System.Func<System.Threading.Tasks.Task> actionAsync, System.Reactive.Concurrency.IScheduler scheduler) { }
         public static System.IObservable<System.Reactive.Unit> FromAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> actionAsync, bool ignoreExceptionsAfterUnsubscribe) { }
         public static System.IObservable<System.Reactive.Unit> FromAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> actionAsync, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public static System.IObservable<System.Reactive.Unit> FromAsync(System.Func<System.Threading.Tasks.Task> actionAsync, System.Reactive.Concurrency.IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe) { }
         public static System.IObservable<System.Reactive.Unit> FromAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> actionAsync, System.Reactive.Concurrency.IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe) { }
         public static System.IObservable<TResult> FromAsync<TResult>(System.Func<System.Threading.Tasks.Task<TResult>> functionAsync) { }
         public static System.IObservable<TResult> FromAsync<TResult>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>> functionAsync) { }
+        public static System.IObservable<TResult> FromAsync<TResult>(System.Func<System.Threading.Tasks.Task<TResult>> functionAsync, bool ignoreExceptionsAfterUnsubscribe) { }
         public static System.IObservable<TResult> FromAsync<TResult>(System.Func<System.Threading.Tasks.Task<TResult>> functionAsync, System.Reactive.Concurrency.IScheduler scheduler) { }
         public static System.IObservable<TResult> FromAsync<TResult>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>> functionAsync, bool ignoreExceptionsAfterUnsubscribe) { }
         public static System.IObservable<TResult> FromAsync<TResult>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>> functionAsync, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public static System.IObservable<TResult> FromAsync<TResult>(System.Func<System.Threading.Tasks.Task<TResult>> functionAsync, System.Reactive.Concurrency.IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe) { }
         public static System.IObservable<TResult> FromAsync<TResult>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>> functionAsync, System.Reactive.Concurrency.IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe) { }
         [System.Obsolete(@"This conversion is no longer supported. Replace use of the Begin/End asynchronous method pair with a new Task-based async method, and convert the result using ToObservable. If no Task-based async method is available, use Task.Factory.FromAsync to obtain a Task object.")]
         public static System.Func<System.IObservable<System.Reactive.Unit>> FromAsyncPattern(System.Func<System.AsyncCallback, object?, System.IAsyncResult> begin, System.Action<System.IAsyncResult> end) { }
@@ -1382,15 +1388,19 @@ namespace System.Reactive.Linq
         public static System.IObservable<TResult> Start<TResult>(System.Func<TResult> function, System.Reactive.Concurrency.IScheduler scheduler) { }
         public static System.IObservable<System.Reactive.Unit> StartAsync(System.Func<System.Threading.Tasks.Task> actionAsync) { }
         public static System.IObservable<System.Reactive.Unit> StartAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> actionAsync) { }
+        public static System.IObservable<System.Reactive.Unit> StartAsync(System.Func<System.Threading.Tasks.Task> actionAsync, bool ignoreExceptionsAfterUnsubscribe) { }
         public static System.IObservable<System.Reactive.Unit> StartAsync(System.Func<System.Threading.Tasks.Task> actionAsync, System.Reactive.Concurrency.IScheduler scheduler) { }
         public static System.IObservable<System.Reactive.Unit> StartAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> actionAsync, bool ignoreExceptionsAfterUnsubscribe) { }
         public static System.IObservable<System.Reactive.Unit> StartAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> actionAsync, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public static System.IObservable<System.Reactive.Unit> StartAsync(System.Func<System.Threading.Tasks.Task> actionAsync, System.Reactive.Concurrency.IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe) { }
         public static System.IObservable<System.Reactive.Unit> StartAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> actionAsync, System.Reactive.Concurrency.IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe) { }
         public static System.IObservable<TResult> StartAsync<TResult>(System.Func<System.Threading.Tasks.Task<TResult>> functionAsync) { }
         public static System.IObservable<TResult> StartAsync<TResult>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>> functionAsync) { }
+        public static System.IObservable<TResult> StartAsync<TResult>(System.Func<System.Threading.Tasks.Task<TResult>> functionAsync, bool ignoreExceptionsAfterUnsubscribe) { }
         public static System.IObservable<TResult> StartAsync<TResult>(System.Func<System.Threading.Tasks.Task<TResult>> functionAsync, System.Reactive.Concurrency.IScheduler scheduler) { }
         public static System.IObservable<TResult> StartAsync<TResult>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>> functionAsync, bool ignoreExceptionsAfterUnsubscribe) { }
         public static System.IObservable<TResult> StartAsync<TResult>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>> functionAsync, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public static System.IObservable<TResult> StartAsync<TResult>(System.Func<System.Threading.Tasks.Task<TResult>> functionAsync, System.Reactive.Concurrency.IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe) { }
         public static System.IObservable<TResult> StartAsync<TResult>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>> functionAsync, System.Reactive.Concurrency.IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe) { }
         public static System.IObservable<TSource> StartWith<TSource>(this System.IObservable<TSource> source, System.Collections.Generic.IEnumerable<TSource> values) { }
         public static System.IObservable<TSource> StartWith<TSource>(this System.IObservable<TSource> source, params TSource[] values) { }
@@ -3128,9 +3138,13 @@ namespace System.Reactive.Threading.Tasks
     public static class TaskObservableExtensions
     {
         public static System.IObservable<System.Reactive.Unit> ToObservable(this System.Threading.Tasks.Task task) { }
+        public static System.IObservable<System.Reactive.Unit> ToObservable(this System.Threading.Tasks.Task task, bool ignoreExceptionsAfterUnsubscribe) { }
         public static System.IObservable<System.Reactive.Unit> ToObservable(this System.Threading.Tasks.Task task, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public static System.IObservable<System.Reactive.Unit> ToObservable(this System.Threading.Tasks.Task task, System.Reactive.Concurrency.IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe) { }
         public static System.IObservable<TResult> ToObservable<TResult>(this System.Threading.Tasks.Task<TResult> task) { }
+        public static System.IObservable<TResult> ToObservable<TResult>(this System.Threading.Tasks.Task<TResult> task, bool ignoreExceptionsAfterUnsubscribe) { }
         public static System.IObservable<TResult> ToObservable<TResult>(this System.Threading.Tasks.Task<TResult> task, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public static System.IObservable<TResult> ToObservable<TResult>(this System.Threading.Tasks.Task<TResult> task, System.Reactive.Concurrency.IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe) { }
         public static System.Threading.Tasks.Task<TResult> ToTask<TResult>(this System.IObservable<TResult> observable) { }
         public static System.Threading.Tasks.Task<TResult> ToTask<TResult>(this System.IObservable<TResult> observable, System.Reactive.Concurrency.IScheduler scheduler) { }
         public static System.Threading.Tasks.Task<TResult> ToTask<TResult>(this System.IObservable<TResult> observable, System.Threading.CancellationToken cancellationToken) { }

--- a/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Api/ApiApprovalTests.Core.verified.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Api/ApiApprovalTests.Core.verified.cs
@@ -1049,11 +1049,15 @@ namespace System.Reactive.Linq
         public static System.IObservable<System.Reactive.Unit> FromAsync(System.Func<System.Threading.Tasks.Task> actionAsync) { }
         public static System.IObservable<System.Reactive.Unit> FromAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> actionAsync) { }
         public static System.IObservable<System.Reactive.Unit> FromAsync(System.Func<System.Threading.Tasks.Task> actionAsync, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public static System.IObservable<System.Reactive.Unit> FromAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> actionAsync, bool ignoreExceptionsAfterUnsubscribe) { }
         public static System.IObservable<System.Reactive.Unit> FromAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> actionAsync, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public static System.IObservable<System.Reactive.Unit> FromAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> actionAsync, System.Reactive.Concurrency.IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe) { }
         public static System.IObservable<TResult> FromAsync<TResult>(System.Func<System.Threading.Tasks.Task<TResult>> functionAsync) { }
         public static System.IObservable<TResult> FromAsync<TResult>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>> functionAsync) { }
         public static System.IObservable<TResult> FromAsync<TResult>(System.Func<System.Threading.Tasks.Task<TResult>> functionAsync, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public static System.IObservable<TResult> FromAsync<TResult>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>> functionAsync, bool ignoreExceptionsAfterUnsubscribe) { }
         public static System.IObservable<TResult> FromAsync<TResult>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>> functionAsync, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public static System.IObservable<TResult> FromAsync<TResult>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>> functionAsync, System.Reactive.Concurrency.IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe) { }
         [System.Obsolete(@"This conversion is no longer supported. Replace use of the Begin/End asynchronous method pair with a new Task-based async method, and convert the result using ToObservable. If no Task-based async method is available, use Task.Factory.FromAsync to obtain a Task object.")]
         public static System.Func<System.IObservable<System.Reactive.Unit>> FromAsyncPattern(System.Func<System.AsyncCallback, object?, System.IAsyncResult> begin, System.Action<System.IAsyncResult> end) { }
         [System.Obsolete(@"This conversion is no longer supported. Replace use of the Begin/End asynchronous method pair with a new Task-based async method, and convert the result using ToObservable. If no Task-based async method is available, use Task.Factory.FromAsync to obtain a Task object.")]
@@ -1379,11 +1383,15 @@ namespace System.Reactive.Linq
         public static System.IObservable<System.Reactive.Unit> StartAsync(System.Func<System.Threading.Tasks.Task> actionAsync) { }
         public static System.IObservable<System.Reactive.Unit> StartAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> actionAsync) { }
         public static System.IObservable<System.Reactive.Unit> StartAsync(System.Func<System.Threading.Tasks.Task> actionAsync, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public static System.IObservable<System.Reactive.Unit> StartAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> actionAsync, bool ignoreExceptionsAfterUnsubscribe) { }
         public static System.IObservable<System.Reactive.Unit> StartAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> actionAsync, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public static System.IObservable<System.Reactive.Unit> StartAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> actionAsync, System.Reactive.Concurrency.IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe) { }
         public static System.IObservable<TResult> StartAsync<TResult>(System.Func<System.Threading.Tasks.Task<TResult>> functionAsync) { }
         public static System.IObservable<TResult> StartAsync<TResult>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>> functionAsync) { }
         public static System.IObservable<TResult> StartAsync<TResult>(System.Func<System.Threading.Tasks.Task<TResult>> functionAsync, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public static System.IObservable<TResult> StartAsync<TResult>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>> functionAsync, bool ignoreExceptionsAfterUnsubscribe) { }
         public static System.IObservable<TResult> StartAsync<TResult>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>> functionAsync, System.Reactive.Concurrency.IScheduler scheduler) { }
+        public static System.IObservable<TResult> StartAsync<TResult>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>> functionAsync, System.Reactive.Concurrency.IScheduler scheduler, bool ignoreExceptionsAfterUnsubscribe) { }
         public static System.IObservable<TSource> StartWith<TSource>(this System.IObservable<TSource> source, System.Collections.Generic.IEnumerable<TSource> values) { }
         public static System.IObservable<TSource> StartWith<TSource>(this System.IObservable<TSource> source, params TSource[] values) { }
         public static System.IObservable<TSource> StartWith<TSource>(this System.IObservable<TSource> source, System.Reactive.Concurrency.IScheduler scheduler, System.Collections.Generic.IEnumerable<TSource> values) { }

--- a/Rx.NET/Source/tests/Tests.System.Reactive/TaskErrorObservation.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/TaskErrorObservation.cs
@@ -1,0 +1,162 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT License.
+// See the LICENSE file in the project root for more information. 
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace Tests.System.Reactive
+{
+    /// <summary>
+    /// Verifies behavior around unobserved exceptions from tasks.
+    /// </summary>
+    /// <remarks>
+    /// Testing whether unhandled exceptions emerge from <see cref="TaskScheduler.UnobservedTaskException"/> is not
+    /// entirely straightforward. A few tests need to do this because we have some historical behaviour described in
+    /// https://github.com/dotnet/reactive/issues/1256 that needs to be preserved for backwards compatibility, along
+    /// with some new functionality enabling optional different behavior regarding unobserved exceptions. This provides
+    /// common mechanism to enable such testing.
+    /// </remarks>
+    internal class TaskErrorObservation : IDisposable
+    {
+        private ManualResetEventSlim _exceptionReportedAsUnobserved;
+        private WeakReference<Task> _taskWeakReference;
+
+        public TaskErrorObservation()
+        {
+            _exceptionReportedAsUnobserved = new(false);
+            TaskScheduler.UnobservedTaskException += HandleUnobservedException;
+        }
+
+        public Exception Exception { get; } = new();
+
+        public void Dispose()
+        {
+            if (_exceptionReportedAsUnobserved is not null)
+            {
+                _exceptionReportedAsUnobserved.Dispose();
+                _exceptionReportedAsUnobserved = null;
+                TaskScheduler.UnobservedTaskException -= HandleUnobservedException;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IDisposable SuscribeWithoutKeepingSourceReachable(
+            Func<Func<Task, Task>, Exception, IDisposable> subscribe)
+        {
+            // We provide nested function because the temporary storage location that
+            // holds the value returned by a call to, say, Observable.StartAsync can end up keeping it reachable
+            // for GC purposes, which in turn keeps the task reachable. That stops the
+            // finalization-driven unobserved exception detection from working.
+            // By calling Subscribe in a method whose stack frame is then immediately torn
+            // down, we ensure that we don't hang onto anything other than the IDisposable
+            // it returns.
+
+            return subscribe(
+                t =>
+                {
+                    _taskWeakReference = new(t);
+                    return t;
+                },
+                this.Exception);
+        }
+
+        public IDisposable SuscribeWithoutKeepingSourceReachable<T>(
+            Func<Func<Task<T>, Task<T>>, Exception, IDisposable> subscribe)
+        {
+            return SuscribeWithoutKeepingSourceReachable(
+                (Func<Task, Task> setTask, Exception ex) => subscribe(
+                    t =>
+                    {
+                        setTask(t);
+                        return t;
+                    }, ex));
+        }
+
+
+        public void AssertExceptionReportedAsUnobserved()
+        {
+            int start = Environment.TickCount;
+            bool firstIteration = true;
+            while (!_exceptionReportedAsUnobserved.Wait(TimeSpan.FromSeconds(firstIteration ? 0 : 0.001)) &&
+                ((Environment.TickCount - start) < 5000))
+            {
+                firstIteration = false;
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+            }
+
+            Assert.True(_exceptionReportedAsUnobserved.Wait(TimeSpan.FromSeconds(0.01)));
+        }
+
+        /// <summary>
+        /// Waits for the task to become unreachable, and then verifies that this did not result in
+        /// <see cref="TaskScheduler.UnobservedTaskException"/> reporting the failure.
+        /// </summary>
+        /// <exception cref="InvalidOperationException"></exception>
+        public void AssertExceptionNotReportedAsUnobserved()
+        {
+            if (_taskWeakReference is null)
+            {
+                throw new InvalidOperationException("Test did not supply task to " + nameof(TaskErrorObservation));
+            }
+
+            int start = Environment.TickCount;
+            bool firstIteration = true;
+            do
+            {
+                // We try to get away without sleeping, to enable tests to run as quickly as
+                // possible, but if the object remains reachable after the initial attempt to
+                // force a GC and then immediately run finalizers, there's probably some deferred
+                // work waiting to happen somewhere, so we are better off backing off and giving
+                // that a chance to run.
+                if (firstIteration)
+                {
+                    firstIteration = false;
+                }
+                else
+                {
+                    Thread.Sleep(1);
+                }
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+            } while (IsTaskStillReachable() &&
+                     ((Environment.TickCount - start) < 5000));
+
+
+            // The task is now unreachable, but it's possible that this happened in between our
+            // last call to GC.WaitForPendingFinalizers and our test for reachability, in which
+            // case it might still be awaiting finalization, so we need one more of these to ensure
+            // it gets flushed through:
+            GC.WaitForPendingFinalizers();
+
+            Assert.False(_exceptionReportedAsUnobserved.IsSet);
+        }
+
+        // This needs to be done in a separate method to ensure that when the weak reference returns a task, we
+        // immediately destroy the stack frame containing the temporary variable into which it was returned,
+        // to avoid keeping the task reachable by accident.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private bool IsTaskStillReachable()
+        {
+            return _taskWeakReference.TryGetTarget(out _);
+        }
+
+
+        private void HandleUnobservedException(object sender, UnobservedTaskExceptionEventArgs e)
+        {
+            if (e.Exception.InnerException == this.Exception)
+            {
+                e.SetObserved();
+                _exceptionReportedAsUnobserved.Set();
+            }
+        }
+    }
+}

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/ArgumentValidationTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/ArgumentValidationTest.cs
@@ -67,6 +67,7 @@ namespace ReactiveTests.Tests
                 { "Object", new object() },
                 { "Exception", new Exception() },
                 { "String", "String" },
+                { "Boolean", false },
 
                 { "IDictionary`2[Int32, IObservable`1[Int32]]", new Dictionary<int, IObservable<int>>() },
 

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/StartAsyncTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/StartAsyncTest.cs
@@ -7,10 +7,14 @@ using System.Linq;
 using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Reactive.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Tests.System.Reactive;
 
 using Assert = Xunit.Assert;
 
@@ -37,13 +41,19 @@ namespace ReactiveTests.Tests
             var s = Scheduler.Immediate;
 
             ReactiveAssert.Throws<ArgumentNullException>(() => Observable.StartAsync(default(Func<Task<int>>)));
+            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.StartAsync(default(Func<Task<int>>), true));
             ReactiveAssert.Throws<ArgumentNullException>(() => Observable.StartAsync(default(Func<CancellationToken, Task<int>>)));
+            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.StartAsync(default(Func<CancellationToken, Task<int>>), true));
 
             ReactiveAssert.Throws<ArgumentNullException>(() => Observable.StartAsync(default(Func<Task<int>>), s));
+            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.StartAsync(default(Func<Task<int>>), s, true));
             ReactiveAssert.Throws<ArgumentNullException>(() => Observable.StartAsync(default(Func<CancellationToken, Task<int>>), s));
+            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.StartAsync(default(Func<CancellationToken, Task<int>>), s, true));
 
-            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.StartAsync(() => _doneTask, default));
-            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.StartAsync(ct => _doneTask, default));
+            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.StartAsync(() => _doneTask, default(IScheduler)));
+            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.StartAsync(() => _doneTask, default(IScheduler), true));
+            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.StartAsync(ct => _doneTask, default(IScheduler)));
+            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.StartAsync(ct => _doneTask, default(IScheduler), true));
         }
 
         [TestMethod]
@@ -182,6 +192,94 @@ namespace ReactiveTests.Tests
             }
         }
 
+        [TestMethod]
+        public void Start_Func_UnsubscribeThenError_ErrorReportedAsUnobserved()
+        {
+            Start_Func_ErrorAfterUnsubscribeReportedAsUnobserved_Core(
+                createTask => Observable.StartAsync(createTask),
+                errorObservation =>
+                {
+                    errorObservation.AssertExceptionReportedAsUnobserved();
+                });
+        }
+
+        [TestMethod]
+        public void Start_FuncWithCancel_UnsubscribeThenError_ErrorReportedAsUnobserved()
+        {
+            Start_Func_ErrorAfterUnsubscribeReportedAsUnobserved_Core(
+                createTask => Observable.StartAsync(_ => createTask()),
+                errorObservation =>
+                {
+                    errorObservation.AssertExceptionReportedAsUnobserved();
+                });
+        }
+
+        [TestMethod]
+        public void Start_Func_WithScheduler_UnsubscribeThenError_ErrorReportedAsUnobserved()
+        {
+            Start_Func_ErrorAfterUnsubscribeReportedAsUnobserved_Core(
+                createTask => Observable.StartAsync(createTask, TaskPoolScheduler.Default),
+                errorObservation =>
+                {
+                    errorObservation.AssertExceptionReportedAsUnobserved();
+                });
+        }
+
+        [TestMethod]
+        public void Start_FuncWithCancel_WithScheduler_UnsubscribeThenError_ErrorReportedAsUnobserved()
+        {
+            Start_Func_ErrorAfterUnsubscribeReportedAsUnobserved_Core(
+                createTask => Observable.StartAsync(_ => createTask(), TaskPoolScheduler.Default),
+                errorObservation =>
+                {
+                    errorObservation.AssertExceptionReportedAsUnobserved();
+                });
+        }
+
+        [TestMethod]
+        public void Start_Func_IgnorePostUnsubscribeErrors_UnsubscribeThenError_ErrorNotReportedAsUnobserved()
+        {
+            Start_Func_ErrorAfterUnsubscribeReportedAsUnobserved_Core(
+                createTask => Observable.StartAsync(createTask, ignoreExceptionsAfterUnsubscribe: true),
+                errorObservation =>
+                {
+                    errorObservation.AssertExceptionNotReportedAsUnobserved();
+                });
+        }
+
+        [TestMethod]
+        public void Start_FuncWithCancel_IgnorePostUnsubscribeErrors_UnsubscribeThenError_ErrorNotReportedAsUnobserved()
+        {
+            Start_Func_ErrorAfterUnsubscribeReportedAsUnobserved_Core(
+                createTask => Observable.StartAsync(_ => createTask(), ignoreExceptionsAfterUnsubscribe: true),
+                errorObservation =>
+                {
+                    errorObservation.AssertExceptionNotReportedAsUnobserved();
+                });
+        }
+
+        [TestMethod]
+        public void Start_Func_WithScheduler_IgnorePostUnsubscribeErrors_UnsubscribeThenError_ErrorNotReportedAsUnobserved()
+        {
+            Start_Func_ErrorAfterUnsubscribeReportedAsUnobserved_Core(
+                createTask => Observable.StartAsync(createTask, TaskPoolScheduler.Default, ignoreExceptionsAfterUnsubscribe: true),
+                errorObservation =>
+                {
+                    errorObservation.AssertExceptionNotReportedAsUnobserved();
+                });
+        }
+
+        [TestMethod]
+        public void Start_FuncWithCancel_WithScheduler_IgnorePostUnsubscribeErrors_UnsubscribeThenError_ErrorNotReportedAsUnobserved()
+        {
+            Start_Func_ErrorAfterUnsubscribeReportedAsUnobserved_Core(
+                createTask => Observable.StartAsync(_ => createTask(), TaskPoolScheduler.Default, ignoreExceptionsAfterUnsubscribe: true),
+                errorObservation =>
+                {
+                    errorObservation.AssertExceptionNotReportedAsUnobserved();
+                });
+        }
+
 #if DESKTOPCLR
         [TestMethod]
         public void StartAsync_Func_Scheduler1()
@@ -244,12 +342,17 @@ namespace ReactiveTests.Tests
             var s = Scheduler.Immediate;
 
             ReactiveAssert.Throws<ArgumentNullException>(() => Observable.StartAsync(default(Func<Task>)));
+            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.StartAsync(default(Func<Task>), true));
             ReactiveAssert.Throws<ArgumentNullException>(() => Observable.StartAsync(default(Func<CancellationToken, Task>)));
+            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.StartAsync(default(Func<CancellationToken, Task>), true));
 
             ReactiveAssert.Throws<ArgumentNullException>(() => Observable.StartAsync(default(Func<Task>), s));
             ReactiveAssert.Throws<ArgumentNullException>(() => Observable.StartAsync(default(Func<CancellationToken, Task>), s));
-            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.StartAsync(() => (Task)_doneTask, default));
-            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.StartAsync(ct => (Task)_doneTask, default));
+            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.StartAsync(default(Func<CancellationToken, Task>), s, true));
+            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.StartAsync(() => (Task)_doneTask, default(IScheduler)));
+            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.StartAsync(() => (Task)_doneTask, default(IScheduler), true));
+            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.StartAsync(ct => (Task)_doneTask, default(IScheduler)));
+            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.StartAsync(ct => (Task)_doneTask, default(IScheduler), true));
         }
 
         [TestMethod]
@@ -380,6 +483,94 @@ namespace ReactiveTests.Tests
             }
         }
 
+        [TestMethod]
+        public void Start_Action_UnsubscribeThenError_ErrorReportedAsUnobserved()
+        {
+            Start_Action_ErrorAfterUnsubscribeReportedAsUnobserved_Core(
+                createTask => Observable.StartAsync(createTask),
+                errorObservation =>
+                {
+                    errorObservation.AssertExceptionReportedAsUnobserved();
+                });
+        }
+
+        [TestMethod]
+        public void Start_ActionWithCancel_UnsubscribeThenError_ErrorReportedAsUnobserved()
+        {
+            Start_Action_ErrorAfterUnsubscribeReportedAsUnobserved_Core(
+                createTask => Observable.StartAsync(_ => createTask()),
+                errorObservation =>
+                {
+                    errorObservation.AssertExceptionReportedAsUnobserved();
+                });
+        }
+
+        [TestMethod]
+        public void Start_Action_WithScheduler_UnsubscribeThenError_ErrorReportedAsUnobserved()
+        {
+            Start_Action_ErrorAfterUnsubscribeReportedAsUnobserved_Core(
+                createTask => Observable.StartAsync(createTask, TaskPoolScheduler.Default),
+                errorObservation =>
+                {
+                    errorObservation.AssertExceptionReportedAsUnobserved();
+                });
+        }
+
+        [TestMethod]
+        public void Start_ActionWithCancel_WithScheduler_UnsubscribeThenError_ErrorReportedAsUnobserved()
+        {
+            Start_Action_ErrorAfterUnsubscribeReportedAsUnobserved_Core(
+                createTask => Observable.StartAsync(_ => createTask(), TaskPoolScheduler.Default),
+                errorObservation =>
+                {
+                    errorObservation.AssertExceptionReportedAsUnobserved();
+                });
+        }
+
+        [TestMethod]
+        public void Start_Action_IgnorePostUnsubscribeErrors_UnsubscribeThenError_ErrorNotReportedAsUnobserved()
+        {
+            Start_Action_ErrorAfterUnsubscribeReportedAsUnobserved_Core(
+                createTask => Observable.StartAsync(createTask, ignoreExceptionsAfterUnsubscribe: true),
+                errorObservation =>
+                {
+                    errorObservation.AssertExceptionNotReportedAsUnobserved();
+                });
+        }
+
+        [TestMethod]
+        public void Start_ActionWithCancel_IgnorePostUnsubscribeErrors_UnsubscribeThenError_ErrorNotReportedAsUnobserved()
+        {
+            Start_Action_ErrorAfterUnsubscribeReportedAsUnobserved_Core(
+                createTask => Observable.StartAsync(_ => createTask(), ignoreExceptionsAfterUnsubscribe: true),
+                errorObservation =>
+                {
+                    errorObservation.AssertExceptionNotReportedAsUnobserved();
+                });
+        }
+
+        [TestMethod]
+        public void Start_Action_WithScheduler_IgnorePostUnsubscribeErrors_UnsubscribeThenError_ErrorNotReportedAsUnobserved()
+        {
+            Start_Action_ErrorAfterUnsubscribeReportedAsUnobserved_Core(
+                createTask => Observable.StartAsync(createTask, TaskPoolScheduler.Default, ignoreExceptionsAfterUnsubscribe: true),
+                errorObservation =>
+                {
+                    errorObservation.AssertExceptionNotReportedAsUnobserved();
+                });
+        }
+
+        [TestMethod]
+        public void Start_ActionWithCancel_WithScheduler_IgnorePostUnsubscribeErrors_UnsubscribeThenError_ErrorNotReportedAsUnobserved()
+        {
+            Start_Action_ErrorAfterUnsubscribeReportedAsUnobserved_Core(
+                createTask => Observable.StartAsync(_ => createTask(), TaskPoolScheduler.Default, ignoreExceptionsAfterUnsubscribe: true),
+                errorObservation =>
+                {
+                    errorObservation.AssertExceptionNotReportedAsUnobserved();
+                });
+        }
+
 #if DESKTOPCLR
         [TestMethod]
         public void StartAsync_Action_Scheduler1()
@@ -428,5 +619,50 @@ namespace ReactiveTests.Tests
 
         #endregion
 
+        private void Start_Func_ErrorAfterUnsubscribeReportedAsUnobserved_Core(
+            Func<Func<Task<int>>, IObservable<int>> createObservable,
+            Action<TaskErrorObservation> testResults)
+        {
+            Start_Func_ErrorAfterUnsubscribeReportedAsUnobserved_Core<int>(createObservable, testResults);
+        }
+
+        private void Start_Action_ErrorAfterUnsubscribeReportedAsUnobserved_Core(
+            Func<Func<Task>, IObservable<Unit>> createObservable,
+            Action<TaskErrorObservation> testResults)
+        {
+            Start_Func_ErrorAfterUnsubscribeReportedAsUnobserved_Core<Unit>(createObservable, testResults);
+        }
+
+        private void Start_Func_ErrorAfterUnsubscribeReportedAsUnobserved_Core<T>(
+            Func<Func<Task<T>>, IObservable<T>> createObservable,
+            Action<TaskErrorObservation> testResults)
+        {
+            using Barrier gate = new(2);
+            using TaskErrorObservation errorObservation = new();
+
+            var sub = errorObservation.SuscribeWithoutKeepingSourceReachable<T>(
+                (setTask, exception) => createObservable(
+                    () => setTask(Task.Factory.StartNew<T>(
+                        () =>
+                        {
+                            // 1: Notify that task execution has begun
+                            gate.SignalAndWait();
+                            // 2: Wait until unsubscribe Dispose has returned
+                            gate.SignalAndWait();
+                            throw exception;
+                        })))
+                    .Subscribe());
+
+            // 1: wait until task execution has begun
+            gate.SignalAndWait();
+
+            sub.Dispose();
+            //sub = null;
+
+            // 2: Notify that unsubscribe Dispose has returned
+            gate.SignalAndWait();
+
+            testResults(errorObservation);
+        }
     }
 }

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/TaskObservableExtensionsTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/TaskObservableExtensionsTest.cs
@@ -37,9 +37,12 @@ namespace ReactiveTests.Tests
             var s = Scheduler.Immediate;
 
             ReactiveAssert.Throws<ArgumentNullException>(() => TaskObservableExtensions.ToObservable((Task<int>)null));
+            ReactiveAssert.Throws<ArgumentNullException>(() => TaskObservableExtensions.ToObservable((Task<int>)null, false));
 
             ReactiveAssert.Throws<ArgumentNullException>(() => TaskObservableExtensions.ToObservable((Task<int>)null, s));
-            ReactiveAssert.Throws<ArgumentNullException>(() => TaskObservableExtensions.ToObservable(_doneTask, default));
+            ReactiveAssert.Throws<ArgumentNullException>(() => TaskObservableExtensions.ToObservable((Task<int>)null, s, false));
+            ReactiveAssert.Throws<ArgumentNullException>(() => TaskObservableExtensions.ToObservable(_doneTask, default(IScheduler)));
+            ReactiveAssert.Throws<ArgumentNullException>(() => TaskObservableExtensions.ToObservable(_doneTask, default(IScheduler), false));
 
             var tcs = new TaskCompletionSource<int>();
             var task = tcs.Task;
@@ -397,9 +400,12 @@ namespace ReactiveTests.Tests
             var s = Scheduler.Immediate;
 
             ReactiveAssert.Throws<ArgumentNullException>(() => TaskObservableExtensions.ToObservable(null));
+            ReactiveAssert.Throws<ArgumentNullException>(() => TaskObservableExtensions.ToObservable(null, false));
 
             ReactiveAssert.Throws<ArgumentNullException>(() => TaskObservableExtensions.ToObservable(null, s));
-            ReactiveAssert.Throws<ArgumentNullException>(() => TaskObservableExtensions.ToObservable((Task)_doneTask, default));
+            ReactiveAssert.Throws<ArgumentNullException>(() => TaskObservableExtensions.ToObservable(null, s, false));
+            ReactiveAssert.Throws<ArgumentNullException>(() => TaskObservableExtensions.ToObservable((Task)_doneTask, default(IScheduler)));
+            ReactiveAssert.Throws<ArgumentNullException>(() => TaskObservableExtensions.ToObservable((Task)_doneTask, default(IScheduler), false));
 
             var tcs = new TaskCompletionSource<int>();
             Task task = tcs.Task;

--- a/Rx.NET/tools/HomoIcon/Program.cs
+++ b/Rx.NET/tools/HomoIcon/Program.cs
@@ -153,26 +153,24 @@ namespace HomoIconize
  */
 ");
             WriteLine(
-@"#pragma warning disable 1591
+@"#nullable enable
+#pragma warning disable 1591
 ");
 
             WriteLine(
-@"using System;
-using System.Reactive.Concurrency;
-using System.Collections.Generic;");
+@"using System.Collections.Generic;");
 
             if (exludeFromCodeCoverage)
                 WriteLine("using System.Diagnostics.CodeAnalysis;");
 
             WriteLine(
-@"using System.Reactive.Joins;
-using System.Linq;
+@"using System.Linq;
 using System.Linq.Expressions;
+using System.Reactive.Concurrency;
+using System.Reactive.Subjects;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Reactive;
-using System.Reactive.Subjects;
 ");
             WriteLine(
 @"namespace System.Reactive.Linq
@@ -425,9 +423,9 @@ using System.Reactive.Subjects;
                     WriteLine("InfoOf(() => " + typeName + "." + name + g + "(" + string.Join(", ", ptps.Select(pt => "default(" + pt + ")")) + "))" + cma);
                     WriteLine("#else", true);
                     if (!m.IsGenericMethod)
-                        WriteLine("(MethodInfo)MethodInfo.GetCurrentMethod()" + cma);
+                        WriteLine("(MethodInfo)MethodInfo.GetCurrentMethod()!" + cma);
                     else
-                        WriteLine("((MethodInfo)MethodInfo.GetCurrentMethod()).MakeGenericMethod(" + string.Join(", ", m.GetGenericArguments().Select(ga => "typeof(" + ga.Name + ")").ToArray()) + ")" + cma);
+                        WriteLine("((MethodInfo)MethodInfo.GetCurrentMethod()!).MakeGenericMethod(" + string.Join(", ", m.GetGenericArguments().Select(ga => "typeof(" + ga.Name + ")").ToArray()) + ")" + cma);
                     WriteLine("#endif", true);
                     for (int j = 0; j < args.Count; j++)
                         WriteLine(args[j] + (j < args.Count - 1 ? "," : ""));
@@ -614,9 +612,9 @@ using System.Reactive.Subjects;
                         WriteLine("var m = InfoOf(() => " + typeName + ".ToAsync" + genArgss + "(" + string.Join(", ", aprs.Select(pt => "default(" + pt + ")")) + "));");
                         WriteLine("#else", true);
                         if (genArgs.Length == 0)
-                            WriteLine("var m = (MethodInfo)MethodInfo.GetCurrentMethod();");
+                            WriteLine("var m = (MethodInfo)MethodInfo.GetCurrentMethod()!;");
                         else
-                            WriteLine("var m = ((MethodInfo)MethodInfo.GetCurrentMethod()).MakeGenericMethod(" + string.Join(", ", genArgs.Select(a => "typeof(" + a + ")").ToArray()) + ");");
+                            WriteLine("var m = ((MethodInfo)MethodInfo.GetCurrentMethod()!).MakeGenericMethod(" + string.Join(", ", genArgs.Select(a => "typeof(" + a + ")").ToArray()) + ");");
                         WriteLine("#endif", true);
 
                         WriteLine("return (" + string.Join(", ", lamPars) + ") => provider.CreateQuery<" + ret + ">(");
@@ -724,7 +722,7 @@ using System.Reactive.Subjects;
                     WriteLine("[Obsolete(Constants_Linq.USE_TASK_FROMASYNCPATTERN)]");
                     WriteLine("#endif", true);
 
-                    WriteLine("public static " + retType + " FromAsyncPattern" + genArgss + "(this IQbservableProvider provider, " + begType + " begin, " + endType + "end)");
+                    WriteLine("public static " + retType + " FromAsyncPattern" + genArgss + "(this IQbservableProvider provider, " + begType + " begin, " + endType + " end)");
                     WriteLine("{");
 
                     Indent();
@@ -751,9 +749,9 @@ using System.Reactive.Subjects;
                     WriteLine("var m = InfoOf(() => " + typeName + ".FromAsyncPattern" + genArgss + "(" + string.Join(", ", aprs.Select(pt => "default(" + pt + ")")) + "));");
                     WriteLine("#else", true);
                     if (genArgs.Length == 0)
-                        WriteLine("var m = (MethodInfo)MethodInfo.GetCurrentMethod();");
+                        WriteLine("var m = (MethodInfo)MethodInfo.GetCurrentMethod()!;");
                     else
-                        WriteLine("var m = ((MethodInfo)MethodInfo.GetCurrentMethod()).MakeGenericMethod(" + string.Join(", ", genArgs.Select(a => "typeof(" + a + ")").ToArray()) + ");");
+                        WriteLine("var m = ((MethodInfo)MethodInfo.GetCurrentMethod()!).MakeGenericMethod(" + string.Join(", ", genArgs.Select(a => "typeof(" + a + ")").ToArray()) + ");");
                     WriteLine("#endif", true);
 
                     WriteLine("return (" + string.Join(", ", lamPars) + ") => provider.CreateQuery<" + ret + ">(");


### PR DESCRIPTION
**NOTE:** we are more likely to go with #1914 instead now. A problem with the approach in this PR is that it creates additional opportunities for overload resolution ambiguity, so although this is a binary-compatible change, it might cause build errors when people upgrade.

Resolves #1256 

Various Rx operators and extension methods can wrap a `Task` as an `IObservable<T>`. Historically, if you unsubscribe before the task is finished and the task subsequently fails, the resulting exception pops out through `TaskScheduler.UnobservedException`.

There is a point of view that this is inconsistent with how we cope with exceptions in things like `Select` projection callbacks that occur after unsubscription - those are just swallowed.

This PR provides the ability to ask for these kinds of orphaned exceptions to be ignored when they occur in tasks, just like they are in other scenarios.

The default behaviour does not change because that would break applications depending on the `UnobservedException` event. This adds new overloads enabling opting out.