### PR TITLE
System.Linq.Async takes a dependency on Microsoft.Bcl.AsyncInterfaces on target frameworks where it should not

### DIFF
--- a/Ix.NET/Source/System.Linq.Async/System.Linq.Async.csproj
+++ b/Ix.NET/Source/System.Linq.Async/System.Linq.Async.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Condition="'$(TargetFramework)' != 'netcoreapp3.1' and '$(TargetFramework)' != 'netstandard2.1' " Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    <PackageReference Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netstandard2.0' " Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <ReferenceAssemblyProjectReference Include="..\refs\System.Linq.Async.Ref\System.Linq.Async.Ref.csproj" />
     <ProjectReference Include="..\System.Linq.Async.SourceGenerator\System.Linq.Async.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" Private="false" />
   </ItemGroup>


### PR DESCRIPTION
#### Bugfix

A change in [a2410b2](https://github.com/dotnet/reactive/commit/a2410b2267abe193191f3894d243771ae4b126fd#diff-040f99bf5abf4bafb4e02f92a7b83c27b42785a4b692995a2c629cf9b5711b69L4) added net6.0, bumped to net48 and dropped netcoreapp3.1 for System.Linq.Async. As a consequence, the condition on which a reference to Microsoft.Bcl.AsyncInterfaces is taken proves no longer useful. This results in the package reference being present on net6.0 (and beyond) when it should not be.

This commit rewrites the condition.

Fixes #1834.


