### PR TITLE
Update NuGet refs

### DIFF
--- a/Rx.NET/Source/Directory.build.props
+++ b/Rx.NET/Source/Directory.build.props
@@ -31,7 +31,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.119" PrivateAssets="all" />
+    
+    <!--
+    Nerdbank.GitVersioning 3.6.128 injects a reference to a .proj file that doesn't work inside UWP projects,
+    so we make this conditional so it doesn't appear in the test runner.
+    -->
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.128" PrivateAssets="all" Condition="$(TargetPlatformIdentifier) != 'UAP'" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">

--- a/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/Benchmarks.System.Reactive.csproj
+++ b/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/Benchmarks.System.Reactive.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
     <PackageReference Include="WindowsBase" Version="4.6.1055" />
   </ItemGroup>
 

--- a/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Tests.System.Reactive.ApiApprovals.csproj
+++ b/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Tests.System.Reactive.ApiApprovals.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="Verify.Xunit" Version="19.11.2" />
+    <PackageReference Include="Verify.Xunit" Version="19.14.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="DiffPlex" Version="1.7.1" />


### PR DESCRIPTION
* Nerdbank.GitVersioning 3.6.128
* BenchmarkDotNet 0.13.5
* Verify.Xunit 19.14.1

Also disabled Nerdbank.GitVersioning for UWP test runner since recent versions of this library import a .proj file that doesn't work with UWP projects. (The runner doesn't need to be built with the current version number, since we never publish it anyway.)

Resolves #1898