### PR TITLE
BehaviorSubject implements IBehaviorObservable

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Subjects/BehaviorSubject.cs
+++ b/Rx.NET/Source/src/System.Reactive/Subjects/BehaviorSubject.cs
@@ -13,7 +13,7 @@ namespace System.Reactive.Subjects
     /// Observers can subscribe to the subject to receive the last (or initial) value and all subsequent notifications.
     /// </summary>
     /// <typeparam name="T">The type of the elements processed by the subject.</typeparam>
-    public sealed class BehaviorSubject<T> : SubjectBase<T>
+    public sealed class BehaviorSubject<T> : SubjectBase<T>, IBehaviorObservable<T>
     {
         #region Fields
 

--- a/Rx.NET/Source/src/System.Reactive/Subjects/IBehaviorObservable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Subjects/IBehaviorObservable.cs
@@ -1,0 +1,6 @@
+﻿namespace System.Reactive.Subjects;
+
+public interface IBehaviorObservable<out T> : IObservable<T>
+{
+    T Value { get; }
+}

--- a/Rx.NET/Source/src/System.Reactive/Subjects/IBehaviorObservable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Subjects/IBehaviorObservable.cs
@@ -1,6 +1,6 @@
 ﻿namespace System.Reactive.Subjects;
 
-public interface IBehaviourObservable<out T> : IObservable<T>
+public interface IBehaviorObservable<out T> : IObservable<T>
 {
     T Value { get; }
 }

--- a/Rx.NET/Source/src/System.Reactive/Subjects/IBehaviorObservable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Subjects/IBehaviorObservable.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Reactive.Subjects;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT License.
+// See the LICENSE file in the project root for more information. 
+
+namespace System.Reactive.Subjects;
 
 public interface IBehaviorObservable<out T> : IObservable<T>
 {

--- a/Rx.NET/Source/src/System.Reactive/Subjects/IBehaviourObservable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Subjects/IBehaviourObservable.cs
@@ -1,6 +1,6 @@
 ﻿namespace System.Reactive.Subjects;
 
-public interface IBehaviorObservable<out T> : IObservable<T>
+public interface IBehaviourObservable<out T> : IObservable<T>
 {
     T Value { get; }
 }


### PR DESCRIPTION
What is the nature of your contribution?

#### Enhancement

IBehaviorObservable<T> is used to expose the subject's Value property as readonly, in order to restrict public write access.