### PR TITLE
Run tests on .NET 8.0

### DIFF
--- a/Rx.NET/Integration/LinuxTests/LinuxTests.csproj
+++ b/Rx.NET/Integration/LinuxTests/LinuxTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Tests.System.Reactive</AssemblyName>
@@ -12,7 +12,7 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <DefineConstants>$(DefineConstants);</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0' ">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0' or '$(TargetFramework)' == 'net8.0'">
     <DefineConstants>$(DefineConstants);LINUX</DefineConstants>
   </PropertyGroup>
 

--- a/Rx.NET/Integration/WindowsDesktopTests/WindowsDesktopTests.csproj
+++ b/Rx.NET/Integration/WindowsDesktopTests/WindowsDesktopTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net6.0-windows10.0.19041;net7.0;net7.0-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>net6.0;net6.0-windows10.0.19041;net7.0;net7.0-windows10.0.19041;net8.0;net8.0-windows10.0.19041</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Tests.System.Reactive</AssemblyName>
@@ -9,7 +9,7 @@
     <AssemblyOriginatorKeyFile>..\..\Source\ReactiveX.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('net6.0-windows')) or $(TargetFramework.StartsWith('net7.0-windows'))">
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('net6.0-windows')) or $(TargetFramework.StartsWith('net7.0-windows')) or $(TargetFramework.StartsWith('net8.0-windows'))">
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <DefineConstants>$(DefineConstants);HAS_TRACE;HAS_WINRT;PREFER_ASYNC;HAS_TPL46;NO_REMOTING;HAS_WINFORMS;HAS_WPF;HAS_DISPATCHER;DESKTOPCLR;WINDOWS;CSWINRT</DefineConstants>

--- a/Rx.NET/Source/Directory.build.targets
+++ b/Rx.NET/Source/Directory.build.targets
@@ -16,10 +16,10 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <DefineConstants>$(DefineConstants);HAS_WINRT;NO_NULLABLE_ATTRIBUTES</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('net6.0')) or $(TargetFramework.StartsWith('net7.0'))">
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('net6.0')) or $(TargetFramework.StartsWith('net7.0')) or $(TargetFramework.StartsWith('net8.0'))">
     <DefineConstants>$(DefineConstants);HAS_TRIMMABILITY_ATTRIBUTES</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('net6.0-windows')) or $(TargetFramework.StartsWith('net7.0-windows'))">
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('net6.0-windows')) or $(TargetFramework.StartsWith('net7.0-windows')) or $(TargetFramework.StartsWith('net8.0-windows'))">
     <DefineConstants>$(DefineConstants);HAS_WINRT;HAS_WINFORMS;HAS_WPF;HAS_DISPATCHER;DESKTOPCLR;WINDOWS;CSWINRT</DefineConstants>
   </PropertyGroup>
 

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests.System.Reactive.csproj
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests.System.Reactive.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net7.0;net6.0-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0;net6.0-windows10.0.19041;net8.0;net8.0-windows10.0.19041</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
 

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ToLookupTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ToLookupTest.cs
@@ -206,8 +206,16 @@ namespace ReactiveTests.Tests
         public void ToLookup_Hides_Internal_List()
         {
             var d1 = Observable.Range(1, 10).ToLookup(x => (x % 2).ToString()).First();
-            Assert.False(d1["0"] is ICollection<int>);
-            Assert.False(d1["0"] is IList<int>);
+
+            // Up to .NET 7.0, the wrapper returned by LINQ to Objects' Skip (which is
+            // what Rx uses today to hide the list) used not to implement IList or
+            // ICollection. As of .NET 8.0 it does, but we can check we don't have
+            // access to the underlying list by checking that we are unable to modify
+            // it. Before .NET 8.0, these tests succeed because the wrapped list
+            // doesn't implement the interfaces. On .NET 8.0 they succeed because it
+            // provides a read-only implementation of them.
+            Assert.False(d1["0"] is ICollection<int> coll && !coll.IsReadOnly);
+            Assert.False(d1["0"] is IList<int> list && !list.IsReadOnly);
         }
 
         [TestMethod]

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -34,9 +34,9 @@ stages:
 
     steps:
     - task: UseDotNet@2
-      displayName: Use .NET Core 7.0.x SDK
+      displayName: Use .NET Core 8.0.x SDK
       inputs:
-        version: 7.0.x
+        version: 8.0.x
         performMultiLevelLookup: true
 
     - task: DotNetCoreCLI@2
@@ -120,7 +120,12 @@ stages:
     steps:
     - task: UseDotNet@2
       inputs:
-        version: 7.0.x
+        version: 8.0.x
+
+    - task: UseDotNet@2
+      inputs:
+        version: '7.0.x'
+        packageType: runtime
 
     - task: UseDotNet@2
       inputs:
@@ -155,6 +160,13 @@ stages:
       inputs:
         command: test
         projects: $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LinuxTests/LinuxTests.csproj
+        arguments: -c $(BuildConfiguration) -f net8.0 --filter "TestCategory!=SkipCI"
+      displayName: Run 8.0 Tests on Linux
+
+    - task: DotNetCoreCLI@2
+      inputs:
+        command: test
+        projects: $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LinuxTests/LinuxTests.csproj
         arguments: -c $(BuildConfiguration) -f net7.0 --filter "TestCategory!=SkipCI"
       displayName: Run 7.0 Tests on Linux
 
@@ -177,7 +189,7 @@ stages:
     steps:
     - task: UseDotNet@2
       inputs:
-        version: 7.0.x
+        version: 8.0.x
         performMultiLevelLookup: true
 
     - task: DotNetCoreCLI@2

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -34,20 +34,25 @@ stages:
 
     steps:
     - task: UseDotNet@2
-      displayName: Use .NET Core 8.0.x SDK
+      displayName: Use .NET 8.0.x SDK
       inputs:
         version: 8.0.x
         performMultiLevelLookup: true
 
+    # We need .NET 7.0 and 6.0 to be able to run all tests.
+    # For .NET 7.0, the runtime package is sufficient because we don't need to build anything.
+    # That doesn't work for 6.0, because we need the desktop framework, and the only way to
+    # get that into a build agent seems to be to install the SDK.
     - task: UseDotNet@2
+      displayName: Use .NET 7.0 runtime
       inputs:
         version: '7.0.x'
         packageType: runtime
 
     - task: UseDotNet@2
+      displayName: Use .NET 6.0 SDK
       inputs:
         version: '6.0.x'
-        packageType: runtime
 
     - task: DotNetCoreCLI@2
       inputs:

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -213,7 +213,6 @@ stages:
       displayName: Use .NET 7.0 SDK
       inputs:
         version: '7.0.x'
-        packageType: runtime
 
     - task: UseDotNet@2
       displayName: Use .NET 6.0 SDK

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -39,6 +39,16 @@ stages:
         version: 8.0.x
         performMultiLevelLookup: true
 
+    - task: UseDotNet@2
+      inputs:
+        version: '7.0.x'
+        packageType: runtime
+
+    - task: UseDotNet@2
+      inputs:
+        version: '6.0.x'
+        packageType: runtime
+
     - task: DotNetCoreCLI@2
       inputs:
         command: custom

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -138,11 +138,13 @@ stages:
         version: 8.0.x
 
     - task: UseDotNet@2
+      displayName: Use .NET 7.0 SDK
       inputs:
         version: '7.0.x'
         packageType: runtime
 
     - task: UseDotNet@2
+      displayName: Use .NET 6.0 SDK
       inputs:
         version: '6.0.x'
         packageType: runtime
@@ -206,6 +208,17 @@ stages:
       inputs:
         version: 8.0.x
         performMultiLevelLookup: true
+
+    - task: UseDotNet@2
+      displayName: Use .NET 7.0 SDK
+      inputs:
+        version: '7.0.x'
+        packageType: runtime
+
+    - task: UseDotNet@2
+      displayName: Use .NET 6.0 SDK
+      inputs:
+        version: '6.0.x'
 
     - task: DotNetCoreCLI@2
       inputs:


### PR DESCRIPTION
Added `net8.0` and `net8.0-windows10.0.19041` targets to test project.

Modified `Directory.build.targets` to recognize .NET 8.0 targets.

One test needed to be lightly modified because the way in which it was trying to test what it wanted to test doesn't quite work in .NET 8.0.