### PR TITLE
Feature/2005 large composite disposable perf

### DIFF
--- a/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/GroupByCompletion.cs
+++ b/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/GroupByCompletion.cs
@@ -1,0 +1,69 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reactive.Linq;
+
+using BenchmarkDotNet.Attributes;
+
+
+namespace Benchmarks.System.Reactive
+{
+    /// <summary>
+    /// Completion of a wide fan-out/in scenario.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This was added to address https://github.com/dotnet/reactive/issues/2005 in which completion
+    /// takes longer and longer to handle as the number of groups increases.
+    /// </para>
+    /// </remarks>
+    [MemoryDiagnoser]
+    public class GroupByCompletion
+    {
+
+        [Params(200_000, 1_000_000)]
+        public int NumberOfSamples { get; set; }
+
+        [Params(10, 100, 1_000, 10_000, 100_000, 150_000, 200_000)]
+        public int NumberOfGroups { get; set; }
+
+        private int[] data;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            data = new int[NumberOfSamples];
+            for (var i = 0; i < data.Length; ++i)
+            {
+                data[i] = i;
+            }
+
+            observable = data.ToObservable();
+        }
+
+        private IObservable<int> observable;
+
+        [Benchmark]
+        public void GroupBySelectMany()
+        {
+            var numberOfGroups = NumberOfGroups;
+
+            observable!.GroupBy(value => value % numberOfGroups)
+                .SelectMany(groupOfInts => groupOfInts)
+                .Subscribe(intValue => { });
+        }
+
+        [Benchmark]
+        public void GroupByMerge()
+        {
+            var numberOfGroups = NumberOfGroups;
+
+            observable!.GroupBy(value => value % numberOfGroups)
+                .Merge()
+                .Subscribe(intValue => { });
+        }
+
+    }
+}

--- a/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/Program.cs
+++ b/Rx.NET/Source/benchmarks/Benchmarks.System.Reactive/Program.cs
@@ -27,7 +27,8 @@ namespace Benchmarks.System.Reactive
                 typeof(ScalarScheduleBenchmark),
                 typeof(StableCompositeDisposableBenchmark),
                 typeof(SubjectBenchmark),
-                typeof(ComparisonAsyncBenchmark)
+                typeof(ComparisonAsyncBenchmark),
+                typeof(GroupByCompletion)
 #if (CURRENT)
                 ,typeof(AppendPrependBenchmark)
                 ,typeof(PrependVsStartWtihBenchmark)

--- a/Rx.NET/Source/src/System.Reactive/Disposables/CompositeDisposable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/CompositeDisposable.cs
@@ -288,8 +288,6 @@ namespace System.Reactive.Disposables
                     {
                         dictionaryDisposables[item] = thisDisposableCount;
                     }
-
-                    // TODO: do we need to shrink the dictionary?
                 }
 
                 // make sure the Count property sees an atomic update

--- a/Rx.NET/Source/src/System.Reactive/Disposables/CompositeDisposable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/CompositeDisposable.cs
@@ -4,6 +4,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 
 namespace System.Reactive.Disposables
@@ -16,9 +17,16 @@ namespace System.Reactive.Disposables
     {
         private readonly object _gate = new();
         private bool _disposed;
-        private List<IDisposable?> _disposables;
+        private object _disposables;
         private int _count;
         private const int ShrinkThreshold = 64;
+
+        // The maximum number of items to keep in a list before switching to a dictionary.
+        // Issue https://github.com/dotnet/reactive/issues/2005 reported that when a SelectMany
+        // observes large numbers (1000s) of observables, the CompositeDisposable it uses to
+        // keep track of all of the inner observables it creates becomes a bottleneck when the
+        // subscription completes.
+        private const int MaximumLinearSearchThreshold = 1024;
 
         // Default initial capacity of the _disposables list in case
         // The number of items is not known upfront
@@ -29,7 +37,7 @@ namespace System.Reactive.Disposables
         /// </summary>
         public CompositeDisposable()
         {
-            _disposables = [];
+            _disposables = new List<IDisposable?>();
         }
 
         /// <summary>
@@ -60,11 +68,11 @@ namespace System.Reactive.Disposables
                 throw new ArgumentNullException(nameof(disposables));
             }
 
-            _disposables = ToList(disposables);
+            (_disposables, _) = ToListOrDictionary(disposables);
 
             // _count can be read by other threads and thus should be properly visible
             // also releases the _disposables contents so it becomes thread-safe
-            Volatile.Write(ref _count, _disposables.Count);
+            Volatile.Write(ref _count, disposables.Length);
         }
 
         /// <summary>
@@ -80,14 +88,14 @@ namespace System.Reactive.Disposables
                 throw new ArgumentNullException(nameof(disposables));
             }
 
-            _disposables = ToList(disposables);
+            (_disposables, var count) = ToListOrDictionary(disposables);
 
             // _count can be read by other threads and thus should be properly visible
             // also releases the _disposables contents so it becomes thread-safe
-            Volatile.Write(ref _count, _disposables.Count);
+            Volatile.Write(ref _count, count);
         }
 
-        private static List<IDisposable?> ToList(IEnumerable<IDisposable> disposables)
+        private static (object Collection, int Count) ToListOrDictionary(IEnumerable<IDisposable> disposables)
         {
             var capacity = disposables switch
             {
@@ -95,6 +103,26 @@ namespace System.Reactive.Disposables
                 ICollection<IDisposable> c => c.Count,
                 _ => DefaultCapacity
             };
+
+            if (capacity > MaximumLinearSearchThreshold)
+            {
+                var dictionary = new Dictionary<IDisposable, int>(capacity);
+                var disposableCount = 0;
+                foreach (var d in disposables)
+                {
+                    if (d == null)
+                    {
+                        throw new ArgumentException(Strings_Core.DISPOSABLES_CANT_CONTAIN_NULL, nameof(disposables));
+                    }
+
+                    dictionary.TryGetValue(d, out var thisDisposableCount);
+                    dictionary[d] = thisDisposableCount + 1;
+
+                    disposableCount += 1;
+                }
+
+                return (dictionary, disposableCount);
+            }
 
             var list = new List<IDisposable?>(capacity);
 
@@ -110,7 +138,14 @@ namespace System.Reactive.Disposables
                 list.Add(d);
             }
 
-            return list;
+            if (list.Count > MaximumLinearSearchThreshold)
+            {
+                // We end up here if we didn't know the count up front because it's an
+                // IEnumerable<IDisposable> and not an ICollection<IDisposable>, and it then turns out that
+                // the number of items exceeds our maximum tolerance for linear search.
+            }
+
+            return (list, list.Count);
         }
 
         /// <summary>
@@ -134,7 +169,37 @@ namespace System.Reactive.Disposables
             {
                 if (!_disposed)
                 {
-                    _disposables.Add(item);
+                    if (_disposables is List<IDisposable?> listDisposables)
+                    {
+                        listDisposables.Add(item);
+
+                        // Once we get to thousands of items (which happens with wide fan-out/in configurations)
+                        // the cost of linear search becomes too high. We switch to a dictionary at that point.
+                        // See https://github.com/dotnet/reactive/issues/2005
+                        if (listDisposables.Count > MaximumLinearSearchThreshold)
+                        {
+                            // If we've blown through this threshold, chances are there's more to come,
+                            // so allocate some more spare capacity.
+                            var dictionary = new Dictionary<IDisposable, int>(listDisposables.Count + (listDisposables.Count / 4));
+                            foreach (var d in listDisposables)
+                            {
+                                if (d is not null)
+                                {
+                                    dictionary.TryGetValue(d, out var thisDisposableCount);
+                                    dictionary[d] = thisDisposableCount + 1;
+                                }
+                            }
+
+                            _disposables = dictionary;
+                        }
+
+                    }
+                    else
+                    {
+                        var dictionaryDisposables = (Dictionary<IDisposable, int>)_disposables;
+                        dictionaryDisposables.TryGetValue(item, out var thisDisposableCount);
+                        dictionaryDisposables[item] = thisDisposableCount + 1;
+                    }
 
                     // If read atomically outside the lock, it should be written atomically inside
                     // the plain read on _count is fine here because manipulation always happens
@@ -180,28 +245,51 @@ namespace System.Reactive.Disposables
                 // read fields as infrequently as possible
                 var current = _disposables;
 
-                var i = current.IndexOf(item);
-                if (i < 0)
+                if (current is List<IDisposable?> currentList)
                 {
-                    // not found, just return
-                    return false;
-                }
-
-                current[i] = null;
-
-                if (current.Capacity > ShrinkThreshold && _count < current.Capacity / 2)
-                {
-                    var fresh = new List<IDisposable?>(current.Capacity / 2);
-
-                    foreach (var d in current)
+                    var i = currentList.IndexOf(item);
+                    if (i < 0)
                     {
-                        if (d != null)
-                        {
-                            fresh.Add(d);
-                        }
+                        // not found, just return
+                        return false;
                     }
 
-                    _disposables = fresh;
+                    currentList[i] = null;
+
+                    if (currentList.Capacity > ShrinkThreshold && _count < currentList.Capacity / 2)
+                    {
+                        var fresh = new List<IDisposable?>(currentList.Capacity / 2);
+
+                        foreach (var d in currentList)
+                        {
+                            if (d != null)
+                            {
+                                fresh.Add(d);
+                            }
+                        }
+
+                        _disposables = fresh;
+                    } 
+                }
+                else
+                {
+                    var dictionaryDisposables = (Dictionary<IDisposable, int>)_disposables;
+                    if (!dictionaryDisposables.TryGetValue(item, out var thisDisposableCount))
+                    {
+                        return false;
+                    }
+
+                    thisDisposableCount -= 1;
+                    if (thisDisposableCount == 0)
+                    {
+                        dictionaryDisposables.Remove(item);
+                    }
+                    else
+                    {
+                        dictionaryDisposables[item] = thisDisposableCount;
+                    }
+
+                    // TODO: do we need to shrink the dictionary?
                 }
 
                 // make sure the Count property sees an atomic update
@@ -221,13 +309,15 @@ namespace System.Reactive.Disposables
         /// </summary>
         public void Dispose()
         {
-            List<IDisposable?>? currentDisposables = null;
+            List<IDisposable?>? currentDisposablesList = null;
+            Dictionary<IDisposable, int>? currentDisposablesDictionary = null;
 
             lock (_gate)
             {
                 if (!_disposed)
                 {
-                    currentDisposables = _disposables;
+                    currentDisposablesList = _disposables as List<IDisposable?>;
+                    currentDisposablesDictionary = _disposables as Dictionary<IDisposable, int>;
 
                     // nulling out the reference is faster no risk to
                     // future Add/Remove because _disposed will be true
@@ -239,11 +329,22 @@ namespace System.Reactive.Disposables
                 }
             }
 
-            if (currentDisposables != null)
+            if (currentDisposablesList is not null)
             {
-                foreach (var d in currentDisposables)
+                foreach (var d in currentDisposablesList)
                 {
+                    // Although we don't all nulls in from the outside, we implement Remove
+                    // by setting entries to null, and shrinking the list if it gets too sparse.
+                    // So some entries may be null.
                     d?.Dispose();
+                }
+            }
+
+            if (currentDisposablesDictionary is not null)
+            {
+                foreach (var kv in currentDisposablesDictionary)
+                {
+                    kv.Key.Dispose();
                 }
             }
         }
@@ -265,8 +366,18 @@ namespace System.Reactive.Disposables
 
                 var current = _disposables;
 
-                previousDisposables = current.ToArray();
-                current.Clear();
+                if (current is List<IDisposable?> currentList)
+                {
+                    previousDisposables = currentList.ToArray();
+                    currentList.Clear();
+                }
+                else
+                {
+                    var currentDictionary = (Dictionary<IDisposable, int>)current;
+                    previousDisposables = new IDisposable[currentDictionary.Count];
+                    currentDictionary.Keys.CopyTo(previousDisposables!, 0);
+                    currentDictionary.Clear();
+                }
 
                 Volatile.Write(ref _count, 0);
             }
@@ -297,7 +408,10 @@ namespace System.Reactive.Disposables
                     return false;
                 }
 
-                return _disposables.Contains(item);
+                var current = _disposables;
+                return current is List<IDisposable?> list
+                    ? list.Contains(item)
+                    : ((Dictionary<IDisposable, int>) current).ContainsKey(item);
             }
         }
 
@@ -336,12 +450,27 @@ namespace System.Reactive.Disposables
                 }
                 
                 var i = arrayIndex;
-                
-                foreach (var d in _disposables)
+
+                var current = _disposables;
+
+                if (current is List<IDisposable?> currentList)
                 {
-                    if (d != null)
+                    foreach (var d in currentList)
                     {
-                        array[i++] = d;
+                        if (d != null)
+                        {
+                            array[i++] = d;
+                        }
+                    }
+                }
+                else
+                {
+                    foreach (var kv in (Dictionary<IDisposable, int>)current)
+                    {
+                        for (var j = 0; j < kv.Value; j++)
+                        {
+                            array[i++] = kv.Key;
+                        }
                     }
                 }
             }
@@ -365,9 +494,11 @@ namespace System.Reactive.Disposables
                     return EmptyEnumerator;
                 }
 
+                var current = _disposables;
+
                 // the copy is unavoidable but the creation
                 // of an outer IEnumerable is avoidable
-                return new CompositeEnumerator(_disposables.ToArray());
+                return new CompositeEnumerator(current is List<IDisposable?> currentList ? currentList.ToArray() : ((Dictionary<IDisposable, int>)current).Keys.ToArray());
             }
         }
 


### PR DESCRIPTION
Addresses #2005

This change makes the `CompositeDisposable` far more efficient when it is dealing with large numbers (thousands) of `IDisposable` objects.  This matters in "fan out/in" scenarios where items are split into large numbers of groups with `GroupBy`, and then later recombined (usually with some per-group processing having been applied) with either `SelectMany` or `Merge`, because these operators use `CompositeDisposable` to keep track of their subscriptions to upstream observables (the ones that emerge by `GroupBy` in the scenario being described here).

Fan out/in is an important technique in Rx.NET, as described at https://introtorx.com/chapters/transformation-of-sequences#the-significance-of-selectmany and https://introtorx.com/chapters/partitioning so we want this to work well even with large numbers of groups.

Before, `CompositeDisposable` used a `List<IDisposable>` internally, which meant that its `Remove` method had to perform a linear scan of the list to find the item to remove. This resulted in $O(N^2)$ performance (where $N$ is the number of groups being merged) when the source finally calls `OnCompleted`. If you had over 100,000 groups, this could end up taking seconds to complete!

With this change, the `CompositeDisposable` continues to use the same strategy as before for small and moderate sized lists because there's no observable performance problem with that, and it is likely to be more efficient for small collections than a strategy optimized for larger collections. And awful lot of `CompositeDisposable` instances end up with only a handful of items, so it's important that it continues to perform well in that scenario.

But with large numbers of disposables, it switches to a different strategy in which it uses a dictionary to track disposables.

We use a dictionary instead of the more obvious `HashSet<IDisposable>` because `CompositeDisposable` has always allowed you add the same disposable instance multiple times. Although it would not be a good idea to depend on this, we've never prevented it, and since this is a public type, some Rx users might depend on it. So the dictionary has an `int` value keeping track of how many times each particular disposable has been added. We expect this to be `1` in most cases in practice.

As the discussion at https://github.com/dotnet/reactive/issues/2005#issuecomment-1991961257 shows, we've added benchmarks that verify that this does address the performance problem described. We've also checked that this doesn't cause any significant change in performance for any other benchmarks. (That's important because `CompositeDisposable` is widely used within Rx.NET, so changes of this kind have the potential to have a broad negative impact. We wanted to make sure we hadn't made normal operation much slower just to improve this one particular and relatively unusual scenario.)