### PR TITLE
Mention change in min UWP target platform version in release notes

### DIFF
--- a/Rx.NET/Documentation/ReleaseHistory/Rx.v6.md
+++ b/Rx.NET/Documentation/ReleaseHistory/Rx.v6.md
@@ -5,6 +5,7 @@
 ### Breaking changes
 
 * Out-of-support target frameworks (.NET Core 3.1, .NET 5) removed
+* Minimum target platform for UWP apps raised from 10.0.16299.0 to 10.0.18362.0
 
 ### New features
 


### PR DESCRIPTION
The breaking changes didn't previous mention that v6 raises the lower bound on the target platform version when targeting UWP. 

This change was described in https://github.com/dotnet/reactive/blob/main/Rx.NET/Documentation/adr/0001-net7.0-era-tooling-update.md#windows-sdk-version-1