### PR TITLE
Remove dynamic load of QueryDebugger

### DIFF
--- a/Rx.NET/Documentation/ReleaseHistory/Rx.v6.md
+++ b/Rx.NET/Documentation/ReleaseHistory/Rx.v6.md
@@ -1,6 +1,10 @@
 # Rx Release History v6.0
 
-## v6.0.0-preview
+## v6.0.1-preview
+
+This release fixes [Issue #1942: "AOT compilation produces single trim analysis warning"](https://github.com/dotnet/reactive/issues/1942)
+
+## v6.0.0
 
 ### Breaking changes
 

--- a/Rx.NET/Source/src/System.Reactive/Internal/CurrentPlatformEnlightenmentProvider.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/CurrentPlatformEnlightenmentProvider.cs
@@ -68,27 +68,9 @@ namespace System.Reactive.PlatformServices
                 // expectation it'd be pretty hard to turn on interception dynamically
                 // upon a debugger attach event, so we should make this check early.
                 //
-                // In the initial release of v2.0 (RTM), we won't have the corresponding
-                // debugger assembly available yet, so the dynamic load would always
-                // fail. We also don't want to take the price of (an attempt to) a dynamic
-                // assembly load for the regular production case.
-                //
                 if (Debugger.IsAttached)
                 {
-                    var ifType = t.GetTypeInfo();
-
-                    var asm = new AssemblyName(ifType.Assembly.FullName!)
-                    {
-                        Name = "System.Reactive"
-                    };
-
-                    var name = "System.Reactive.Linq.QueryDebugger, " + asm.FullName;
-
-                    var dbg = Type.GetType(name, false);
-                    if (dbg != null)
-                    {
-                        return (T?)Activator.CreateInstance(dbg);
-                    }
+                    return (T)(object)new QueryDebugger();
                 }
             }
 

--- a/Rx.NET/Source/version.json
+++ b/Rx.NET/Source/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.0.0-preview.{height}",
+  "version": "6.0.1-preview.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/main$", // we release out of main
     "^refs/heads/rel/v\\d+\\.\\d+", // we also release branches starting with rel/vN.N


### PR DESCRIPTION
(Just use new() instead.)

Resolves #1942

This dynamic load has been unnecessary since commit 40e8696 modified CurrentPlatformEnlightenmentProvider to look for QueryDebugger in the assembly named System.Reactive. Before that, it used to look for one called System.Reactive.Debugger, in which case a dynamic load would have made sense. But since for almost 6 years now, it has been passing "System.Reactive" as the assembly name, there is absolutely no reason for this to be a dynamic load. The code that performs this dynamic load is also in System.Reactive, so the dynamic load is completely pointless.

This only ever happened when the debugger was attached, but it has become problematic because assembly trimming doesn't like dynamic loads. If you set <PublishAot>true</PublishAot>, this dynamic loading code in CurrentPlatformEnlightenmentProvider causes a trim analysis warning (IL2057). The warning could safely be ignored, but it shouldn't happen in the first place. This change should stop that warning from emerging.