### PR TITLE
Add netstandard2.0 target to AsyncRx.NET

### DIFF
--- a/AsyncRx.NET/ApiCompare/ApiCompare.csproj
+++ b/AsyncRx.NET/ApiCompare/ApiCompare.csproj
@@ -10,10 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reactive" Version="6.0.0-preview.1" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\System.Reactive.Async\System.Reactive.Async.csproj" />
   </ItemGroup>
 

--- a/AsyncRx.NET/System.Reactive.Async/Linq/Operators/CombineLatest.Generated.tt
+++ b/AsyncRx.NET/System.Reactive.Async/Linq/Operators/CombineLatest.Generated.tt
@@ -161,7 +161,7 @@ for (var j = 1; j <= i; j++)
 }
 #>
 
-            var gate = new AsyncLock();
+            var gate = new AsyncGate();
 
             return
             (
@@ -248,7 +248,7 @@ for (var j = 1; j <= i; j++)
 }
 #>
 
-            var gate = new AsyncLock();
+            var gate = new AsyncGate();
 
             return
             (

--- a/AsyncRx.NET/System.Reactive.Async/Linq/Operators/Zip.Generated.tt
+++ b/AsyncRx.NET/System.Reactive.Async/Linq/Operators/Zip.Generated.tt
@@ -152,7 +152,7 @@ for (var i = 2; i <= 15; i++)
             if (observer == null)
                 throw new ArgumentNullException(nameof(observer));
 
-            var gate = new AsyncLock();
+            var gate = new AsyncGate();
 
 <#
 for (var j = 1; j <= i; j++)
@@ -258,7 +258,7 @@ for (var j = 1; j <= i; j++)
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            var gate = new AsyncLock();
+            var gate = new AsyncGate();
 
 <#
 for (var j = 1; j <= i; j++)

--- a/AsyncRx.NET/System.Reactive.Async/System.Reactive.Async.csproj
+++ b/AsyncRx.NET/System.Reactive.Async/System.Reactive.Async.csproj
@@ -1,13 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
 
     <RootNamespace>System.Reactive</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reactive" Version="6.0.0-preview.1" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" Condition="$(TargetFramework) == 'netstandard2.0'" />
+    <PackageReference Include="System.Reactive" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Resolves #1954 

**NOTE**: it is not yet clear whether this is going to work, because we don't currently know why the project didn't do this to begin with.

It's true that `netstandard2.0` doesn't include the `IAsyncEnumerable<T>`, `IAsyncEnumerator<T>`, and `IAsyncDisposable` interfaces, but these are available through the `Microsoft.Bcl.AsyncInterfaces` NuGet package. Perhaps that wasn't available when this code was first written. But there might be some deeper problem. (And since this project doesn't yet have a test suite, we can't be confident in changes like this.)

If @bartdesmet happens to spot this, it would be great to know whether there's some good reason we can't just use that NuGet package to get ourselves a `netstandard2.0`-compatible package.

So this is currently an experimental feature.