### PR TITLE
Retain cancel callback until ForEachAsync completes

### DIFF
--- a/AsyncRx.NET/System.Reactive.Async/Linq/Operators/ForEachAsync.cs
+++ b/AsyncRx.NET/System.Reactive.Async/Linq/Operators/ForEachAsync.cs
@@ -124,9 +124,9 @@ namespace System.Reactive.Linq
                 var d = await source.SubscribeAsync(o).ConfigureAwait(false);
 
                 await subscription.AssignAsync(d).ConfigureAwait(false);
-            }
 
-            await tcs.Task.ConfigureAwait(false);
+                await tcs.Task.ConfigureAwait(false);
+            }
         }
     }
 }


### PR DESCRIPTION
Resolves #1940

The code that waits for processing to complete was after the closing brace of the `using` that unregisters the cancellation callback. This meant that it almost immediately unregistered for cancellation notifications. Simply moving that await inside the relevant block addresses this.