### PR TITLE
Resolve SDK 8.0.2xx diagnostics

### DIFF
--- a/Ix.NET/Integration/Android/Resources/Resource.Designer.cs
+++ b/Ix.NET/Integration/Android/Resources/Resource.Designer.cs
@@ -14,7 +14,7 @@ namespace Android
 {
 	
 	
-	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
+	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "13.2.2.120")]
 	public partial class Resource
 	{
 		

--- a/Rx.NET/Integration/Installation/Android/Resources/Resource.Designer.cs
+++ b/Rx.NET/Integration/Installation/Android/Resources/Resource.Designer.cs
@@ -14,7 +14,7 @@ namespace Android
 {
 	
 	
-	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
+	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "13.2.2.120")]
 	public partial class Resource
 	{
 		

--- a/Rx.NET/Source/src/Microsoft.Reactive.Testing/Microsoft.Reactive.Testing.csproj
+++ b/Rx.NET/Source/src/Microsoft.Reactive.Testing/Microsoft.Reactive.Testing.csproj
@@ -9,7 +9,7 @@
     <Description>Reactive Extensions (Rx) for .NET - Testing Library</Description>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
     <!-- NB: A lot of CA and IDE warnings are disabled because of the .cs files included from xunit.assert.source. -->
-    <NoWarn>$(NoWarn);IDE0054;IDE0066;CA1305;CA1307;CA1032;CA1064;CA1704;CA1822;CA1812;CA1820;CA1823;CA1825;CA1845;CA2249;IDE0016;IDE0018;IDE0019;IDE0020;IDE0031;IDE0039;IDE0044;IDE0059;IDE0074;IDE0270</NoWarn>
+    <NoWarn>$(NoWarn);IDE0054;IDE0066;CA1305;CA1307;CA1032;CA1064;CA1704;CA1822;CA1812;CA1820;CA1823;CA1825;CA1845;CA2249;IDE0016;IDE0018;IDE0019;IDE0020;IDE0028;IDE0031;IDE0039;IDE0044;IDE0059;IDE0074;IDE0090;IDE0270;IDE0300</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Rx.NET/Source/src/System.Reactive/Internal/Lookup.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/Lookup.cs
@@ -39,7 +39,7 @@ namespace System.Reactive
             {
                 if (!_dictionary.TryGetValue(key, out var list))
                 {
-                    return Enumerable.Empty<E>();
+                    return [];
                 }
 
                 return Hide(list);

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Buffer.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Buffer.cs
@@ -29,7 +29,7 @@ namespace System.Reactive.Linq.ObservableImpl
             {
                 private readonly int _count;
                 private int _index;
-                private IList<TSource>? _buffer;
+                private List<TSource>? _buffer;
 
                 internal ExactSink(IObserver<IList<TSource>> observer, int count) : base(observer)
                 {
@@ -41,7 +41,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     var buffer = _buffer;
                     if (buffer == null)
                     {
-                        buffer = new List<TSource>();
+                        buffer = [];
                         _buffer = buffer;
                     }
 
@@ -102,7 +102,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 private readonly int _count;
                 private readonly int _skip;
                 private int _index;
-                private IList<TSource>? _buffer;
+                private List<TSource>? _buffer;
 
                 internal SkipSink(IObserver<IList<TSource>> observer, int count, int skip) : base(observer)
                 {
@@ -116,7 +116,7 @@ namespace System.Reactive.Linq.ObservableImpl
                     var buffer = _buffer;
                     if (idx == 0)
                     {
-                        buffer = new List<TSource>();
+                        buffer = [];
                         _buffer = buffer;
                     }
 

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/FromEventPattern.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/FromEventPattern.cs
@@ -135,13 +135,13 @@ namespace System.Reactive.Linq.ObservableImpl
 
             private Action AddHandlerCore(Delegate handler)
             {
-                _addMethod.Invoke(_target, new object[] { handler });
-                return () => _removeMethod.Invoke(_target, new object[] { handler });
+                _addMethod.Invoke(_target, [handler]);
+                return () => _removeMethod.Invoke(_target, [handler]);
             }
 
             private Action AddHandlerCoreWinRT(Delegate handler)
             {
-                var token = _addMethod.Invoke(_target, new object[] { handler });
+                var token = _addMethod.Invoke(_target, [handler]);
                 return () => _removeMethod.Invoke(_target, [token]);
             }
         }

--- a/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Blocking.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Blocking.cs
@@ -16,7 +16,7 @@ namespace System.Reactive.Linq
 
         public virtual IEnumerable<IList<TSource>> Chunkify<TSource>(IObservable<TSource> source)
         {
-            return source.Collect<TSource, IList<TSource>>(() => new List<TSource>(), (lst, x) => { lst.Add(x); return lst; }, _ => new List<TSource>());
+            return source.Collect<TSource, IList<TSource>>(() => [], (lst, x) => { lst.Add(x); return lst; }, _ => []);
         }
 
         #endregion

--- a/Rx.NET/Source/src/System.Reactive/ObservableQuery.cs
+++ b/Rx.NET/Source/src/System.Reactive/ObservableQuery.cs
@@ -322,13 +322,13 @@ namespace System.Reactive
                     if (lastArgument.NodeType == ExpressionType.NewArrayInit)
                     {
                         var paramsArray = (NewArrayExpression)lastArgument;
-                        return new List<Expression>
-                        {
+                        return
+                        [
                             Expression.NewArrayInit(
                                 typeof(Plan<>).MakeGenericType(method.GetGenericArguments()[0]),
                                 paramsArray.Expressions.Select(param => Visit(param))
                             )
-                        };
+                        ];
                     }
                 }
 

--- a/Rx.NET/Source/src/System.Reactive/Subjects/AsyncSubject.cs
+++ b/Rx.NET/Source/src/System.Reactive/Subjects/AsyncSubject.cs
@@ -22,7 +22,7 @@ namespace System.Reactive.Subjects
         private bool _hasValue;
         private Exception? _exception;
 
-#pragma warning disable CA1825 // (Avoid zero-length array allocations.) The identity of these arrays matters, so we can't use the shared Array.Empty<T>() instance
+#pragma warning disable CA1825,IDE0300 // (Avoid zero-length array allocations. Use collection expressions) The identity of these arrays matters, so we can't use the shared Array.Empty<T>() instance either explicitly, or indirectly via a collection expression
         /// <summary>
         /// A pre-allocated empty array indicating the AsyncSubject has terminated.
         /// </summary>
@@ -31,7 +31,7 @@ namespace System.Reactive.Subjects
         /// A pre-allocated empty array indicating the AsyncSubject has been disposed.
         /// </summary>
         private static readonly AsyncSubjectDisposable[] Disposed = new AsyncSubjectDisposable[0];
-#pragma warning restore CA1825
+#pragma warning restore CA1825,IDE0300
 
         #endregion
 

--- a/Rx.NET/Source/src/System.Reactive/Subjects/Subject.cs
+++ b/Rx.NET/Source/src/System.Reactive/Subjects/Subject.cs
@@ -18,10 +18,10 @@ namespace System.Reactive.Subjects
 
         private SubjectDisposable[] _observers;
         private Exception? _exception;
-#pragma warning disable CA1825 // (Avoid zero-length array allocations.) The identity of these arrays matters, so we can't use the shared Array.Empty<T>() instance
+#pragma warning disable CA1825,IDE0300 // (Avoid zero-length array allocations. Use collection expressions) The identity of these arrays matters, so we can't use the shared Array.Empty<T>() instance either explicitly, or indirectly via a collection expression
         private static readonly SubjectDisposable[] Terminated = new SubjectDisposable[0];
         private static readonly SubjectDisposable[] Disposed = new SubjectDisposable[0];
-#pragma warning restore CA1825
+#pragma warning restore CA1825,IDE0300
 
         #endregion
 

--- a/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Api/ApiApprovalTests.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive.ApiApprovals/Api/ApiApprovalTests.cs
@@ -50,7 +50,7 @@ namespace ReactiveTests.Tests.Api
         {
             ApiGeneratorOptions options = new()
             {
-                AllowNamespacePrefixes = new[] { "System", "Microsoft" }
+                AllowNamespacePrefixes = ["System", "Microsoft"]
             };
             return Filter(ApiGenerator.GeneratePublicApi(assembly, options));
         }

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Aliases.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Aliases.cs
@@ -21,10 +21,10 @@ namespace ReactiveTests.Tests
         {
             var xs = Observable.Return(1).AsQbservable();
 
-            Assert.True(xs.Filter(x => true).ToEnumerable().SequenceEqual(new[] { 1 }), "Filter");
-            Assert.True(xs.Filter(x => true).Concat(xs.Filter(x => false)).ToEnumerable().SequenceEqual(new[] { 1 }), "Concat/Filter");
-            Assert.True(xs.Map(x => x.ToString()).ToEnumerable().SequenceEqual(new[] { "1" }), "Map");
-            Assert.True(xs.FlatMap(x => xs).ToEnumerable().SequenceEqual(new[] { 1 }), "FlatMap");
+            Assert.True(xs.Filter(x => true).ToEnumerable().SequenceEqual([1]), "Filter");
+            Assert.True(xs.Filter(x => true).Concat(xs.Filter(x => false)).ToEnumerable().SequenceEqual([1]), "Concat/Filter");
+            Assert.True(xs.Map(x => x.ToString()).ToEnumerable().SequenceEqual(["1"]), "Map");
+            Assert.True(xs.FlatMap(x => xs).ToEnumerable().SequenceEqual([1]), "FlatMap");
         }
     }
 }

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/ArgumentValidationTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/ArgumentValidationTest.cs
@@ -40,6 +40,7 @@ namespace ReactiveTests.Tests
         /// </summary>
         static ArgumentValidationTest()
         {
+#pragma warning disable IDE0300 // Simplify collection initialization. We want to be clear about what kinds of collections are in use in these tests.
             _defaultValues = new Dictionary<string, object>
             {
                 { "IObservable`1[Object]", Observable.Return(new object()) },
@@ -269,6 +270,7 @@ namespace ReactiveTests.Tests
 
                 { "Func`17[Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, AsyncCallback, Object, IAsyncResult]", new Func<int, int, int, int, int, int, int, int, int, int, int, int, int, int, AsyncCallback, object, IAsyncResult>((v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16) => null) }
             };
+#pragma warning restore IDE0300 // Simplify collection initialization
         }
 
         #endregion

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Concurrency/SchedulerTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Concurrency/SchedulerTest.cs
@@ -479,7 +479,7 @@ namespace ReactiveTests.Tests
         public void DisableOptimizations_ArgumentChecking()
         {
             ReactiveAssert.Throws<ArgumentNullException>(() => Scheduler.DisableOptimizations(default));
-            ReactiveAssert.Throws<ArgumentNullException>(() => Scheduler.DisableOptimizations(default, new Type[0]));
+            ReactiveAssert.Throws<ArgumentNullException>(() => Scheduler.DisableOptimizations(default, []));
 #if !WINDOWS
             ReactiveAssert.Throws<ArgumentNullException>(() => Scheduler.DisableOptimizations(ThreadPoolScheduler.Instance, default));
 #endif

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Disposables/DisposableTests.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Disposables/DisposableTests.cs
@@ -196,7 +196,7 @@ namespace ReactiveTests.Tests
             var g = new CompositeDisposable(d1, d2);
             Assert.Equal(2, g.Count);
             var x = Enumerable.ToArray(g);
-            Assert.True(g.ToArray().SequenceEqual(new[] { d1, d2 }));
+            Assert.True(g.ToArray().SequenceEqual([d1, d2]));
         }
 
         [TestMethod]
@@ -211,7 +211,7 @@ namespace ReactiveTests.Tests
                 lst.Add(x);
             }
 
-            Assert.True(lst.SequenceEqual(new[] { d1, d2 }));
+            Assert.True(lst.SequenceEqual([d1, d2]));
         }
 
         [TestMethod]
@@ -226,7 +226,7 @@ namespace ReactiveTests.Tests
                 lst.Add(x);
             }
 
-            Assert.True(lst.SequenceEqual(new[] { d1, d2 }));
+            Assert.True(lst.SequenceEqual([d1, d2]));
         }
 
         [TestMethod]
@@ -252,7 +252,7 @@ namespace ReactiveTests.Tests
         [TestMethod]
         public void CompositeDisposable_AddNull_via_IEnum_ctor()
         {
-            IEnumerable<IDisposable> values = new IDisposable[] { null };
+            IEnumerable<IDisposable> values = [null];
 #pragma warning disable CA1806 // (Unused new instance.) We expect the constructor to throw.
             ReactiveAssert.Throws<ArgumentException>(() => new CompositeDisposable(values));
 #pragma warning restore CA1806
@@ -882,7 +882,7 @@ namespace ReactiveTests.Tests
             var disp3 = false;
             var d3 = Disposable.Create(() => { Assert.False(disp3); disp3 = true; });
 
-            var d = StableCompositeDisposable.Create(new List<IDisposable>(new[] { d1, d2, d3 }));
+            var d = StableCompositeDisposable.Create(new List<IDisposable>([d1, d2, d3]));
 
             Assert.False(disp1);
             Assert.False(disp2);

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/ImmutableListTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/ImmutableListTest.cs
@@ -21,37 +21,37 @@ namespace ReactiveTests.Tests
         {
             var list = ImmutableList<int>.Empty;
 
-            Assert.True(list.Data.SequenceEqual(new int[] { }));
+            Assert.True(list.Data.SequenceEqual([]));
 
             list = list.Add(42);
 
-            Assert.True(list.Data.SequenceEqual(new int[] { 42 }));
+            Assert.True(list.Data.SequenceEqual([42]));
 
             list = list.Remove(42);
 
-            Assert.True(list.Data.SequenceEqual(new int[] { }));
+            Assert.True(list.Data.SequenceEqual([]));
 
             list = list.Remove(42);
 
-            Assert.True(list.Data.SequenceEqual(new int[] { }));
+            Assert.True(list.Data.SequenceEqual([]));
 
             list = list.Add(43);
             list = list.Add(44);
             list = list.Add(43);
 
-            Assert.True(list.Data.SequenceEqual(new int[] { 43, 44, 43 }));
+            Assert.True(list.Data.SequenceEqual([43, 44, 43]));
 
             list = list.Remove(43);
 
-            Assert.True(list.Data.SequenceEqual(new int[] { 44, 43 }));
+            Assert.True(list.Data.SequenceEqual([44, 43]));
 
             list = list.Remove(43);
 
-            Assert.True(list.Data.SequenceEqual(new int[] { 44 }));
+            Assert.True(list.Data.SequenceEqual([44]));
 
             list = list.Remove(44);
 
-            Assert.True(list.Data.SequenceEqual(new int[] { }));
+            Assert.True(list.Data.SequenceEqual([]));
         }
 
         [TestMethod]
@@ -59,15 +59,15 @@ namespace ReactiveTests.Tests
         {
             var list = ImmutableList<string>.Empty;
 
-            Assert.True(list.Data.SequenceEqual(new string[] { }));
+            Assert.True(list.Data.SequenceEqual([]));
 
             list = list.Add(null);
 
-            Assert.True(list.Data.SequenceEqual(new string[] { null }));
+            Assert.True(list.Data.SequenceEqual([null]));
 
             list = list.Remove(null);
 
-            Assert.True(list.Data.SequenceEqual(new string[] { }));
+            Assert.True(list.Data.SequenceEqual([]));
         }
     }
 #endif

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/AutoConnectTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/AutoConnectTest.cs
@@ -12,6 +12,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Assert = Xunit.Assert;
 
+#pragma warning disable IDE0028 // Simplify collection initialization. Using this in Assert.Equals makes it unclear what types are actually in use.
+
 namespace ReactiveTests.Tests
 {
     [TestClass]

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/BufferTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/BufferTest.cs
@@ -56,9 +56,9 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(300, b => b.SequenceEqual(new int[] { 3, 4 })),
-                OnNext<IList<int>>(500, b => b.SequenceEqual(new int[] { 5, 6, 7, 8, 9 })),
-                OnNext<IList<int>>(590, b => b.SequenceEqual(new int[] { 10 })),
+                OnNext<IList<int>>(300, b => b.SequenceEqual([3, 4])),
+                OnNext<IList<int>>(500, b => b.SequenceEqual([5, 6, 7, 8, 9])),
+                OnNext<IList<int>>(590, b => b.SequenceEqual([10])),
                 OnCompleted<IList<int>>(590)
             );
 
@@ -112,10 +112,10 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(300, b => b.SequenceEqual(new int[] { 3, 4 })),
-                OnNext<IList<int>>(400, b => b.SequenceEqual(new int[] { 5, 6 })),
-                OnNext<IList<int>>(500, b => b.SequenceEqual(new int[] { 7, 8, 9 })),
-                OnNext<IList<int>>(590, b => b.SequenceEqual(new int[] { 10 })),
+                OnNext<IList<int>>(300, b => b.SequenceEqual([3, 4])),
+                OnNext<IList<int>>(400, b => b.SequenceEqual([5, 6])),
+                OnNext<IList<int>>(500, b => b.SequenceEqual([7, 8, 9])),
+                OnNext<IList<int>>(590, b => b.SequenceEqual([10])),
                 OnCompleted<IList<int>>(590)
             );
 
@@ -166,9 +166,9 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(300, l => l.SequenceEqual(new int[] { 3, 4 })),
-                OnNext<IList<int>>(500, l => l.SequenceEqual(new int[] { 5, 6, 7, 8, 9 })),
-                OnNext<IList<int>>(590, l => l.SequenceEqual(new int[] { 10 })),
+                OnNext<IList<int>>(300, l => l.SequenceEqual([3, 4])),
+                OnNext<IList<int>>(500, l => l.SequenceEqual([5, 6, 7, 8, 9])),
+                OnNext<IList<int>>(590, l => l.SequenceEqual([10])),
                 OnCompleted<IList<int>>(590)
             );
 
@@ -205,7 +205,7 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(300, l => l.SequenceEqual(new int[] { 3, 4 }))
+                OnNext<IList<int>>(300, l => l.SequenceEqual([3, 4]))
             );
 
             xs.Subscriptions.AssertEqual(
@@ -241,8 +241,8 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(300, l => l.SequenceEqual(new int[] { 3, 4 })),
-                OnNext<IList<int>>(500, l => l.SequenceEqual(new int[] { 5, 6, 7, 8, 9 })),
+                OnNext<IList<int>>(300, l => l.SequenceEqual([3, 4])),
+                OnNext<IList<int>>(500, l => l.SequenceEqual([5, 6, 7, 8, 9])),
                 OnError<IList<int>>(590, ex)
             );
 
@@ -351,10 +351,10 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(305, b => b.SequenceEqual(new int[] { 4 })),
-                OnNext<IList<int>>(400, b => b.SequenceEqual(new int[] { })),
-                OnNext<IList<int>>(430, b => b.SequenceEqual(new int[] { 6, 7, 8 })),
-                OnNext<IList<int>>(490, b => b.SequenceEqual(new int[] { 7, 8, 9 })),
+                OnNext<IList<int>>(305, b => b.SequenceEqual([4])),
+                OnNext<IList<int>>(400, b => b.SequenceEqual([])),
+                OnNext<IList<int>>(430, b => b.SequenceEqual([6, 7, 8])),
+                OnNext<IList<int>>(490, b => b.SequenceEqual([7, 8, 9])),
                 OnCompleted<IList<int>>(900)
             );
 
@@ -406,12 +406,12 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(255, b => b.SequenceEqual(new int[] { 3 })),
-                OnNext<IList<int>>(330, b => b.SequenceEqual(new int[] { 4, 5 })),
-                OnNext<IList<int>>(350, b => b.SequenceEqual(new int[] { 6 })),
-                OnNext<IList<int>>(400, b => b.SequenceEqual(new int[] { })),
-                OnNext<IList<int>>(500, b => b.SequenceEqual(new int[] { 7, 8, 9 })),
-                OnNext<IList<int>>(590, b => b.SequenceEqual(new int[] { 10 })),
+                OnNext<IList<int>>(255, b => b.SequenceEqual([3])),
+                OnNext<IList<int>>(330, b => b.SequenceEqual([4, 5])),
+                OnNext<IList<int>>(350, b => b.SequenceEqual([6])),
+                OnNext<IList<int>>(400, b => b.SequenceEqual([])),
+                OnNext<IList<int>>(500, b => b.SequenceEqual([7, 8, 9])),
+                OnNext<IList<int>>(590, b => b.SequenceEqual([10])),
                 OnCompleted<IList<int>>(590)
             );
 
@@ -455,10 +455,10 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(255, b => b.SequenceEqual(new int[] { 3 })),
-                OnNext<IList<int>>(330, b => b.SequenceEqual(new int[] { 4, 5 })),
-                OnNext<IList<int>>(350, b => b.SequenceEqual(new int[] { 6 })),
-                OnNext<IList<int>>(400, b => b.SequenceEqual(new int[] { })),
+                OnNext<IList<int>>(255, b => b.SequenceEqual([3])),
+                OnNext<IList<int>>(330, b => b.SequenceEqual([4, 5])),
+                OnNext<IList<int>>(350, b => b.SequenceEqual([6])),
+                OnNext<IList<int>>(400, b => b.SequenceEqual([])),
                 OnCompleted<IList<int>>(400)
             );
 
@@ -501,9 +501,9 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(255, b => b.SequenceEqual(new int[] { 3 })),
-                OnNext<IList<int>>(330, b => b.SequenceEqual(new int[] { 4, 5 })),
-                OnNext<IList<int>>(350, b => b.SequenceEqual(new int[] { 6 })),
+                OnNext<IList<int>>(255, b => b.SequenceEqual([3])),
+                OnNext<IList<int>>(330, b => b.SequenceEqual([4, 5])),
+                OnNext<IList<int>>(350, b => b.SequenceEqual([6])),
                 OnError<IList<int>>(400, ex)
             );
 
@@ -549,9 +549,9 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(255, b => b.SequenceEqual(new int[] { 3 })),
-                OnNext<IList<int>>(330, b => b.SequenceEqual(new int[] { 4, 5 })),
-                OnNext<IList<int>>(350, b => b.SequenceEqual(new int[] { 6 })),
+                OnNext<IList<int>>(255, b => b.SequenceEqual([3])),
+                OnNext<IList<int>>(330, b => b.SequenceEqual([4, 5])),
+                OnNext<IList<int>>(350, b => b.SequenceEqual([6])),
                 OnError<IList<int>>(400, ex)
             );
 
@@ -600,7 +600,7 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(250, l => l.SequenceEqual(new[] { 2, 3, 4, 5 })),
+                OnNext<IList<int>>(250, l => l.SequenceEqual([2, 3, 4, 5])),
                 OnCompleted<IList<int>>(250)
             );
 
@@ -628,8 +628,8 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(220, l => l.SequenceEqual(new[] { 2, 3 })),
-                OnNext<IList<int>>(240, l => l.SequenceEqual(new[] { 4, 5 })),
+                OnNext<IList<int>>(220, l => l.SequenceEqual([2, 3])),
+                OnNext<IList<int>>(240, l => l.SequenceEqual([4, 5])),
                 OnCompleted<IList<int>>(250)
             );
 
@@ -657,8 +657,8 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(230, l => l.SequenceEqual(new int[] { 2, 3, 4 })),
-                OnNext<IList<int>>(250, l => l.SequenceEqual(new int[] { 5 })),
+                OnNext<IList<int>>(230, l => l.SequenceEqual([2, 3, 4])),
+                OnNext<IList<int>>(250, l => l.SequenceEqual([5])),
                 OnCompleted<IList<int>>(250)
             );
 
@@ -715,10 +715,10 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(230, l => l.SequenceEqual(new int[] { 2, 3, 4 })),
-                OnNext<IList<int>>(240, l => l.SequenceEqual(new int[] { 3, 4, 5 })),
-                OnNext<IList<int>>(250, l => l.SequenceEqual(new int[] { 4, 5 })),
-                OnNext<IList<int>>(250, l => l.SequenceEqual(new int[] { 5 })),
+                OnNext<IList<int>>(230, l => l.SequenceEqual([2, 3, 4])),
+                OnNext<IList<int>>(240, l => l.SequenceEqual([3, 4, 5])),
+                OnNext<IList<int>>(250, l => l.SequenceEqual([4, 5])),
+                OnNext<IList<int>>(250, l => l.SequenceEqual([5])),
                 OnCompleted<IList<int>>(250)
             );
 
@@ -746,8 +746,8 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(220, l => l.SequenceEqual(new int[] { 2, 3 })),
-                OnNext<IList<int>>(250, l => l.SequenceEqual(new int[] { 5 })),
+                OnNext<IList<int>>(220, l => l.SequenceEqual([2, 3])),
+                OnNext<IList<int>>(250, l => l.SequenceEqual([5])),
                 OnCompleted<IList<int>>(250)
             );
 

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/CatchTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/CatchTest.cs
@@ -15,6 +15,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Assert = Xunit.Assert;
 
+#pragma warning disable IDE0300 // Simplify collection initialization. We want to be clear about what kinds of collections are in use in these tests.
+
 namespace ReactiveTests.Tests
 {
     [TestClass]
@@ -712,7 +714,7 @@ namespace ReactiveTests.Tests
         {
             var evt = new ManualResetEvent(false);
 
-            IEnumerable<IObservable<int>> sources = new[] { Observable.Return(1), Observable.Return(2), Observable.Return(3) };
+            IEnumerable<IObservable<int>> sources = [Observable.Return(1), Observable.Return(2), Observable.Return(3)];
 
             var res = 0;
             Observable.Catch(sources).Subscribe(x =>
@@ -837,7 +839,7 @@ namespace ReactiveTests.Tests
                 OnCompleted<int>(340)
             );
 
-            var xss = new MockEnumerable<ITestableObservable<int>>(scheduler, new[] { o1, o2, o3, o2 });
+            var xss = new MockEnumerable<ITestableObservable<int>>(scheduler, [o1, o2, o3, o2]);
 
             var res = scheduler.Start(() =>
                 xss.Select(xs => (IObservable<int>)xs).Catch()
@@ -894,7 +896,7 @@ namespace ReactiveTests.Tests
                 OnCompleted<int>(340)
             );
 
-            var xss = new MockEnumerable<ITestableObservable<int>>(scheduler, new[] { o1, o2 });
+            var xss = new MockEnumerable<ITestableObservable<int>>(scheduler, [o1, o2]);
 
             var res = scheduler.Start(() =>
                 xss.Select(xs => (IObservable<int>)xs).Catch(),

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ChunkifyTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ChunkifyTest.cs
@@ -69,13 +69,13 @@ namespace ReactiveTests.Tests
             );
 
             Assert.Equal(7, res.Count);
-            Assert.True(res[0].SequenceEqual(new int[] { }));
-            Assert.True(res[1].SequenceEqual(new int[] { 3 }));
-            Assert.True(res[2].SequenceEqual(new int[] { 4 }));
-            Assert.True(res[3].SequenceEqual(new int[] { }));
-            Assert.True(res[4].SequenceEqual(new int[] { 5, 6, 7 }));
-            Assert.True(res[5].SequenceEqual(new int[] { 8 }));
-            Assert.True(res[6].SequenceEqual(new int[] { }));
+            Assert.True(res[0].SequenceEqual([]));
+            Assert.True(res[1].SequenceEqual([3]));
+            Assert.True(res[2].SequenceEqual([4]));
+            Assert.True(res[3].SequenceEqual([]));
+            Assert.True(res[4].SequenceEqual([5, 6, 7]));
+            Assert.True(res[5].SequenceEqual([8]));
+            Assert.True(res[6].SequenceEqual([]));
         }
 
         [TestMethod]
@@ -118,8 +118,8 @@ namespace ReactiveTests.Tests
             );
 
             Assert.Equal(2, res.Count);
-            Assert.True(res[0].SequenceEqual(new int[] { 3, 4, 5 }));
-            Assert.True(res[1].SequenceEqual(new int[] { 6, 7, 8 }));
+            Assert.True(res[0].SequenceEqual([3, 4, 5]));
+            Assert.True(res[1].SequenceEqual([6, 7, 8]));
         }
 
         [TestMethod]
@@ -175,10 +175,10 @@ namespace ReactiveTests.Tests
             );
 
             Assert.Equal(4, res.Count);
-            Assert.True(res[0].SequenceEqual(new int[] { }));
-            Assert.True(res[1].SequenceEqual(new int[] { 3 }));
-            Assert.True(res[2].SequenceEqual(new int[] { 4 }));
-            Assert.True(res[3].SequenceEqual(new int[] { }));
+            Assert.True(res[0].SequenceEqual([]));
+            Assert.True(res[1].SequenceEqual([3]));
+            Assert.True(res[2].SequenceEqual([4]));
+            Assert.True(res[3].SequenceEqual([]));
         }
 
     }

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/CombineLatestTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/CombineLatestTest.cs
@@ -3707,10 +3707,10 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(230, l => l.SequenceEqual(new[] { 1, 2, 3 })),
-                OnNext<IList<int>>(240, l => l.SequenceEqual(new[] { 4, 2, 3 })),
-                OnNext<IList<int>>(250, l => l.SequenceEqual(new[] { 4, 5, 3 })),
-                OnNext<IList<int>>(260, l => l.SequenceEqual(new[] { 4, 5, 6 })),
+                OnNext<IList<int>>(230, l => l.SequenceEqual([1, 2, 3])),
+                OnNext<IList<int>>(240, l => l.SequenceEqual([4, 2, 3])),
+                OnNext<IList<int>>(250, l => l.SequenceEqual([4, 5, 3])),
+                OnNext<IList<int>>(260, l => l.SequenceEqual([4, 5, 6])),
                 OnCompleted<IList<int>>(290)
             );
         }
@@ -3720,7 +3720,7 @@ namespace ReactiveTests.Tests
         {
             ReactiveAssert.Throws<ArgumentNullException>(() => Observable.CombineLatest(default(IEnumerable<IObservable<int>>)));
             ReactiveAssert.Throws<ArgumentNullException>(() => Observable.CombineLatest(default(IEnumerable<IObservable<int>>), _ => 42));
-            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.CombineLatest(new[] { Observable.Return(42) }, default(Func<IList<int>, string>)));
+            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.CombineLatest([Observable.Return(42)], default(Func<IList<int>, string>)));
             ReactiveAssert.Throws<ArgumentNullException>(() => Observable.CombineLatest(default(IObservable<int>[])));
         }
 
@@ -3738,10 +3738,10 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(230, l => l.SequenceEqual(new[] { 1, 2, 3 })),
-                OnNext<IList<int>>(240, l => l.SequenceEqual(new[] { 1, 5, 3 })),
-                OnNext<IList<int>>(250, l => l.SequenceEqual(new[] { 4, 5, 3 })),
-                OnNext<IList<int>>(260, l => l.SequenceEqual(new[] { 4, 5, 6 })),
+                OnNext<IList<int>>(230, l => l.SequenceEqual([1, 2, 3])),
+                OnNext<IList<int>>(240, l => l.SequenceEqual([1, 5, 3])),
+                OnNext<IList<int>>(250, l => l.SequenceEqual([4, 5, 3])),
+                OnNext<IList<int>>(260, l => l.SequenceEqual([4, 5, 6])),
                 OnCompleted<IList<int>>(420)
             );
 
@@ -3806,13 +3806,13 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(230, l => l.SequenceEqual(new[] { 1, 2, 3 })),
-                OnNext<IList<int>>(240, l => l.SequenceEqual(new[] { 1, 5, 3 })),
-                OnNext<IList<int>>(250, l => l.SequenceEqual(new[] { 4, 5, 3 })),
-                OnNext<IList<int>>(260, l => l.SequenceEqual(new[] { 4, 5, 6 })),
-                OnNext<IList<int>>(280, l => l.SequenceEqual(new[] { 4, 5, 8 })),
-                OnNext<IList<int>>(290, l => l.SequenceEqual(new[] { 4, 7, 8 })),
-                OnNext<IList<int>>(310, l => l.SequenceEqual(new[] { 4, 9, 8 })),
+                OnNext<IList<int>>(230, l => l.SequenceEqual([1, 2, 3])),
+                OnNext<IList<int>>(240, l => l.SequenceEqual([1, 5, 3])),
+                OnNext<IList<int>>(250, l => l.SequenceEqual([4, 5, 3])),
+                OnNext<IList<int>>(260, l => l.SequenceEqual([4, 5, 6])),
+                OnNext<IList<int>>(280, l => l.SequenceEqual([4, 5, 8])),
+                OnNext<IList<int>>(290, l => l.SequenceEqual([4, 7, 8])),
+                OnNext<IList<int>>(310, l => l.SequenceEqual([4, 9, 8])),
                 OnCompleted<IList<int>>(410)
             );
 
@@ -3882,8 +3882,8 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(230, l => l.SequenceEqual(new[] { 1, 2, 3 })),
-                OnNext<IList<int>>(240, l => l.SequenceEqual(new[] { 1, 5, 3 })),
+                OnNext<IList<int>>(230, l => l.SequenceEqual([1, 2, 3])),
+                OnNext<IList<int>>(240, l => l.SequenceEqual([1, 5, 3])),
                 OnError<IList<int>>(250, ex)
             );
 

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ConcatTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ConcatTest.cs
@@ -59,7 +59,7 @@ namespace ReactiveTests.Tests
         {
             var evt = new ManualResetEvent(false);
 
-            IEnumerable<IObservable<int>> sources = new[] { Observable.Return(1), Observable.Return(2), Observable.Return(3) };
+            IEnumerable<IObservable<int>> sources = [Observable.Return(1), Observable.Return(2), Observable.Return(3)];
 
             var sum = 0;
             Observable.Concat(sources).Subscribe(n =>
@@ -716,7 +716,7 @@ namespace ReactiveTests.Tests
                 OnCompleted<int>(340)
             );
 
-            var xss = new MockEnumerable<ITestableObservable<int>>(scheduler, new[] { o1, o2, o3, o2 });
+            var xss = new MockEnumerable<ITestableObservable<int>>(scheduler, [o1, o2, o3, o2]);
 
             var res = scheduler.Start(() =>
                 xss.Select(xs => (IObservable<int>)xs).Concat()
@@ -777,7 +777,7 @@ namespace ReactiveTests.Tests
                 OnCompleted<int>(340)
             );
 
-            var xss = new MockEnumerable<ITestableObservable<int>>(scheduler, new[] { o1, o2 });
+            var xss = new MockEnumerable<ITestableObservable<int>>(scheduler, [o1, o2]);
 
             var res = scheduler.Start(() =>
                 xss.Select(xs => (IObservable<int>)xs).Concat(),
@@ -940,7 +940,7 @@ namespace ReactiveTests.Tests
 
             var res = tss.ToArray().Single();
 
-            Assert.True(res.SequenceEqual(new[] { 1, 2, 3 }));
+            Assert.True(res.SequenceEqual([1, 2, 3]));
         }
 
     }

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/CreateAsyncTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/CreateAsyncTest.cs
@@ -46,7 +46,7 @@ namespace ReactiveTests.Tests
             var d = xs.Subscribe(lst.Add);
             d.Dispose();
 
-            Assert.True(lst.SequenceEqual(new[] { 42 }));
+            Assert.True(lst.SequenceEqual([42]));
         }
 
         [TestMethod]
@@ -62,7 +62,7 @@ namespace ReactiveTests.Tests
             var d = xs.Subscribe(lst.Add);
             d.Dispose();
 
-            Assert.True(lst.SequenceEqual(new[] { 42 }));
+            Assert.True(lst.SequenceEqual([42]));
         }
 
         [TestMethod]
@@ -78,7 +78,7 @@ namespace ReactiveTests.Tests
             var d = xs.Subscribe(lst.Add);
             d.Dispose();
 
-            Assert.True(lst.SequenceEqual(new[] { 42 }));
+            Assert.True(lst.SequenceEqual([42]));
         }
 
         [TestMethod]
@@ -94,7 +94,7 @@ namespace ReactiveTests.Tests
             var d = xs.Subscribe(lst.Add);
             d.Dispose();
 
-            Assert.True(lst.SequenceEqual(new[] { 42 }));
+            Assert.True(lst.SequenceEqual([42]));
         }
 
         private Task Producer1(IObserver<int> results, IScheduler scheduler, CancellationToken token)

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/CreateTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/CreateTest.cs
@@ -53,7 +53,7 @@ namespace ReactiveTests.Tests
             var d = xs.Subscribe(lst.Add);
             d.Dispose();
 
-            Assert.True(lst.SequenceEqual(new[] { 42 }));
+            Assert.True(lst.SequenceEqual([42]));
         }
 
         [TestMethod]
@@ -228,7 +228,7 @@ namespace ReactiveTests.Tests
             var d = xs.Subscribe(lst.Add);
             d.Dispose();
 
-            Assert.True(lst.SequenceEqual(new[] { 42 }));
+            Assert.True(lst.SequenceEqual([42]));
         }
 
         [TestMethod]

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/DelayTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/DelayTest.cs
@@ -694,13 +694,13 @@ namespace ReactiveTests.Tests
         [TestMethod]
         public void Delay_TimeSpan_DefaultScheduler()
         {
-            Assert.True(Observable.Return(1).Delay(TimeSpan.FromMilliseconds(1)).ToEnumerable().SequenceEqual(new[] { 1 }));
+            Assert.True(Observable.Return(1).Delay(TimeSpan.FromMilliseconds(1)).ToEnumerable().SequenceEqual([1]));
         }
 
         [TestMethod]
         public void Delay_DateTimeOffset_DefaultScheduler()
         {
-            Assert.True(Observable.Return(1).Delay(DateTimeOffset.UtcNow + TimeSpan.FromMilliseconds(1)).ToEnumerable().SequenceEqual(new[] { 1 }));
+            Assert.True(Observable.Return(1).Delay(DateTimeOffset.UtcNow + TimeSpan.FromMilliseconds(1)).ToEnumerable().SequenceEqual([1]));
         }
 
         [TestMethod]

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ForEachTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ForEachTest.cs
@@ -34,7 +34,7 @@ namespace ReactiveTests.Tests
         {
             var lst = new List<int>();
             Observable.Empty<int>().ForEach(x => lst.Add(x));
-            Assert.True(lst.SequenceEqual(Enumerable.Empty<int>()));
+            Assert.True(lst.SequenceEqual([]));
         }
 
         [TestMethod]
@@ -42,7 +42,7 @@ namespace ReactiveTests.Tests
         {
             var lstX = new List<int>();
             Observable.Empty<int>().ForEach((x, i) => lstX.Add(x));
-            Assert.True(lstX.SequenceEqual(Enumerable.Empty<int>()));
+            Assert.True(lstX.SequenceEqual([]));
         }
 
         [TestMethod]
@@ -50,7 +50,7 @@ namespace ReactiveTests.Tests
         {
             var lst = new List<int>();
             Observable.Return(42).ForEach(x => lst.Add(x));
-            Assert.True(lst.SequenceEqual(new[] { 42 }));
+            Assert.True(lst.SequenceEqual([42]));
         }
 
         [TestMethod]
@@ -59,8 +59,8 @@ namespace ReactiveTests.Tests
             var lstX = new List<int>();
             var lstI = new List<int>();
             Observable.Return(42).ForEach((x, i) => { lstX.Add(x); lstI.Add(i); });
-            Assert.True(lstX.SequenceEqual(new[] { 42 }));
-            Assert.True(lstI.SequenceEqual(new[] { 0 }));
+            Assert.True(lstX.SequenceEqual([42]));
+            Assert.True(lstI.SequenceEqual([0]));
         }
 
         [TestMethod]

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ForkJoinTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ForkJoinTest.cs
@@ -312,7 +312,7 @@ namespace ReactiveTests.Tests
             var res = scheduler.Start(() => ObservableEx.ForkJoin(o1, o2, o3));
 
             res.Messages.AssertEqual(
-                OnNext<int[]>(270, l => l.SequenceEqual(new[] { 4, 7, 5 })), // TODO: fix ForkJoin behavior
+                OnNext<int[]>(270, l => l.SequenceEqual([4, 7, 5])), // TODO: fix ForkJoin behavior
                 OnCompleted<int[]>(270)
             );
         }
@@ -424,7 +424,7 @@ namespace ReactiveTests.Tests
             var res = scheduler.Start(() => ObservableEx.ForkJoin(new List<IObservable<int>> { o1, o2, o3, Observable.Return(20) }));
 
             res.Messages.AssertEqual(
-                OnNext<int[]>(270, l => l.SequenceEqual(new[] { 4, 7, 5, 20 })),
+                OnNext<int[]>(270, l => l.SequenceEqual([4, 7, 5, 20])),
                 OnCompleted<int[]>(270)
             );
         }
@@ -462,7 +462,7 @@ namespace ReactiveTests.Tests
             var res = scheduler.Start(() => ObservableEx.ForkJoin(new List<IObservable<int>> { Observable.Return(20), o1, o2, o3 }));
 
             res.Messages.AssertEqual(
-                OnNext<int[]>(270, l => l.SequenceEqual(new[] { 20, 4, 7, 5 })),
+                OnNext<int[]>(270, l => l.SequenceEqual([20, 4, 7, 5])),
                 OnCompleted<int[]>(270)
             );
         }
@@ -500,7 +500,7 @@ namespace ReactiveTests.Tests
             var res = scheduler.Start(() => ObservableEx.ForkJoin(new List<IObservable<int>> { o1, o2, o3 }));
 
             res.Messages.AssertEqual(
-                OnNext<int[]>(270, l => l.SequenceEqual(new[] { 4, 7, 5 })), // TODO: fix ForkJoin behavior
+                OnNext<int[]>(270, l => l.SequenceEqual([4, 7, 5])), // TODO: fix ForkJoin behavior
                 OnCompleted<int[]>(270)
             );
         }

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/FromAsyncPatternTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/FromAsyncPatternTest.cs
@@ -93,7 +93,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 1; };
 
             var res = Observable.FromAsyncPattern(begin, end)().Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>() }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>()]));
         }
 
         [TestMethod]
@@ -105,7 +105,7 @@ namespace ReactiveTests.Tests
             Action<IAsyncResult> end = iar => { Assert.Same(x, iar); };
 
             var res = Observable.FromAsyncPattern(begin, end)().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new[] { new Unit() }));
+            Assert.True(res.SequenceEqual([new Unit()]));
         }
 
         [TestMethod]
@@ -118,7 +118,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); throw ex; };
 
             var res = Observable.FromAsyncPattern(begin, end)().Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -131,7 +131,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 0; };
 
             var res = Observable.FromAsyncPattern(begin, end)().Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -148,7 +148,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 1; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>() }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>()]));
         }
 
         [TestMethod]
@@ -165,7 +165,7 @@ namespace ReactiveTests.Tests
             Action<IAsyncResult> end = iar => { Assert.Same(x, iar); };
 
             var res = Observable.FromAsyncPattern(begin, end)(2).ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new[] { new Unit() }));
+            Assert.True(res.SequenceEqual([new Unit()]));
         }
 
         [TestMethod]
@@ -178,7 +178,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); throw ex; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -191,7 +191,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 0; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -209,7 +209,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 1; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>() }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>()]));
         }
 
         [TestMethod]
@@ -227,7 +227,7 @@ namespace ReactiveTests.Tests
             Action<IAsyncResult> end = iar => { Assert.Same(x, iar); };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3).ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new[] { new Unit() }));
+            Assert.True(res.SequenceEqual([new Unit()]));
         }
 
         [TestMethod]
@@ -240,7 +240,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); throw ex; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -253,7 +253,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 0; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -272,7 +272,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 1; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>() }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>()]));
         }
         [TestMethod]
         public void FromAsyncPatternAction3()
@@ -290,7 +290,7 @@ namespace ReactiveTests.Tests
             Action<IAsyncResult> end = iar => { Assert.Same(x, iar); };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4).ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new[] { new Unit() }));
+            Assert.True(res.SequenceEqual([new Unit()]));
         }
 
         [TestMethod]
@@ -303,7 +303,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); throw ex; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -316,7 +316,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 0; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -336,7 +336,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 1; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>() }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>()]));
         }
 
         [TestMethod]
@@ -356,7 +356,7 @@ namespace ReactiveTests.Tests
             Action<IAsyncResult> end = iar => { Assert.Same(x, iar); };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5).ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new[] { new Unit() }));
+            Assert.True(res.SequenceEqual([new Unit()]));
         }
 
         [TestMethod]
@@ -369,7 +369,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); throw ex; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -382,7 +382,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 0; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -403,7 +403,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 1; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>() }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>()]));
         }
 
         [TestMethod]
@@ -424,7 +424,7 @@ namespace ReactiveTests.Tests
             Action<IAsyncResult> end = iar => { Assert.Same(x, iar); };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6).ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new[] { new Unit() }));
+            Assert.True(res.SequenceEqual([new Unit()]));
         }
 
         [TestMethod]
@@ -437,7 +437,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); throw ex; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -450,7 +450,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 0; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -472,7 +472,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 1; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>() }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>()]));
         }
 
         [TestMethod]
@@ -494,7 +494,7 @@ namespace ReactiveTests.Tests
             Action<IAsyncResult> end = iar => { Assert.Same(x, iar); };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7).ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new[] { new Unit() }));
+            Assert.True(res.SequenceEqual([new Unit()]));
         }
 
         [TestMethod]
@@ -507,7 +507,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); throw ex; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -520,7 +520,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 0; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -543,7 +543,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 1; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>() }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>()]));
         }
 
         [TestMethod]
@@ -566,7 +566,7 @@ namespace ReactiveTests.Tests
             Action<IAsyncResult> end = iar => { Assert.Same(x, iar); };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8).ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new[] { new Unit() }));
+            Assert.True(res.SequenceEqual([new Unit()]));
         }
 
         [TestMethod]
@@ -579,7 +579,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); throw ex; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -592,7 +592,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 0; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -616,7 +616,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 1; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8, 9).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>() }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>()]));
         }
 
         [TestMethod]
@@ -640,7 +640,7 @@ namespace ReactiveTests.Tests
             Action<IAsyncResult> end = iar => { Assert.Same(x, iar); };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8, 9).ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new[] { new Unit() }));
+            Assert.True(res.SequenceEqual([new Unit()]));
         }
 
         [TestMethod]
@@ -653,7 +653,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); throw ex; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8, 9).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -666,7 +666,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 0; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8, 9).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -691,7 +691,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 1; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8, 9, 10).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>() }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>()]));
         }
 
         [TestMethod]
@@ -716,7 +716,7 @@ namespace ReactiveTests.Tests
             Action<IAsyncResult> end = iar => { Assert.Same(x, iar); };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8, 9, 10).ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new[] { new Unit() }));
+            Assert.True(res.SequenceEqual([new Unit()]));
         }
 
         [TestMethod]
@@ -729,7 +729,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); throw ex; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8, 9, 10).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -742,7 +742,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 0; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8, 9, 10).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -768,7 +768,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 1; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8, 9, 10, 11).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>() }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>()]));
         }
 
         [TestMethod]
@@ -794,7 +794,7 @@ namespace ReactiveTests.Tests
             Action<IAsyncResult> end = iar => { Assert.Same(x, iar); };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8, 9, 10, 11).ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new[] { new Unit() }));
+            Assert.True(res.SequenceEqual([new Unit()]));
         }
 
         [TestMethod]
@@ -807,7 +807,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); throw ex; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8, 9, 10, 11).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -820,7 +820,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 0; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8, 9, 10, 11).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -847,7 +847,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 1; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>() }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>()]));
         }
 
         [TestMethod]
@@ -874,7 +874,7 @@ namespace ReactiveTests.Tests
             Action<IAsyncResult> end = iar => { Assert.Same(x, iar); };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new[] { new Unit() }));
+            Assert.True(res.SequenceEqual([new Unit()]));
         }
 
         [TestMethod]
@@ -887,7 +887,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); throw ex; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -900,7 +900,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 0; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -928,7 +928,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 1; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>() }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>()]));
         }
 
         [TestMethod]
@@ -956,7 +956,7 @@ namespace ReactiveTests.Tests
             Action<IAsyncResult> end = iar => { Assert.Same(x, iar); };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13).ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new[] { new Unit() }));
+            Assert.True(res.SequenceEqual([new Unit()]));
         }
 
         [TestMethod]
@@ -969,7 +969,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); throw ex; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -982,7 +982,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 0; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -1011,7 +1011,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 1; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>() }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>()]));
         }
 
         [TestMethod]
@@ -1040,7 +1040,7 @@ namespace ReactiveTests.Tests
             Action<IAsyncResult> end = iar => { Assert.Same(x, iar); };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14).ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new[] { new Unit() }));
+            Assert.True(res.SequenceEqual([new Unit()]));
         }
 
         [TestMethod]
@@ -1053,7 +1053,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); throw ex; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -1066,7 +1066,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 0; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -1096,7 +1096,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 1; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>() }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnNext(1), Notification.CreateOnCompleted<int>()]));
         }
 
         [TestMethod]
@@ -1126,7 +1126,7 @@ namespace ReactiveTests.Tests
             Action<IAsyncResult> end = iar => { Assert.Same(x, iar); };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new[] { new Unit() }));
+            Assert.True(res.SequenceEqual([new Unit()]));
         }
 
         [TestMethod]
@@ -1139,7 +1139,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); throw ex; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
@@ -1152,7 +1152,7 @@ namespace ReactiveTests.Tests
             Func<IAsyncResult, int> end = iar => { Assert.Same(x, iar); return 0; };
 
             var res = Observable.FromAsyncPattern(begin, end)(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).Materialize().ToEnumerable().ToArray();
-            Assert.True(res.SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(res.SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         private class Result : IAsyncResult

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/FromEventPatternTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/FromEventPatternTest.cs
@@ -486,13 +486,13 @@ namespace ReactiveTests.Tests
             var tpe = mod.DefineType("FromEvent");
 
             var ev1 = tpe.DefineEvent("Bar", (EventAttributes)MethodAttributes.Public, typeof(Action));
-            var add = tpe.DefineMethod("add_Bar", MethodAttributes.Public, CallingConventions.Standard, typeof(void), new Type[0]);
+            var add = tpe.DefineMethod("add_Bar", MethodAttributes.Public, CallingConventions.Standard, typeof(void), []);
             var ge1 = add.GetILGenerator();
             ge1.Emit(System.Reflection.Emit.OpCodes.Ret);
             ev1.SetAddOnMethod(add);
 
             var ev2 = tpe.DefineEvent("Foo", (EventAttributes)MethodAttributes.Public, typeof(Action));
-            var rem = tpe.DefineMethod("remove_Foo", MethodAttributes.Public, CallingConventions.Standard, typeof(void), new Type[0]);
+            var rem = tpe.DefineMethod("remove_Foo", MethodAttributes.Public, CallingConventions.Standard, typeof(void), []);
             var ge2 = rem.GetILGenerator();
             ge2.Emit(System.Reflection.Emit.OpCodes.Ret);
             ev2.SetRemoveOnMethod(rem);

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/FromEventTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/FromEventTest.cs
@@ -188,7 +188,7 @@ namespace ReactiveTests.Tests
 
             src.OnBar(42);
 
-            Assert.True(fst.SequenceEqual(new[] { 42 }));
+            Assert.True(fst.SequenceEqual([42]));
 
             d1.Dispose();
 
@@ -203,8 +203,8 @@ namespace ReactiveTests.Tests
 
             src.OnBar(43);
 
-            Assert.True(fst.SequenceEqual(new[] { 42 }));
-            Assert.True(snd.SequenceEqual(new[] { 43 }));
+            Assert.True(fst.SequenceEqual([42]));
+            Assert.True(snd.SequenceEqual([43]));
 
             var thd = new List<int>();
             var d3 = xs.Subscribe(e => thd.Add(e.EventArgs.Value));
@@ -214,9 +214,9 @@ namespace ReactiveTests.Tests
 
             src.OnBar(44);
 
-            Assert.True(fst.SequenceEqual(new[] { 42 }));
-            Assert.True(snd.SequenceEqual(new[] { 43, 44 }));
-            Assert.True(thd.SequenceEqual(new[] { 44 }));
+            Assert.True(fst.SequenceEqual([42]));
+            Assert.True(snd.SequenceEqual([43, 44]));
+            Assert.True(thd.SequenceEqual([44]));
 
             d2.Dispose();
 
@@ -225,9 +225,9 @@ namespace ReactiveTests.Tests
 
             src.OnBar(45);
 
-            Assert.True(fst.SequenceEqual(new[] { 42 }));
-            Assert.True(snd.SequenceEqual(new[] { 43, 44 }));
-            Assert.True(thd.SequenceEqual(new[] { 44, 45 }));
+            Assert.True(fst.SequenceEqual([42]));
+            Assert.True(snd.SequenceEqual([43, 44]));
+            Assert.True(thd.SequenceEqual([44, 45]));
 
             d3.Dispose();
 
@@ -236,9 +236,9 @@ namespace ReactiveTests.Tests
 
             src.OnBar(46);
 
-            Assert.True(fst.SequenceEqual(new[] { 42 }));
-            Assert.True(snd.SequenceEqual(new[] { 43, 44 }));
-            Assert.True(thd.SequenceEqual(new[] { 44, 45 }));
+            Assert.True(fst.SequenceEqual([42]));
+            Assert.True(snd.SequenceEqual([43, 44]));
+            Assert.True(thd.SequenceEqual([44, 45]));
         }
 
         [TestMethod]
@@ -289,10 +289,10 @@ namespace ReactiveTests.Tests
                 subscribeOnCtx = ReferenceEquals(addCtx, ctx);
 
                 src.OnBar(42);
-                fstNext = res.SequenceEqual(new[] { 42 });
+                fstNext = res.SequenceEqual([42]);
 
                 src.OnBar(43);
-                sndNext = res.SequenceEqual(new[] { 42, 43 });
+                sndNext = res.SequenceEqual([42, 43]);
 
                 var u = new Thread(() =>
                 {
@@ -309,7 +309,7 @@ namespace ReactiveTests.Tests
                 disposeOnCtx = ReferenceEquals(remCtx, ctx);
 
                 src.OnBar(44);
-                thdNext = res.SequenceEqual(new[] { 42, 43 });
+                thdNext = res.SequenceEqual([42, 43]);
             });
 
             Assert.True(beforeSubscribeNull);

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/IntervalTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/IntervalTest.cs
@@ -113,7 +113,7 @@ namespace ReactiveTests.Tests
         [TestMethod]
         public void Interval_TimeSpan_DefaultScheduler()
         {
-            Assert.True(Observable.Interval(TimeSpan.FromMilliseconds(1)).ToEnumerable().Take(3).SequenceEqual(new[] { 0L, 1L, 2L }));
+            Assert.True(Observable.Interval(TimeSpan.FromMilliseconds(1)).ToEnumerable().Take(3).SequenceEqual([0L, 1L, 2L]));
         }
 
     }

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/MaxByTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/MaxByTest.cs
@@ -67,9 +67,9 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<KeyValuePair<int, string>>>(250, x => x.SequenceEqual(new[] {
+                OnNext<IList<KeyValuePair<int, string>>>(250, x => x.SequenceEqual([
                     new KeyValuePair<int, string>(2, "a"),
-                })),
+                ])),
                 OnCompleted<IList<KeyValuePair<int, string>>>(250)
             );
 
@@ -96,9 +96,9 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<KeyValuePair<int, string>>>(250, x => x.SequenceEqual(new[] {
+                OnNext<IList<KeyValuePair<int, string>>>(250, x => x.SequenceEqual([
                     new KeyValuePair<int, string>(4, "c"),
-                })),
+                ])),
                 OnCompleted<IList<KeyValuePair<int, string>>>(250)
             );
 
@@ -128,10 +128,10 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<KeyValuePair<int, string>>>(250, x => x.SequenceEqual(new[] {
+                OnNext<IList<KeyValuePair<int, string>>>(250, x => x.SequenceEqual([
                     new KeyValuePair<int, string>(4, "a"),
                     new KeyValuePair<int, string>(4, "r"),
-                })),
+                ])),
                 OnCompleted<IList<KeyValuePair<int, string>>>(250)
             );
 
@@ -227,9 +227,9 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<KeyValuePair<int, string>>>(250, x => x.SequenceEqual(new[] {
+                OnNext<IList<KeyValuePair<int, string>>>(250, x => x.SequenceEqual([
                     new KeyValuePair<int, string>(2, "a"),
-                })),
+                ])),
                 OnCompleted<IList<KeyValuePair<int, string>>>(250)
             );
 
@@ -256,9 +256,9 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<KeyValuePair<int, string>>>(250, x => x.SequenceEqual(new[] {
+                OnNext<IList<KeyValuePair<int, string>>>(250, x => x.SequenceEqual([
                     new KeyValuePair<int, string>(2, "a"),
-                })),
+                ])),
                 OnCompleted<IList<KeyValuePair<int, string>>>(250)
             );
 

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/MergeTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/MergeTest.cs
@@ -1080,19 +1080,19 @@ namespace ReactiveTests.Tests
         [TestMethod]
         public void Merge_Binary_DefaultScheduler()
         {
-            Assert.True(Observable.Return(1).Merge(Observable.Return(2)).ToEnumerable().OrderBy(x => x).SequenceEqual(new[] { 1, 2 }));
+            Assert.True(Observable.Return(1).Merge(Observable.Return(2)).ToEnumerable().OrderBy(x => x).SequenceEqual([1, 2]));
         }
 
         [TestMethod]
         public void Merge_Params_DefaultScheduler()
         {
-            Assert.True(Observable.Merge(Observable.Return(1), Observable.Return(2)).ToEnumerable().OrderBy(x => x).SequenceEqual(new[] { 1, 2 }));
+            Assert.True(Observable.Merge(Observable.Return(1), Observable.Return(2)).ToEnumerable().OrderBy(x => x).SequenceEqual([1, 2]));
         }
 
         [TestMethod]
         public void Merge_IEnumerableOfIObservable_DefaultScheduler()
         {
-            Assert.True(Observable.Merge((IEnumerable<IObservable<int>>)new[] { Observable.Return(1), Observable.Return(2) }).ToEnumerable().OrderBy(x => x).SequenceEqual(new[] { 1, 2 }));
+            Assert.True(Observable.Merge((IEnumerable<IObservable<int>>)[Observable.Return(1), Observable.Return(2)]).ToEnumerable().OrderBy(x => x).SequenceEqual([1, 2]));
         }
 
         [TestMethod]
@@ -1717,7 +1717,7 @@ namespace ReactiveTests.Tests
 
             var res = tss.ToArray().Single();
 
-            Assert.True(res.OrderBy(x => x).SequenceEqual(new[] { 1, 2, 3 }));
+            Assert.True(res.OrderBy(x => x).SequenceEqual([1, 2, 3]));
         }
 
         [TestMethod]
@@ -1785,7 +1785,7 @@ namespace ReactiveTests.Tests
 
             done.WaitOne();
 
-            lst.AssertEqual(new int[0]);
+            lst.AssertEqual([]);
             Assert.Same(ex, err);
         }
 
@@ -1810,7 +1810,7 @@ namespace ReactiveTests.Tests
 
             done.WaitOne();
 
-            lst.AssertEqual(new int[0]);
+            lst.AssertEqual([]);
             Assert.Same(ex, err);
         }
 
@@ -1834,7 +1834,7 @@ namespace ReactiveTests.Tests
 
             done.WaitOne();
 
-            lst.AssertEqual(new int[0]);
+            lst.AssertEqual([]);
             Assert.True(err is TaskCanceledException tcException && tcException.Task == tcss[1].Task);
         }
 
@@ -1858,7 +1858,7 @@ namespace ReactiveTests.Tests
 
             done.WaitOne();
 
-            lst.AssertEqual(new int[0]);
+            lst.AssertEqual([]);
             Assert.True(err is TaskCanceledException tcException && tcException.Task == tcss[1].Task);
         }
 

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/MinByTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/MinByTest.cs
@@ -66,9 +66,9 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<KeyValuePair<int, string>>>(250, x => x.SequenceEqual(new[] {
+                OnNext<IList<KeyValuePair<int, string>>>(250, x => x.SequenceEqual([
                     new KeyValuePair<int, string>(2, "a"),
-                })),
+                ])),
                 OnCompleted<IList<KeyValuePair<int, string>>>(250)
             );
 
@@ -95,9 +95,9 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<KeyValuePair<int, string>>>(250, x => x.SequenceEqual(new[] {
+                OnNext<IList<KeyValuePair<int, string>>>(250, x => x.SequenceEqual([
                     new KeyValuePair<int, string>(2, "c"),
-                })),
+                ])),
                 OnCompleted<IList<KeyValuePair<int, string>>>(250)
             );
 
@@ -127,10 +127,10 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<KeyValuePair<int, string>>>(250, x => x.SequenceEqual(new[] {
+                OnNext<IList<KeyValuePair<int, string>>>(250, x => x.SequenceEqual([
                     new KeyValuePair<int, string>(2, "d"),
                     new KeyValuePair<int, string>(2, "y"),
-                })),
+                ])),
                 OnCompleted<IList<KeyValuePair<int, string>>>(250)
             );
 
@@ -227,9 +227,9 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<KeyValuePair<int, string>>>(250, x => x.SequenceEqual(new[] {
+                OnNext<IList<KeyValuePair<int, string>>>(250, x => x.SequenceEqual([
                     new KeyValuePair<int, string>(2, "a"),
-                })),
+                ])),
                 OnCompleted<IList<KeyValuePair<int, string>>>(250)
             );
 
@@ -256,9 +256,9 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<KeyValuePair<int, string>>>(250, x => x.SequenceEqual(new[] {
+                OnNext<IList<KeyValuePair<int, string>>>(250, x => x.SequenceEqual([
                     new KeyValuePair<int, string>(20, "c"),
-                })),
+                ])),
                 OnCompleted<IList<KeyValuePair<int, string>>>(250)
             );
 

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ObserveOnTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ObserveOnTest.cs
@@ -443,7 +443,7 @@ namespace ReactiveTests.Tests
 
             end.WaitOne();
 
-            Assert.True(lst.SequenceEqual(new[] { 1, 2, 3 }));
+            Assert.True(lst.SequenceEqual([1, 2, 3]));
         }
 
         [TestMethod]
@@ -533,7 +533,7 @@ namespace ReactiveTests.Tests
             resume.Set();
 
             end.WaitOne();
-            Assert.True(lst.SequenceEqual(new[] { 1, 2, 3 }));
+            Assert.True(lst.SequenceEqual([1, 2, 3]));
             Assert.Same(ex, err);
         }
 

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/OnErrorResumeNextTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/OnErrorResumeNextTest.cs
@@ -447,7 +447,7 @@ namespace ReactiveTests.Tests
         {
             var evt = new ManualResetEvent(false);
 
-            IEnumerable<IObservable<int>> sources = new[] { Observable.Return(1), Observable.Return(2), Observable.Return(3) };
+            IEnumerable<IObservable<int>> sources = [Observable.Return(1), Observable.Return(2), Observable.Return(3)];
 
             var sum = 0;
             Observable.OnErrorResumeNext(sources).Subscribe(x =>
@@ -545,7 +545,7 @@ namespace ReactiveTests.Tests
                 OnCompleted<int>(340)
             );
 
-            var xss = new MockEnumerable<ITestableObservable<int>>(scheduler, new[] { o1, o2, o3, o2 });
+            var xss = new MockEnumerable<ITestableObservable<int>>(scheduler, [o1, o2, o3, o2]);
 
             var res = scheduler.Start(() =>
                 xss.Select(xs => (IObservable<int>)xs).OnErrorResumeNext()
@@ -606,7 +606,7 @@ namespace ReactiveTests.Tests
                 OnCompleted<int>(340)
             );
 
-            var xss = new MockEnumerable<ITestableObservable<int>>(scheduler, new[] { o1, o2 });
+            var xss = new MockEnumerable<ITestableObservable<int>>(scheduler, [o1, o2]);
 
             var res = scheduler.Start(() =>
                 xss.Select(xs => (IObservable<int>)xs).OnErrorResumeNext(),
@@ -712,7 +712,7 @@ namespace ReactiveTests.Tests
                     }),
                     Observable.Return(2)
                 )
-                .SequenceEqual(new[] { 1, 2 });
+                .SequenceEqual([1, 2]);
 
             Assert.True(res.Wait());
         }

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/RefCountTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/RefCountTest.cs
@@ -498,7 +498,7 @@ namespace ReactiveTests.Tests
 
             Assert.Equal(1, connected);
 
-            var expected = new List<int>(new[] { 1, 2, 3, 4, 5 });
+            List<int> expected = [1, 2, 3, 4, 5];
 
             Assert.Equal(expected, list1);
             Assert.Equal(expected, list2);
@@ -548,7 +548,7 @@ namespace ReactiveTests.Tests
 
             Assert.Equal(1, connected);
 
-            var expected = new List<int>(new[] { 1, 2, 3, 4, 5 });
+            var expected = new List<int>([1, 2, 3, 4, 5]);
 
             Assert.Equal(expected, list1);
             Assert.Equal(expected, list2);

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/SelectManyTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/SelectManyTest.cs
@@ -5239,7 +5239,7 @@ namespace ReactiveTests.Tests
 
             done.WaitOne();
 
-            lst.AssertEqual(new int[0]);
+            lst.AssertEqual([]);
             Assert.Same(ex, err);
         }
 
@@ -5264,7 +5264,7 @@ namespace ReactiveTests.Tests
 
             done.WaitOne();
 
-            lst.AssertEqual(new int[0]);
+            lst.AssertEqual([]);
             Assert.Same(ex, err);
         }
 
@@ -5288,7 +5288,7 @@ namespace ReactiveTests.Tests
 
             done.WaitOne();
 
-            lst.AssertEqual(new int[0]);
+            lst.AssertEqual([]);
             Assert.True(err is TaskCanceledException tcException && tcException.Task == tcss[1].Task);
         }
 
@@ -5312,7 +5312,7 @@ namespace ReactiveTests.Tests
 
             done.WaitOne();
 
-            lst.AssertEqual(new int[0]);
+            lst.AssertEqual([]);
             Assert.True(err is TaskCanceledException tcException && tcException.Task == tcss[1].Task);
         }
 
@@ -5632,7 +5632,7 @@ namespace ReactiveTests.Tests
 
             done.WaitOne();
 
-            lst.AssertEqual(new int[0]);
+            lst.AssertEqual([]);
             Assert.Same(ex, err);
         }
 
@@ -5657,7 +5657,7 @@ namespace ReactiveTests.Tests
 
             done.WaitOne();
 
-            lst.AssertEqual(new int[0]);
+            lst.AssertEqual([]);
             Assert.Same(ex, err);
         }
 
@@ -5681,7 +5681,7 @@ namespace ReactiveTests.Tests
 
             done.WaitOne();
 
-            lst.AssertEqual(new int[0]);
+            lst.AssertEqual([]);
             Assert.True(err is TaskCanceledException tcException && tcException.Task == tcss[1].Task);
         }
 
@@ -5705,7 +5705,7 @@ namespace ReactiveTests.Tests
 
             done.WaitOne();
 
-            lst.AssertEqual(new int[0]);
+            lst.AssertEqual([]);
             Assert.True(err is TaskCanceledException tcException && tcException.Task == tcss[1].Task);
         }
 
@@ -6171,7 +6171,7 @@ namespace ReactiveTests.Tests
 
             done.WaitOne();
 
-            lst.AssertEqual(new int[0]);
+            lst.AssertEqual([]);
             Assert.Same(ex, err);
         }
 
@@ -6196,7 +6196,7 @@ namespace ReactiveTests.Tests
 
             done.WaitOne();
 
-            lst.AssertEqual(new int[0]);
+            lst.AssertEqual([]);
             Assert.Same(ex, err);
         }
 
@@ -6220,7 +6220,7 @@ namespace ReactiveTests.Tests
 
             done.WaitOne();
 
-            lst.AssertEqual(new int[0]);
+            lst.AssertEqual([]);
             Assert.True(err is TaskCanceledException tcException && tcException.Task == tcss[1].Task);
         }
 
@@ -6244,7 +6244,7 @@ namespace ReactiveTests.Tests
 
             done.WaitOne();
 
-            lst.AssertEqual(new int[0]);
+            lst.AssertEqual([]);
             Assert.True(err is TaskCanceledException tcException && tcException.Task == tcss[1].Task);
         }
 
@@ -6564,7 +6564,7 @@ namespace ReactiveTests.Tests
 
             done.WaitOne();
 
-            lst.AssertEqual(new int[0]);
+            lst.AssertEqual([]);
             Assert.Same(ex, err);
         }
 
@@ -6589,7 +6589,7 @@ namespace ReactiveTests.Tests
 
             done.WaitOne();
 
-            lst.AssertEqual(new int[0]);
+            lst.AssertEqual([]);
             Assert.Same(ex, err);
         }
 
@@ -6613,7 +6613,7 @@ namespace ReactiveTests.Tests
 
             done.WaitOne();
 
-            lst.AssertEqual(new int[0]);
+            lst.AssertEqual([]);
             Assert.True(err is TaskCanceledException tcException && tcException.Task == tcss[1].Task);
         }
 
@@ -6637,7 +6637,7 @@ namespace ReactiveTests.Tests
 
             done.WaitOne();
 
-            lst.AssertEqual(new int[0]);
+            lst.AssertEqual([]);
             Assert.True(err is TaskCanceledException tcException && tcException.Task == tcss[1].Task);
         }
 

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/SequenceEqualTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/SequenceEqualTest.cs
@@ -27,9 +27,9 @@ namespace ReactiveTests.Tests
 
             ReactiveAssert.Throws<ArgumentNullException>(() => Observable.SequenceEqual(default, new[] { 42 }));
             ReactiveAssert.Throws<ArgumentNullException>(() => Observable.SequenceEqual(DummyObservable<int>.Instance, default(IEnumerable<int>)));
-            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.SequenceEqual(default, new[] { 42 }, EqualityComparer<int>.Default));
+            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.SequenceEqual(default, [42], EqualityComparer<int>.Default));
             ReactiveAssert.Throws<ArgumentNullException>(() => Observable.SequenceEqual(DummyObservable<int>.Instance, default(IEnumerable<int>), EqualityComparer<int>.Default));
-            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.SequenceEqual(DummyObservable<int>.Instance, new[] { 42 }, default));
+            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.SequenceEqual(DummyObservable<int>.Instance, [42], default));
         }
 
         [TestMethod]
@@ -733,7 +733,7 @@ namespace ReactiveTests.Tests
             );
 
             var res = scheduler.Start(() =>
-                xs.SequenceEqual(new[] { 3, 4, 5, 6, 7 })
+                xs.SequenceEqual([3, 4, 5, 6, 7])
             );
 
             res.Messages.AssertEqual(
@@ -763,7 +763,7 @@ namespace ReactiveTests.Tests
             );
 
             var res = scheduler.Start(() =>
-                xs.SequenceEqual(new[] { 3, 4, 9, 6, 7 })
+                xs.SequenceEqual([3, 4, 9, 6, 7])
             );
 
             res.Messages.AssertEqual(
@@ -793,7 +793,7 @@ namespace ReactiveTests.Tests
             );
 
             var res = scheduler.Start(() =>
-                xs.SequenceEqual(new[] { 3 - 2, 4, 5, 6 + 42, 7 - 6 }, new OddEvenComparer())
+                xs.SequenceEqual([3 - 2, 4, 5, 6 + 42, 7 - 6], new OddEvenComparer())
             );
 
             res.Messages.AssertEqual(
@@ -823,7 +823,7 @@ namespace ReactiveTests.Tests
             );
 
             var res = scheduler.Start(() =>
-                xs.SequenceEqual(new[] { 3 - 2, 4, 5 + 9, 6 + 42, 7 - 6 }, new OddEvenComparer())
+                xs.SequenceEqual([3 - 2, 4, 5 + 9, 6 + 42, 7 - 6], new OddEvenComparer())
             );
 
             res.Messages.AssertEqual(
@@ -868,7 +868,7 @@ namespace ReactiveTests.Tests
             var ex = new Exception();
 
             var res = scheduler.Start(() =>
-                xs.SequenceEqual(new[] { 3, 4, 5, 6, 7 }, new ThrowingComparer(5, ex))
+                xs.SequenceEqual([3, 4, 5, 6, 7], new ThrowingComparer(5, ex))
             );
 
             res.Messages.AssertEqual(
@@ -924,7 +924,7 @@ namespace ReactiveTests.Tests
             );
 
             var res = scheduler.Start(() =>
-                xs.SequenceEqual(new[] { 3, 4, 5, 6, 7, 8 })
+                xs.SequenceEqual([3, 4, 5, 6, 7, 8])
             );
 
             res.Messages.AssertEqual(
@@ -954,7 +954,7 @@ namespace ReactiveTests.Tests
             );
 
             var res = scheduler.Start(() =>
-                xs.SequenceEqual(new[] { 3, 4, 5, 6 })
+                xs.SequenceEqual([3, 4, 5, 6])
             );
 
             res.Messages.AssertEqual(
@@ -983,7 +983,7 @@ namespace ReactiveTests.Tests
             );
 
             var res = scheduler.Start(() =>
-                xs.SequenceEqual(new[] { 3, 4 })
+                xs.SequenceEqual([3, 4])
             );
 
             res.Messages.AssertEqual(

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/StartTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/StartTest.cs
@@ -37,7 +37,7 @@ namespace ReactiveTests.Tests
         public void Start_Action()
         {
             var done = false;
-            Assert.True(Observable.Start(() => { done = true; }).ToEnumerable().SequenceEqual(new[] { new Unit() }));
+            Assert.True(Observable.Start(() => { done = true; }).ToEnumerable().SequenceEqual([new Unit()]));
             Assert.True(done, "done");
         }
 
@@ -67,9 +67,9 @@ namespace ReactiveTests.Tests
 
             var res = Observable.Start(() => { throw ex; }).Materialize().ToEnumerable();
 
-            Assert.True(res.SequenceEqual(new[] {
+            Assert.True(res.SequenceEqual([
                 Notification.CreateOnError<Unit>(ex)
-            }));
+            ]));
         }
 
         [TestMethod]
@@ -103,9 +103,9 @@ namespace ReactiveTests.Tests
         {
             var res = Observable.Start(() => 1).ToEnumerable();
 
-            Assert.True(res.SequenceEqual(new[] {
+            Assert.True(res.SequenceEqual([
                 1
-            }));
+            ]));
         }
 
         [TestMethod]
@@ -130,9 +130,9 @@ namespace ReactiveTests.Tests
 
             var res = Observable.Start<int>(() => { throw ex; }).Materialize().ToEnumerable();
 
-            Assert.True(res.SequenceEqual(new[] {
+            Assert.True(res.SequenceEqual([
                 Notification.CreateOnError<int>(ex)
-            }));
+            ]));
         }
 
     }

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/StartWithTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/StartWithTest.cs
@@ -18,7 +18,7 @@ namespace ReactiveTests.Tests
         [TestMethod]
         public void StartWith_ArgumentChecking()
         {
-            var values = (IEnumerable<int>)new[] { 1, 2, 3 };
+            var values = (IEnumerable<int>)[1, 2, 3];
 
             var scheduler = new TestScheduler();
             var someObservable = Observable.Empty<int>();
@@ -95,7 +95,7 @@ namespace ReactiveTests.Tests
                 OnCompleted<int>(250)
             );
 
-            var data = new List<int>(new[] { 1, 2, 3 });
+            List<int> data = [1, 2, 3];
             var res = scheduler.Start(() =>
                 xs.StartWith(data)
             );
@@ -120,7 +120,7 @@ namespace ReactiveTests.Tests
                 OnCompleted<int>(250)
             );
 
-            var data = new List<int>(new[] { 1, 2, 3 });
+            List<int> data = [1, 2, 3];
             var res = scheduler.Start(() =>
                 xs.StartWith(scheduler, data)
             );

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/TakeLastBufferTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/TakeLastBufferTest.cs
@@ -146,7 +146,7 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(650, lst => lst.SequenceEqual(new[] { 9 })),
+                OnNext<IList<int>>(650, lst => lst.SequenceEqual([9])),
                 OnCompleted<IList<int>>(650)
             );
 
@@ -240,7 +240,7 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(650, lst => lst.SequenceEqual(new[] { 7, 8, 9 })),
+                OnNext<IList<int>>(650, lst => lst.SequenceEqual([7, 8, 9])),
                 OnCompleted<IList<int>>(650)
             );
 
@@ -396,7 +396,7 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(240, lst => lst.SequenceEqual(new[] { 2, 3 })),
+                OnNext<IList<int>>(240, lst => lst.SequenceEqual([2, 3])),
                 OnCompleted<IList<int>>(240)
             );
 
@@ -454,7 +454,7 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(300, lst => lst.SequenceEqual(new[] { 6, 7, 8, 9 })),
+                OnNext<IList<int>>(300, lst => lst.SequenceEqual([6, 7, 8, 9])),
                 OnCompleted<IList<int>>(300)
             );
 
@@ -508,7 +508,7 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(230, lst => lst.SequenceEqual(new[] { 1, 2 })),
+                OnNext<IList<int>>(230, lst => lst.SequenceEqual([1, 2])),
                 OnCompleted<IList<int>>(230)
             );
 

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ThrottleTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ThrottleTest.cs
@@ -262,7 +262,7 @@ namespace ReactiveTests.Tests
         [TestMethod]
         public void Throttle_DefaultScheduler()
         {
-            Assert.True(Observable.Return(1).Throttle(TimeSpan.FromMilliseconds(1)).ToEnumerable().SequenceEqual(new[] { 1 }));
+            Assert.True(Observable.Return(1).Throttle(TimeSpan.FromMilliseconds(1)).ToEnumerable().SequenceEqual([1]));
         }
 
         [TestMethod]

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/TimerTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/TimerTest.cs
@@ -132,25 +132,25 @@ namespace ReactiveTests.Tests
         [TestMethod]
         public void OneShotTimer_TimeSpan_DefaultScheduler()
         {
-            Assert.True(Observable.Timer(TimeSpan.FromMilliseconds(1)).ToEnumerable().SequenceEqual(new[] { 0L }));
+            Assert.True(Observable.Timer(TimeSpan.FromMilliseconds(1)).ToEnumerable().SequenceEqual([0L]));
         }
 
         [TestMethod]
         public void OneShotTimer_DateTimeOffset_DefaultScheduler()
         {
-            Assert.True(Observable.Timer(DateTimeOffset.UtcNow + TimeSpan.FromSeconds(1)).ToEnumerable().SequenceEqual(new[] { 0L }));
+            Assert.True(Observable.Timer(DateTimeOffset.UtcNow + TimeSpan.FromSeconds(1)).ToEnumerable().SequenceEqual([0L]));
         }
 
         [TestMethod]
         public void OneShotTimer_TimeSpan_TimeSpan_DefaultScheduler()
         {
-            Assert.True(Observable.Timer(TimeSpan.FromMilliseconds(1), TimeSpan.FromMilliseconds(1)).ToEnumerable().Take(2).SequenceEqual(new[] { 0L, 1L }));
+            Assert.True(Observable.Timer(TimeSpan.FromMilliseconds(1), TimeSpan.FromMilliseconds(1)).ToEnumerable().Take(2).SequenceEqual([0L, 1L]));
         }
 
         [TestMethod]
         public void OneShotTimer_DateTimeOffset_TimeSpan_DefaultScheduler()
         {
-            Assert.True(Observable.Timer(DateTimeOffset.UtcNow + TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(1)).ToEnumerable().Take(2).SequenceEqual(new[] { 0L, 1L }));
+            Assert.True(Observable.Timer(DateTimeOffset.UtcNow + TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(1)).ToEnumerable().Take(2).SequenceEqual([0L, 1L]));
         }
 
         [TestMethod]

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ToArrayTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ToArrayTest.cs
@@ -39,7 +39,7 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<int[]>(660, a => a.SequenceEqual(new[] { 2, 3, 4, 5 })),
+                OnNext<int[]>(660, a => a.SequenceEqual([2, 3, 4, 5])),
                 OnCompleted<int[]>(660)
             );
 

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ToAsyncTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ToAsyncTest.cs
@@ -131,247 +131,247 @@ namespace ReactiveTests.Tests
         [TestMethod]
         public void ToAsync0()
         {
-            Assert.True(Observable.ToAsync(() => 0)().ToEnumerable().SequenceEqual(new[] { 0 }));
-            Assert.True(Observable.ToAsync(() => 0, Scheduler.Default)().ToEnumerable().SequenceEqual(new[] { 0 }));
+            Assert.True(Observable.ToAsync(() => 0)().ToEnumerable().SequenceEqual([0]));
+            Assert.True(Observable.ToAsync(() => 0, Scheduler.Default)().ToEnumerable().SequenceEqual([0]));
         }
 
         [TestMethod]
         public void ToAsync1()
         {
-            Assert.True(Observable.ToAsync<int, int>(a => a)(1).ToEnumerable().SequenceEqual(new[] { 1 }));
-            Assert.True(Observable.ToAsync<int, int>(a => a, Scheduler.Default)(1).ToEnumerable().SequenceEqual(new[] { 1 }));
+            Assert.True(Observable.ToAsync<int, int>(a => a)(1).ToEnumerable().SequenceEqual([1]));
+            Assert.True(Observable.ToAsync<int, int>(a => a, Scheduler.Default)(1).ToEnumerable().SequenceEqual([1]));
         }
 
         [TestMethod]
         public void ToAsync2()
         {
-            Assert.True(Observable.ToAsync<int, int, int>((a, b) => a + b)(1, 2).ToEnumerable().SequenceEqual(new[] { 1 + 2 }));
-            Assert.True(Observable.ToAsync<int, int, int>((a, b) => a + b, Scheduler.Default)(1, 2).ToEnumerable().SequenceEqual(new[] { 1 + 2 }));
+            Assert.True(Observable.ToAsync<int, int, int>((a, b) => a + b)(1, 2).ToEnumerable().SequenceEqual([1 + 2]));
+            Assert.True(Observable.ToAsync<int, int, int>((a, b) => a + b, Scheduler.Default)(1, 2).ToEnumerable().SequenceEqual([1 + 2]));
         }
 
         [TestMethod]
         public void ToAsync3()
         {
-            Assert.True(Observable.ToAsync<int, int, int, int>((a, b, c) => a + b + c)(1, 2, 3).ToEnumerable().SequenceEqual(new[] { 1 + 2 + 3 }));
-            Assert.True(Observable.ToAsync<int, int, int, int>((a, b, c) => a + b + c, Scheduler.Default)(1, 2, 3).ToEnumerable().SequenceEqual(new[] { 1 + 2 + 3 }));
+            Assert.True(Observable.ToAsync<int, int, int, int>((a, b, c) => a + b + c)(1, 2, 3).ToEnumerable().SequenceEqual([1 + 2 + 3]));
+            Assert.True(Observable.ToAsync<int, int, int, int>((a, b, c) => a + b + c, Scheduler.Default)(1, 2, 3).ToEnumerable().SequenceEqual([1 + 2 + 3]));
         }
 
         [TestMethod]
         public void ToAsync4()
         {
-            Assert.True(Observable.ToAsync<int, int, int, int, int>((a, b, c, d) => a + b + c + d)(1, 2, 3, 4).ToEnumerable().SequenceEqual(new[] { 1 + 2 + 3 + 4 }));
-            Assert.True(Observable.ToAsync<int, int, int, int, int>((a, b, c, d) => a + b + c + d, Scheduler.Default)(1, 2, 3, 4).ToEnumerable().SequenceEqual(new[] { 1 + 2 + 3 + 4 }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int>((a, b, c, d) => a + b + c + d)(1, 2, 3, 4).ToEnumerable().SequenceEqual([1 + 2 + 3 + 4]));
+            Assert.True(Observable.ToAsync<int, int, int, int, int>((a, b, c, d) => a + b + c + d, Scheduler.Default)(1, 2, 3, 4).ToEnumerable().SequenceEqual([1 + 2 + 3 + 4]));
         }
 
         [TestMethod]
         public void ToAsync5()
         {
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int>((a, b, c, d, e) => a + b + c + d + e)(1, 2, 3, 4, 5).ToEnumerable().SequenceEqual(new[] { 1 + 2 + 3 + 4 + 5 }));
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int>((a, b, c, d, e) => a + b + c + d + e, Scheduler.Default)(1, 2, 3, 4, 5).ToEnumerable().SequenceEqual(new[] { 1 + 2 + 3 + 4 + 5 }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int>((a, b, c, d, e) => a + b + c + d + e)(1, 2, 3, 4, 5).ToEnumerable().SequenceEqual([1 + 2 + 3 + 4 + 5]));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int>((a, b, c, d, e) => a + b + c + d + e, Scheduler.Default)(1, 2, 3, 4, 5).ToEnumerable().SequenceEqual([1 + 2 + 3 + 4 + 5]));
         }
 
         [TestMethod]
         public void ToAsync6()
         {
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int>((a, b, c, d, e, f) => a + b + c + d + e + f)(1, 2, 3, 4, 5, 6).ToEnumerable().SequenceEqual(new[] { 1 + 2 + 3 + 4 + 5 + 6 }));
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int>((a, b, c, d, e, f) => a + b + c + d + e + f, Scheduler.Default)(1, 2, 3, 4, 5, 6).ToEnumerable().SequenceEqual(new[] { 1 + 2 + 3 + 4 + 5 + 6 }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int>((a, b, c, d, e, f) => a + b + c + d + e + f)(1, 2, 3, 4, 5, 6).ToEnumerable().SequenceEqual([1 + 2 + 3 + 4 + 5 + 6]));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int>((a, b, c, d, e, f) => a + b + c + d + e + f, Scheduler.Default)(1, 2, 3, 4, 5, 6).ToEnumerable().SequenceEqual([1 + 2 + 3 + 4 + 5 + 6]));
         }
 
         [TestMethod]
         public void ToAsync7()
         {
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g) => a + b + c + d + e + f + g)(1, 2, 3, 4, 5, 6, 7).ToEnumerable().SequenceEqual(new[] { 1 + 2 + 3 + 4 + 5 + 6 + 7 }));
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g) => a + b + c + d + e + f + g, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7).ToEnumerable().SequenceEqual(new[] { 1 + 2 + 3 + 4 + 5 + 6 + 7 }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g) => a + b + c + d + e + f + g)(1, 2, 3, 4, 5, 6, 7).ToEnumerable().SequenceEqual([1 + 2 + 3 + 4 + 5 + 6 + 7]));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g) => a + b + c + d + e + f + g, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7).ToEnumerable().SequenceEqual([1 + 2 + 3 + 4 + 5 + 6 + 7]));
         }
 
         [TestMethod]
         public void ToAsync8()
         {
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h) => a + b + c + d + e + f + g + h)(1, 2, 3, 4, 5, 6, 7, 8).ToEnumerable().SequenceEqual(new[] { 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 }));
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h) => a + b + c + d + e + f + g + h, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8).ToEnumerable().SequenceEqual(new[] { 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h) => a + b + c + d + e + f + g + h)(1, 2, 3, 4, 5, 6, 7, 8).ToEnumerable().SequenceEqual([1 + 2 + 3 + 4 + 5 + 6 + 7 + 8]));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h) => a + b + c + d + e + f + g + h, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8).ToEnumerable().SequenceEqual([1 + 2 + 3 + 4 + 5 + 6 + 7 + 8]));
         }
 
         [TestMethod]
         public void ToAsync9()
         {
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i) => a + b + c + d + e + f + g + h + i)(1, 2, 3, 4, 5, 6, 7, 8, 9).ToEnumerable().SequenceEqual(new[] { 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 }));
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i) => a + b + c + d + e + f + g + h + i, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9).ToEnumerable().SequenceEqual(new[] { 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i) => a + b + c + d + e + f + g + h + i)(1, 2, 3, 4, 5, 6, 7, 8, 9).ToEnumerable().SequenceEqual([1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9]));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i) => a + b + c + d + e + f + g + h + i, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9).ToEnumerable().SequenceEqual([1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9]));
         }
 
         [TestMethod]
         public void ToAsync10()
         {
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j) => a + b + c + d + e + f + g + h + i + j)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).ToEnumerable().SequenceEqual(new[] { 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 }));
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j) => a + b + c + d + e + f + g + h + i + j, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).ToEnumerable().SequenceEqual(new[] { 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j) => a + b + c + d + e + f + g + h + i + j)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).ToEnumerable().SequenceEqual([1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10]));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j) => a + b + c + d + e + f + g + h + i + j, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).ToEnumerable().SequenceEqual([1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10]));
         }
 
         [TestMethod]
         public void ToAsync11()
         {
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k) => a + b + c + d + e + f + g + h + i + j + k)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11).ToEnumerable().SequenceEqual(new[] { 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 }));
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k) => a + b + c + d + e + f + g + h + i + j + k, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11).ToEnumerable().SequenceEqual(new[] { 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k) => a + b + c + d + e + f + g + h + i + j + k)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11).ToEnumerable().SequenceEqual([1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11]));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k) => a + b + c + d + e + f + g + h + i + j + k, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11).ToEnumerable().SequenceEqual([1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11]));
         }
 
         [TestMethod]
         public void ToAsync12()
         {
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l) => a + b + c + d + e + f + g + h + i + j + k + l)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).ToEnumerable().SequenceEqual(new[] { 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 }));
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l) => a + b + c + d + e + f + g + h + i + j + k + l, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).ToEnumerable().SequenceEqual(new[] { 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l) => a + b + c + d + e + f + g + h + i + j + k + l)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).ToEnumerable().SequenceEqual([1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12]));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l) => a + b + c + d + e + f + g + h + i + j + k + l, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).ToEnumerable().SequenceEqual([1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12]));
         }
 
         [TestMethod]
         public void ToAsync13()
         {
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m) => a + b + c + d + e + f + g + h + i + j + k + l + m)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13).ToEnumerable().SequenceEqual(new[] { 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13 }));
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m) => a + b + c + d + e + f + g + h + i + j + k + l + m, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13).ToEnumerable().SequenceEqual(new[] { 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13 }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m) => a + b + c + d + e + f + g + h + i + j + k + l + m)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13).ToEnumerable().SequenceEqual([1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13]));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m) => a + b + c + d + e + f + g + h + i + j + k + l + m, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13).ToEnumerable().SequenceEqual([1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13]));
         }
 
         [TestMethod]
         public void ToAsync14()
         {
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n) => a + b + c + d + e + f + g + h + i + j + k + l + m + n)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14).ToEnumerable().SequenceEqual(new[] { 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13 + 14 }));
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n) => a + b + c + d + e + f + g + h + i + j + k + l + m + n, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14).ToEnumerable().SequenceEqual(new[] { 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13 + 14 }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n) => a + b + c + d + e + f + g + h + i + j + k + l + m + n)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14).ToEnumerable().SequenceEqual([1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13 + 14]));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n) => a + b + c + d + e + f + g + h + i + j + k + l + m + n, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14).ToEnumerable().SequenceEqual([1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13 + 14]));
         }
 
         [TestMethod]
         public void ToAsync15()
         {
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) => a + b + c + d + e + f + g + h + i + j + k + l + m + n + o)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).ToEnumerable().SequenceEqual(new[] { 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13 + 14 + 15 }));
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) => a + b + c + d + e + f + g + h + i + j + k + l + m + n + o, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).ToEnumerable().SequenceEqual(new[] { 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13 + 14 + 15 }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) => a + b + c + d + e + f + g + h + i + j + k + l + m + n + o)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).ToEnumerable().SequenceEqual([1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13 + 14 + 15]));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) => a + b + c + d + e + f + g + h + i + j + k + l + m + n + o, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).ToEnumerable().SequenceEqual([1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13 + 14 + 15]));
         }
 
         [TestMethod]
         public void ToAsync16()
         {
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) => a + b + c + d + e + f + g + h + i + j + k + l + m + n + o + p)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16).ToEnumerable().SequenceEqual(new[] { 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13 + 14 + 15 + 16 }));
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) => a + b + c + d + e + f + g + h + i + j + k + l + m + n + o + p, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16).ToEnumerable().SequenceEqual(new[] { 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13 + 14 + 15 + 16 }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) => a + b + c + d + e + f + g + h + i + j + k + l + m + n + o + p)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16).ToEnumerable().SequenceEqual([1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13 + 14 + 15 + 16]));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) => a + b + c + d + e + f + g + h + i + j + k + l + m + n + o + p, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16).ToEnumerable().SequenceEqual([1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13 + 14 + 15 + 16]));
         }
 
         [TestMethod]
         public void ToAsync_Error0()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int>(() => { throw ex; })().Materialize().ToEnumerable().SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(Observable.ToAsync<int>(() => { throw ex; })().Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
         public void ToAsync_Error1()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int>(a => { throw ex; })(1).Materialize().ToEnumerable().SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(Observable.ToAsync<int, int>(a => { throw ex; })(1).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
         public void ToAsync_Error2()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int>((a, b) => { throw ex; })(1, 2).Materialize().ToEnumerable().SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int>((a, b) => { throw ex; })(1, 2).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
         public void ToAsync_Error3()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int, int>((a, b, c) => { throw ex; })(1, 2, 3).Materialize().ToEnumerable().SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int, int>((a, b, c) => { throw ex; })(1, 2, 3).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
         public void ToAsync_Error4()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int, int, int>((a, b, c, d) => { throw ex; })(1, 2, 3, 4).Materialize().ToEnumerable().SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int>((a, b, c, d) => { throw ex; })(1, 2, 3, 4).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
         public void ToAsync_Error5()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int>((a, b, c, d, e) => { throw ex; })(1, 2, 3, 4, 5).Materialize().ToEnumerable().SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int>((a, b, c, d, e) => { throw ex; })(1, 2, 3, 4, 5).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
         public void ToAsync_Error6()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int>((a, b, c, d, e, f) => { throw ex; })(1, 2, 3, 4, 5, 6).Materialize().ToEnumerable().SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int>((a, b, c, d, e, f) => { throw ex; })(1, 2, 3, 4, 5, 6).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
         public void ToAsync_Error7()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g) => { throw ex; })(1, 2, 3, 4, 5, 6, 7).Materialize().ToEnumerable().SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g) => { throw ex; })(1, 2, 3, 4, 5, 6, 7).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
         public void ToAsync_Error8()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h) => { throw ex; })(1, 2, 3, 4, 5, 6, 7, 8).Materialize().ToEnumerable().SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h) => { throw ex; })(1, 2, 3, 4, 5, 6, 7, 8).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
         public void ToAsync_Error9()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i) => { throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9).Materialize().ToEnumerable().SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i) => { throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
         public void ToAsync_Error10()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j) => { throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).Materialize().ToEnumerable().SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j) => { throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
         public void ToAsync_Error11()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k) => { throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11).Materialize().ToEnumerable().SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k) => { throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
         public void ToAsync_Error12()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l) => { throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).Materialize().ToEnumerable().SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l) => { throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
         public void ToAsync_Error13()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m) => { throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13).Materialize().ToEnumerable().SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m) => { throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
         public void ToAsync_Error14()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n) => { throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14).Materialize().ToEnumerable().SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n) => { throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
         public void ToAsync_Error15()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) => { throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).Materialize().ToEnumerable().SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) => { throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
         public void ToAsync_Error16()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) => { throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16).Materialize().ToEnumerable().SequenceEqual(new Notification<int>[] { Notification.CreateOnError<int>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) => { throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<int>(ex)]));
         }
 
         [TestMethod]
         public void ToAsyncAction0()
         {
             var hasRun = false;
-            Assert.True(Observable.ToAsync(() => { hasRun = true; })().ToEnumerable().SequenceEqual(new[] { new Unit() }));
-            Assert.True(Observable.ToAsync(() => { hasRun = true; }, Scheduler.Default)().ToEnumerable().SequenceEqual(new[] { new Unit() }));
+            Assert.True(Observable.ToAsync(() => { hasRun = true; })().ToEnumerable().SequenceEqual([new Unit()]));
+            Assert.True(Observable.ToAsync(() => { hasRun = true; }, Scheduler.Default)().ToEnumerable().SequenceEqual([new Unit()]));
             Assert.True(hasRun, "has run");
         }
 
@@ -379,15 +379,15 @@ namespace ReactiveTests.Tests
         public void ToAsyncActionError0()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync(() => { throw ex; })().Materialize().ToEnumerable().SequenceEqual(new[] { Notification.CreateOnError<Unit>(ex) }));
+            Assert.True(Observable.ToAsync(() => { throw ex; })().Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<Unit>(ex)]));
         }
 
         [TestMethod]
         public void ToAsyncAction1()
         {
             var hasRun = false;
-            Assert.True(Observable.ToAsync<int>(a => { Assert.Equal(1, a); hasRun = true; })(1).ToEnumerable().SequenceEqual(new[] { new Unit() }));
-            Assert.True(Observable.ToAsync<int>(a => { Assert.Equal(1, a); hasRun = true; }, Scheduler.Default)(1).ToEnumerable().SequenceEqual(new[] { new Unit() }));
+            Assert.True(Observable.ToAsync<int>(a => { Assert.Equal(1, a); hasRun = true; })(1).ToEnumerable().SequenceEqual([new Unit()]));
+            Assert.True(Observable.ToAsync<int>(a => { Assert.Equal(1, a); hasRun = true; }, Scheduler.Default)(1).ToEnumerable().SequenceEqual([new Unit()]));
             Assert.True(hasRun, "has run");
         }
 
@@ -395,15 +395,15 @@ namespace ReactiveTests.Tests
         public void ToAsyncActionError1()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int>(a => { Assert.Equal(1, a); throw ex; })(1).Materialize().ToEnumerable().SequenceEqual(new[] { Notification.CreateOnError<Unit>(ex) }));
+            Assert.True(Observable.ToAsync<int>(a => { Assert.Equal(1, a); throw ex; })(1).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<Unit>(ex)]));
         }
 
         [TestMethod]
         public void ToAsyncAction2()
         {
             var hasRun = false;
-            Assert.True(Observable.ToAsync<int, int>((a, b) => { Assert.Equal(1, a); Assert.Equal(2, b); hasRun = true; })(1, 2).ToEnumerable().SequenceEqual(new[] { new Unit() }));
-            Assert.True(Observable.ToAsync<int, int>((a, b) => { Assert.Equal(1, a); Assert.Equal(2, b); hasRun = true; }, Scheduler.Default)(1, 2).ToEnumerable().SequenceEqual(new[] { new Unit() }));
+            Assert.True(Observable.ToAsync<int, int>((a, b) => { Assert.Equal(1, a); Assert.Equal(2, b); hasRun = true; })(1, 2).ToEnumerable().SequenceEqual([new Unit()]));
+            Assert.True(Observable.ToAsync<int, int>((a, b) => { Assert.Equal(1, a); Assert.Equal(2, b); hasRun = true; }, Scheduler.Default)(1, 2).ToEnumerable().SequenceEqual([new Unit()]));
             Assert.True(hasRun, "has run");
         }
 
@@ -411,15 +411,15 @@ namespace ReactiveTests.Tests
         public void ToAsyncActionError2()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int>((a, b) => { Assert.Equal(1, a); Assert.Equal(2, b); throw ex; })(1, 2).Materialize().ToEnumerable().SequenceEqual(new[] { Notification.CreateOnError<Unit>(ex) }));
+            Assert.True(Observable.ToAsync<int, int>((a, b) => { Assert.Equal(1, a); Assert.Equal(2, b); throw ex; })(1, 2).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<Unit>(ex)]));
         }
 
         [TestMethod]
         public void ToAsyncAction3()
         {
             var hasRun = false;
-            Assert.True(Observable.ToAsync<int, int, int>((a, b, c) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); hasRun = true; })(1, 2, 3).ToEnumerable().SequenceEqual(new[] { new Unit() }));
-            Assert.True(Observable.ToAsync<int, int, int>((a, b, c) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); hasRun = true; }, Scheduler.Default)(1, 2, 3).ToEnumerable().SequenceEqual(new[] { new Unit() }));
+            Assert.True(Observable.ToAsync<int, int, int>((a, b, c) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); hasRun = true; })(1, 2, 3).ToEnumerable().SequenceEqual([new Unit()]));
+            Assert.True(Observable.ToAsync<int, int, int>((a, b, c) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); hasRun = true; }, Scheduler.Default)(1, 2, 3).ToEnumerable().SequenceEqual([new Unit()]));
             Assert.True(hasRun, "has run");
         }
 
@@ -427,15 +427,15 @@ namespace ReactiveTests.Tests
         public void ToAsyncActionError3()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int>((a, b, c) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); throw ex; })(1, 2, 3).Materialize().ToEnumerable().SequenceEqual(new[] { Notification.CreateOnError<Unit>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int>((a, b, c) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); throw ex; })(1, 2, 3).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<Unit>(ex)]));
         }
 
         [TestMethod]
         public void ToAsyncAction4()
         {
             var hasRun = false;
-            Assert.True(Observable.ToAsync<int, int, int, int>((a, b, c, d) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); hasRun = true; })(1, 2, 3, 4).ToEnumerable().SequenceEqual(new[] { new Unit() }));
-            Assert.True(Observable.ToAsync<int, int, int, int>((a, b, c, d) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); hasRun = true; }, Scheduler.Default)(1, 2, 3, 4).ToEnumerable().SequenceEqual(new[] { new Unit() }));
+            Assert.True(Observable.ToAsync<int, int, int, int>((a, b, c, d) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); hasRun = true; })(1, 2, 3, 4).ToEnumerable().SequenceEqual([new Unit()]));
+            Assert.True(Observable.ToAsync<int, int, int, int>((a, b, c, d) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); hasRun = true; }, Scheduler.Default)(1, 2, 3, 4).ToEnumerable().SequenceEqual([new Unit()]));
             Assert.True(hasRun, "has run");
         }
 
@@ -443,15 +443,15 @@ namespace ReactiveTests.Tests
         public void ToAsyncActionError4()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int, int>((a, b, c, d) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); throw ex; })(1, 2, 3, 4).Materialize().ToEnumerable().SequenceEqual(new[] { Notification.CreateOnError<Unit>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int, int>((a, b, c, d) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); throw ex; })(1, 2, 3, 4).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<Unit>(ex)]));
         }
 
         [TestMethod]
         public void ToAsyncAction5()
         {
             var hasRun = false;
-            Assert.True(Observable.ToAsync<int, int, int, int, int>((a, b, c, d, e) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); hasRun = true; })(1, 2, 3, 4, 5).ToEnumerable().SequenceEqual(new[] { new Unit() }));
-            Assert.True(Observable.ToAsync<int, int, int, int, int>((a, b, c, d, e) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); hasRun = true; }, Scheduler.Default)(1, 2, 3, 4, 5).ToEnumerable().SequenceEqual(new[] { new Unit() }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int>((a, b, c, d, e) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); hasRun = true; })(1, 2, 3, 4, 5).ToEnumerable().SequenceEqual([new Unit()]));
+            Assert.True(Observable.ToAsync<int, int, int, int, int>((a, b, c, d, e) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); hasRun = true; }, Scheduler.Default)(1, 2, 3, 4, 5).ToEnumerable().SequenceEqual([new Unit()]));
             Assert.True(hasRun, "has run");
         }
 
@@ -459,15 +459,15 @@ namespace ReactiveTests.Tests
         public void ToAsyncActionError5()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int, int, int>((a, b, c, d, e) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); throw ex; })(1, 2, 3, 4, 5).Materialize().ToEnumerable().SequenceEqual(new[] { Notification.CreateOnError<Unit>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int>((a, b, c, d, e) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); throw ex; })(1, 2, 3, 4, 5).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<Unit>(ex)]));
         }
 
         [TestMethod]
         public void ToAsyncAction6()
         {
             var hasRun = false;
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int>((a, b, c, d, e, f) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); hasRun = true; })(1, 2, 3, 4, 5, 6).ToEnumerable().SequenceEqual(new[] { new Unit() }));
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int>((a, b, c, d, e, f) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); hasRun = true; }, Scheduler.Default)(1, 2, 3, 4, 5, 6).ToEnumerable().SequenceEqual(new[] { new Unit() }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int>((a, b, c, d, e, f) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); hasRun = true; })(1, 2, 3, 4, 5, 6).ToEnumerable().SequenceEqual([new Unit()]));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int>((a, b, c, d, e, f) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); hasRun = true; }, Scheduler.Default)(1, 2, 3, 4, 5, 6).ToEnumerable().SequenceEqual([new Unit()]));
             Assert.True(hasRun, "has run");
         }
 
@@ -475,15 +475,15 @@ namespace ReactiveTests.Tests
         public void ToAsyncActionError6()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int>((a, b, c, d, e, f) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); throw ex; })(1, 2, 3, 4, 5, 6).Materialize().ToEnumerable().SequenceEqual(new[] { Notification.CreateOnError<Unit>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int>((a, b, c, d, e, f) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); throw ex; })(1, 2, 3, 4, 5, 6).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<Unit>(ex)]));
         }
 
         [TestMethod]
         public void ToAsyncAction7()
         {
             var hasRun = false;
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int>((a, b, c, d, e, f, g) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); hasRun = true; })(1, 2, 3, 4, 5, 6, 7).ToEnumerable().SequenceEqual(new[] { new Unit() }));
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int>((a, b, c, d, e, f, g) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); hasRun = true; }, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7).ToEnumerable().SequenceEqual(new[] { new Unit() }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int>((a, b, c, d, e, f, g) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); hasRun = true; })(1, 2, 3, 4, 5, 6, 7).ToEnumerable().SequenceEqual([new Unit()]));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int>((a, b, c, d, e, f, g) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); hasRun = true; }, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7).ToEnumerable().SequenceEqual([new Unit()]));
             Assert.True(hasRun, "has run");
         }
 
@@ -491,15 +491,15 @@ namespace ReactiveTests.Tests
         public void ToAsyncActionError7()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int>((a, b, c, d, e, f, g) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); throw ex; })(1, 2, 3, 4, 5, 6, 7).Materialize().ToEnumerable().SequenceEqual(new[] { Notification.CreateOnError<Unit>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int>((a, b, c, d, e, f, g) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); throw ex; })(1, 2, 3, 4, 5, 6, 7).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<Unit>(ex)]));
         }
 
         [TestMethod]
         public void ToAsyncAction8()
         {
             var hasRun = false;
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); hasRun = true; })(1, 2, 3, 4, 5, 6, 7, 8).ToEnumerable().SequenceEqual(new[] { new Unit() }));
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); hasRun = true; }, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8).ToEnumerable().SequenceEqual(new[] { new Unit() }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); hasRun = true; })(1, 2, 3, 4, 5, 6, 7, 8).ToEnumerable().SequenceEqual([new Unit()]));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); hasRun = true; }, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8).ToEnumerable().SequenceEqual([new Unit()]));
             Assert.True(hasRun, "has run");
         }
 
@@ -507,15 +507,15 @@ namespace ReactiveTests.Tests
         public void ToAsyncActionError8()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); throw ex; })(1, 2, 3, 4, 5, 6, 7, 8).Materialize().ToEnumerable().SequenceEqual(new[] { Notification.CreateOnError<Unit>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); throw ex; })(1, 2, 3, 4, 5, 6, 7, 8).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<Unit>(ex)]));
         }
 
         [TestMethod]
         public void ToAsyncAction9()
         {
             var hasRun = false;
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); hasRun = true; })(1, 2, 3, 4, 5, 6, 7, 8, 9).ToEnumerable().SequenceEqual(new[] { new Unit() }));
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); hasRun = true; }, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9).ToEnumerable().SequenceEqual(new[] { new Unit() }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); hasRun = true; })(1, 2, 3, 4, 5, 6, 7, 8, 9).ToEnumerable().SequenceEqual([new Unit()]));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); hasRun = true; }, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9).ToEnumerable().SequenceEqual([new Unit()]));
             Assert.True(hasRun, "has run");
         }
 
@@ -523,15 +523,15 @@ namespace ReactiveTests.Tests
         public void ToAsyncActionError9()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9).Materialize().ToEnumerable().SequenceEqual(new[] { Notification.CreateOnError<Unit>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<Unit>(ex)]));
         }
 
         [TestMethod]
         public void ToAsyncAction10()
         {
             var hasRun = false;
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); hasRun = true; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).ToEnumerable().SequenceEqual(new[] { new Unit() }));
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); hasRun = true; }, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).ToEnumerable().SequenceEqual(new[] { new Unit() }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); hasRun = true; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).ToEnumerable().SequenceEqual([new Unit()]));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); hasRun = true; }, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).ToEnumerable().SequenceEqual([new Unit()]));
             Assert.True(hasRun, "has run");
         }
 
@@ -539,15 +539,15 @@ namespace ReactiveTests.Tests
         public void ToAsyncActionError10()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).Materialize().ToEnumerable().SequenceEqual(new[] { Notification.CreateOnError<Unit>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<Unit>(ex)]));
         }
 
         [TestMethod]
         public void ToAsyncAction11()
         {
             var hasRun = false;
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); hasRun = true; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11).ToEnumerable().SequenceEqual(new[] { new Unit() }));
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); hasRun = true; }, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11).ToEnumerable().SequenceEqual(new[] { new Unit() }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); hasRun = true; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11).ToEnumerable().SequenceEqual([new Unit()]));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); hasRun = true; }, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11).ToEnumerable().SequenceEqual([new Unit()]));
             Assert.True(hasRun, "has run");
         }
 
@@ -555,15 +555,15 @@ namespace ReactiveTests.Tests
         public void ToAsyncActionError11()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11).Materialize().ToEnumerable().SequenceEqual(new[] { Notification.CreateOnError<Unit>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<Unit>(ex)]));
         }
 
         [TestMethod]
         public void ToAsyncAction12()
         {
             var hasRun = false;
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); hasRun = true; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).ToEnumerable().SequenceEqual(new[] { new Unit() }));
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); hasRun = true; }, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).ToEnumerable().SequenceEqual(new[] { new Unit() }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); hasRun = true; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).ToEnumerable().SequenceEqual([new Unit()]));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); hasRun = true; }, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).ToEnumerable().SequenceEqual([new Unit()]));
             Assert.True(hasRun, "has run");
         }
 
@@ -571,15 +571,15 @@ namespace ReactiveTests.Tests
         public void ToAsyncActionError12()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).Materialize().ToEnumerable().SequenceEqual(new[] { Notification.CreateOnError<Unit>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<Unit>(ex)]));
         }
 
         [TestMethod]
         public void ToAsyncAction13()
         {
             var hasRun = false;
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); Assert.Equal(13, m); hasRun = true; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13).ToEnumerable().SequenceEqual(new[] { new Unit() }));
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); Assert.Equal(13, m); hasRun = true; }, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13).ToEnumerable().SequenceEqual(new[] { new Unit() }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); Assert.Equal(13, m); hasRun = true; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13).ToEnumerable().SequenceEqual([new Unit()]));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); Assert.Equal(13, m); hasRun = true; }, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13).ToEnumerable().SequenceEqual([new Unit()]));
             Assert.True(hasRun, "has run");
         }
 
@@ -587,15 +587,15 @@ namespace ReactiveTests.Tests
         public void ToAsyncActionError13()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); Assert.Equal(13, m); throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13).Materialize().ToEnumerable().SequenceEqual(new[] { Notification.CreateOnError<Unit>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); Assert.Equal(13, m); throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<Unit>(ex)]));
         }
 
         [TestMethod]
         public void ToAsyncAction14()
         {
             var hasRun = false;
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); Assert.Equal(13, m); Assert.Equal(14, n); hasRun = true; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14).ToEnumerable().SequenceEqual(new[] { new Unit() }));
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); Assert.Equal(13, m); Assert.Equal(14, n); hasRun = true; }, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14).ToEnumerable().SequenceEqual(new[] { new Unit() }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); Assert.Equal(13, m); Assert.Equal(14, n); hasRun = true; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14).ToEnumerable().SequenceEqual([new Unit()]));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); Assert.Equal(13, m); Assert.Equal(14, n); hasRun = true; }, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14).ToEnumerable().SequenceEqual([new Unit()]));
             Assert.True(hasRun, "has run");
         }
 
@@ -603,15 +603,15 @@ namespace ReactiveTests.Tests
         public void ToAsyncActionError14()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); Assert.Equal(13, m); Assert.Equal(14, n); throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14).Materialize().ToEnumerable().SequenceEqual(new[] { Notification.CreateOnError<Unit>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); Assert.Equal(13, m); Assert.Equal(14, n); throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<Unit>(ex)]));
         }
 
         [TestMethod]
         public void ToAsyncAction15()
         {
             var hasRun = false;
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); Assert.Equal(13, m); Assert.Equal(14, n); Assert.Equal(15, o); hasRun = true; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).ToEnumerable().SequenceEqual(new[] { new Unit() }));
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); Assert.Equal(13, m); Assert.Equal(14, n); Assert.Equal(15, o); hasRun = true; }, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).ToEnumerable().SequenceEqual(new[] { new Unit() }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); Assert.Equal(13, m); Assert.Equal(14, n); Assert.Equal(15, o); hasRun = true; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).ToEnumerable().SequenceEqual([new Unit()]));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); Assert.Equal(13, m); Assert.Equal(14, n); Assert.Equal(15, o); hasRun = true; }, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).ToEnumerable().SequenceEqual([new Unit()]));
             Assert.True(hasRun, "has run");
         }
 
@@ -619,15 +619,15 @@ namespace ReactiveTests.Tests
         public void ToAsyncActionError15()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); Assert.Equal(13, m); Assert.Equal(14, n); Assert.Equal(15, o); throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).Materialize().ToEnumerable().SequenceEqual(new[] { Notification.CreateOnError<Unit>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); Assert.Equal(13, m); Assert.Equal(14, n); Assert.Equal(15, o); throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<Unit>(ex)]));
         }
 
         [TestMethod]
         public void ToAsyncAction16()
         {
             var hasRun = false;
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); Assert.Equal(13, m); Assert.Equal(14, n); Assert.Equal(15, o); Assert.Equal(16, p); hasRun = true; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16).ToEnumerable().SequenceEqual(new[] { new Unit() }));
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); Assert.Equal(13, m); Assert.Equal(14, n); Assert.Equal(15, o); Assert.Equal(16, p); hasRun = true; }, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16).ToEnumerable().SequenceEqual(new[] { new Unit() }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); Assert.Equal(13, m); Assert.Equal(14, n); Assert.Equal(15, o); Assert.Equal(16, p); hasRun = true; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16).ToEnumerable().SequenceEqual([new Unit()]));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); Assert.Equal(13, m); Assert.Equal(14, n); Assert.Equal(15, o); Assert.Equal(16, p); hasRun = true; }, Scheduler.Default)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16).ToEnumerable().SequenceEqual([new Unit()]));
             Assert.True(hasRun, "has run");
         }
 
@@ -635,7 +635,7 @@ namespace ReactiveTests.Tests
         public void ToAsyncActionError16()
         {
             var ex = new Exception();
-            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); Assert.Equal(13, m); Assert.Equal(14, n); Assert.Equal(15, o); Assert.Equal(16, p); throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16).Materialize().ToEnumerable().SequenceEqual(new[] { Notification.CreateOnError<Unit>(ex) }));
+            Assert.True(Observable.ToAsync<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) => { Assert.Equal(1, a); Assert.Equal(2, b); Assert.Equal(3, c); Assert.Equal(4, d); Assert.Equal(5, e); Assert.Equal(6, f); Assert.Equal(7, g); Assert.Equal(8, h); Assert.Equal(9, i); Assert.Equal(10, j); Assert.Equal(11, k); Assert.Equal(12, l); Assert.Equal(13, m); Assert.Equal(14, n); Assert.Equal(15, o); Assert.Equal(16, p); throw ex; })(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16).Materialize().ToEnumerable().SequenceEqual([Notification.CreateOnError<Unit>(ex)]));
         }
 
     }

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ToEventPatternTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ToEventPatternTest.cs
@@ -50,7 +50,7 @@ namespace ReactiveTests.Tests
 
             src.OnNext(new EventPattern<EventArgs<int>>(snd, new EventArgs<int>(44)));
 
-            Assert.True(lst.SequenceEqual(new[] { 42, 43 }));
+            Assert.True(lst.SequenceEqual([42, 43]));
         }
 
         [TestMethod]
@@ -77,7 +77,7 @@ namespace ReactiveTests.Tests
 
             ReactiveAssert.Throws(ex, () => src.OnError(ex));
 
-            Assert.True(lst.SequenceEqual(new[] { 42, 43 }));
+            Assert.True(lst.SequenceEqual([42, 43]));
         }
 
         [TestMethod]
@@ -102,7 +102,7 @@ namespace ReactiveTests.Tests
 
             src.OnCompleted();
 
-            Assert.True(lst.SequenceEqual(new[] { 42, 43 }));
+            Assert.True(lst.SequenceEqual([42, 43]));
         }
 
         private class EventSrc
@@ -151,7 +151,7 @@ namespace ReactiveTests.Tests
 
             src.On("qux");
 
-            Assert.True(lst.SequenceEqual(new[] { "foo", "baz" }));
+            Assert.True(lst.SequenceEqual(["foo", "baz"]));
         }
 
         [TestMethod]

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ToEventTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ToEventTest.cs
@@ -76,7 +76,7 @@ namespace ReactiveTests.Tests
 
             src.OnNext(3);
 
-            Assert.True(lst.SequenceEqual(new[] { 1, 2 }));
+            Assert.True(lst.SequenceEqual([1, 2]));
         }
 
         [TestMethod]
@@ -96,7 +96,7 @@ namespace ReactiveTests.Tests
 
             src.OnNext(3);
 
-            Assert.True(lst.SequenceEqual(new[] { 1, 2 }));
+            Assert.True(lst.SequenceEqual([1, 2]));
         }
 
     }

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ToListTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ToListTest.cs
@@ -40,7 +40,7 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(660, l => l.SequenceEqual(new[] { 2, 3, 4, 5 })),
+                OnNext<IList<int>>(660, l => l.SequenceEqual([2, 3, 4, 5])),
                 OnCompleted<IList<int>>(660)
             );
 

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ToLookupTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ToLookupTest.cs
@@ -58,8 +58,8 @@ namespace ReactiveTests.Tests
                 OnNext<ILookup<int, int>>(660, d =>
                 {
                     return d.Count == 2
-                        && d[0].SequenceEqual(new[] { 4, 8 })
-                        && d[1].SequenceEqual(new[] { 6, 10 });
+                        && d[0].SequenceEqual([4, 8])
+                        && d[1].SequenceEqual([6, 10]);
                 }),
                 OnCompleted<ILookup<int, int>>(660)
             );

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ToObservableTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ToObservableTest.cs
@@ -36,7 +36,7 @@ namespace ReactiveTests.Tests
             var scheduler = new TestScheduler();
 
             var e = new MockEnumerable<int>(scheduler,
-                new[] { 3, 1, 2, 4 }
+                [3, 1, 2, 4]
             );
 
             var results = scheduler.Start(() =>
@@ -62,7 +62,7 @@ namespace ReactiveTests.Tests
             var scheduler = new TestScheduler();
 
             var e = new MockEnumerable<int>(scheduler,
-                new[] { 3, 1, 2, 4 }
+                [3, 1, 2, 4]
             );
 
             var results = scheduler.Start(() =>

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/WhenTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/WhenTest.cs
@@ -12,6 +12,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Assert = Xunit.Assert;
 
+#pragma warning disable IDE0028 // Simplify collection initialization. We want to be clear about what kinds of collections are in use in these tests.
+
 namespace ReactiveTests.Tests
 {
     [TestClass]

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ZipTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/ZipTest.cs
@@ -3462,7 +3462,7 @@ namespace ReactiveTests.Tests
             );
 
             var e = new MockEnumerable<int>(scheduler,
-                Enumerable.Empty<int>()
+                []
             );
 
             var res = scheduler.Start(() =>
@@ -3527,7 +3527,7 @@ namespace ReactiveTests.Tests
             );
 
             var e2 = new MockEnumerable<int>(scheduler,
-                Enumerable.Empty<int>()
+                []
             );
 
             var res = scheduler.Start(() =>
@@ -3558,7 +3558,7 @@ namespace ReactiveTests.Tests
             );
 
             var o = new MockEnumerable<int>(scheduler,
-                new[] { 2 }
+                [2]
             );
 
             var res = scheduler.Start(() =>
@@ -3584,7 +3584,7 @@ namespace ReactiveTests.Tests
             var scheduler = new TestScheduler();
 
             var e = new MockEnumerable<int>(scheduler,
-                Enumerable.Empty<int>()
+                []
             );
 
             var o = scheduler.CreateHotObservable(
@@ -3616,7 +3616,7 @@ namespace ReactiveTests.Tests
             var scheduler = new TestScheduler();
 
             var o = new MockEnumerable<int>(scheduler,
-                new[] { 2 }
+                [2]
             );
 
             var n = scheduler.CreateHotObservable(
@@ -3651,7 +3651,7 @@ namespace ReactiveTests.Tests
             );
 
             var o2 = new MockEnumerable<int>(scheduler,
-                new[] { 3 }
+                [3]
             );
 
             var res = scheduler.Start(() =>
@@ -3713,7 +3713,7 @@ namespace ReactiveTests.Tests
             var ex = new Exception();
 
             var e = new MockEnumerable<int>(scheduler,
-                Enumerable.Empty<int>()
+                []
             );
 
             var f = scheduler.CreateHotObservable(
@@ -3882,7 +3882,7 @@ namespace ReactiveTests.Tests
             var ex = new Exception();
 
             var o = new MockEnumerable<int>(scheduler,
-                new[] { 2 }
+                [2]
             );
 
             var e = scheduler.CreateHotObservable(
@@ -3915,7 +3915,7 @@ namespace ReactiveTests.Tests
             var ex = new Exception();
 
             var o = new MockEnumerable<int>(scheduler,
-                new[] { 5, 4, 3, 2 }
+                [5, 4, 3, 2]
             );
 
             var e = scheduler.CreateHotObservable(
@@ -4029,7 +4029,7 @@ namespace ReactiveTests.Tests
             );
 
             var o2 = new MockEnumerable<int>(scheduler,
-                new[] { 3, 5 }
+                [3, 5]
             );
 
             var ex = new Exception();
@@ -4264,7 +4264,7 @@ namespace ReactiveTests.Tests
         {
             ReactiveAssert.Throws<ArgumentNullException>(() => Observable.Zip(default(IEnumerable<IObservable<int>>)));
             ReactiveAssert.Throws<ArgumentNullException>(() => Observable.Zip(default(IEnumerable<IObservable<int>>), _ => 42));
-            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.Zip(new[] { Observable.Return(42) }, default(Func<IList<int>, string>)));
+            ReactiveAssert.Throws<ArgumentNullException>(() => Observable.Zip([Observable.Return(42)], default(Func<IList<int>, string>)));
             ReactiveAssert.Throws<ArgumentNullException>(() => Observable.Zip(default(IObservable<int>[])));
         }
 
@@ -4282,8 +4282,8 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(230, l => l.SequenceEqual(new[] { 1, 2, 3 })),
-                OnNext<IList<int>>(260, l => l.SequenceEqual(new[] { 4, 5, 6 })),
+                OnNext<IList<int>>(230, l => l.SequenceEqual([1, 2, 3])),
+                OnNext<IList<int>>(260, l => l.SequenceEqual([4, 5, 6])),
                 OnCompleted<IList<int>>(420)
             );
 
@@ -4346,8 +4346,8 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(230, l => l.SequenceEqual(new[] { 1, 2, 3 })),
-                OnNext<IList<int>>(260, l => l.SequenceEqual(new[] { 4, 5, 6 })),
+                OnNext<IList<int>>(230, l => l.SequenceEqual([1, 2, 3])),
+                OnNext<IList<int>>(260, l => l.SequenceEqual([4, 5, 6])),
                 OnCompleted<IList<int>>(310)
             );
 
@@ -4412,7 +4412,7 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(230, l => l.SequenceEqual(new[] { 1, 2, 3 })),
+                OnNext<IList<int>>(230, l => l.SequenceEqual([1, 2, 3])),
                 OnError<IList<int>>(250, ex)
             );
 
@@ -4481,8 +4481,8 @@ namespace ReactiveTests.Tests
             Assert.Equal(200, started);
 
             res.Messages.AssertEqual(
-                OnNext<IList<int>>(230, l => l.SequenceEqual(new[] { 1, 2, 3 })),
-                OnNext<IList<int>>(260, l => l.SequenceEqual(new[] { 4, 5, 6 })),
+                OnNext<IList<int>>(230, l => l.SequenceEqual([1, 2, 3])),
+                OnNext<IList<int>>(260, l => l.SequenceEqual([4, 5, 6])),
                 OnCompleted<IList<int>>(420)
             );
 

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/QbservableTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/QbservableTest.cs
@@ -486,7 +486,7 @@ namespace ReactiveTests.Tests
         {
             ReactiveAssert.Throws<ArgumentNullException>(() => Qbservable.For(null, new[] { 1 }, i => _qbMy));
             ReactiveAssert.Throws<ArgumentNullException>(() => Qbservable.For(_qbp, default(IEnumerable<int>), i => _qbMy));
-            ReactiveAssert.Throws<ArgumentNullException>(() => Qbservable.For(_qbp, new[] { 1 }, default(Expression<Func<int, IObservable<int>>>)));
+            ReactiveAssert.Throws<ArgumentNullException>(() => Qbservable.For(_qbp, [1], default(Expression<Func<int, IObservable<int>>>)));
         }
 
         [TestMethod]
@@ -1535,7 +1535,7 @@ namespace ReactiveTests.Tests
             ReactiveAssert.Throws<ArgumentNullException>(() => Qbservable.Zip(_qbMy, _qbMy, default(Expression<Func<int, int, int>>)));
             ReactiveAssert.Throws<ArgumentNullException>(() => Qbservable.Zip(_qbNull, new[] { 1 }, (a, b) => a + b));
             ReactiveAssert.Throws<ArgumentNullException>(() => Qbservable.Zip(_qbMy, default(IEnumerable<int>), (a, b) => a + b));
-            ReactiveAssert.Throws<ArgumentNullException>(() => Qbservable.Zip(_qbMy, new[] { 1 }, default(Expression<Func<int, int, int>>)));
+            ReactiveAssert.Throws<ArgumentNullException>(() => Qbservable.Zip(_qbMy, [1], default(Expression<Func<int, int, int>>)));
         }
 
         [TestMethod]
@@ -1659,17 +1659,17 @@ namespace ReactiveTests.Tests
         {
             var xs = Observable.Return(1).AsQbservable();
 
-            Assert.True(xs.Where(x => true).ToEnumerable().SequenceEqual(new[] { 1 }), "Where");
-            Assert.True(xs.Select(x => x.ToString()).ToEnumerable().SequenceEqual(new[] { "1" }), "Select");
-            Assert.True(xs.Take(1).ToEnumerable().SequenceEqual(new[] { 1 }), "Take");
-            Assert.True(xs.Sum().ToEnumerable().SequenceEqual(new[] { 1 }), "Sum");
-            Assert.True(xs.Amb(xs).ToEnumerable().SequenceEqual(new[] { 1 }), "Amb");
-            Assert.True(xs.Concat(xs).ToEnumerable().SequenceEqual(new[] { 1, 1 }), "Concat");
-            Assert.True(xs.Aggregate("", (s, i) => s + i).ToEnumerable().SequenceEqual(new[] { "1" }), "Aggregate");
-            Assert.True(xs.Where(x => true).Concat(xs.Where(x => false)).ToEnumerable().SequenceEqual(new[] { 1 }), "Concat/Where");
-            Assert.True(xs.SelectMany(x => xs).ToEnumerable().SequenceEqual(new[] { 1 }), "SelectMany");
-            Assert.True(xs.GroupBy(x => x).SelectMany(g => g).ToEnumerable().SequenceEqual(new[] { 1 }), "GroupBy/SelectMany");
-            Assert.True(xs.GroupBy(x => x, x => x).SelectMany(g => g).ToEnumerable().SequenceEqual(new[] { 1 }), "GroupBy/SelectMany (more generics)");
+            Assert.True(xs.Where(x => true).ToEnumerable().SequenceEqual([1]), "Where");
+            Assert.True(xs.Select(x => x.ToString()).ToEnumerable().SequenceEqual(["1"]), "Select");
+            Assert.True(xs.Take(1).ToEnumerable().SequenceEqual([1]), "Take");
+            Assert.True(xs.Sum().ToEnumerable().SequenceEqual([1]), "Sum");
+            Assert.True(xs.Amb(xs).ToEnumerable().SequenceEqual([1]), "Amb");
+            Assert.True(xs.Concat(xs).ToEnumerable().SequenceEqual([1, 1]), "Concat");
+            Assert.True(xs.Aggregate("", (s, i) => s + i).ToEnumerable().SequenceEqual(["1"]), "Aggregate");
+            Assert.True(xs.Where(x => true).Concat(xs.Where(x => false)).ToEnumerable().SequenceEqual([1]), "Concat/Where");
+            Assert.True(xs.SelectMany(x => xs).ToEnumerable().SequenceEqual([1]), "SelectMany");
+            Assert.True(xs.GroupBy(x => x).SelectMany(g => g).ToEnumerable().SequenceEqual([1]), "GroupBy/SelectMany");
+            Assert.True(xs.GroupBy(x => x, x => x).SelectMany(g => g).ToEnumerable().SequenceEqual([1]), "GroupBy/SelectMany (more generics)");
 
             // TODO: IQueryable ones
         }
@@ -1679,8 +1679,8 @@ namespace ReactiveTests.Tests
         {
             var xs = Observable.Return(1).AsQbservable();
 
-            Assert.True(Qbservable.Provider.Amb(xs, xs, xs).ToEnumerable().SequenceEqual(new[] { 1 }), "Amb (n-ary)");
-            Assert.True(Qbservable.Provider.Concat(xs, xs, xs).ToEnumerable().SequenceEqual(new[] { 1, 1, 1 }), "Concat (n-ary)");
+            Assert.True(Qbservable.Provider.Amb(xs, xs, xs).ToEnumerable().SequenceEqual([1]), "Amb (n-ary)");
+            Assert.True(Qbservable.Provider.Concat(xs, xs, xs).ToEnumerable().SequenceEqual([1, 1, 1]), "Concat (n-ary)");
 
             ReactiveAssert.Throws<MyException>(() => Qbservable.Provider.Throw<int>(new MyException()).ForEach(_ => { }));
         }
@@ -1696,8 +1696,8 @@ namespace ReactiveTests.Tests
             var ys = Observable.Return(2).AsQbservable();
             var zs = Observable.Return(3).AsQbservable();
 
-            Assert.True(Qbservable.Provider.When(xs.And(ys).Then((x, y) => x + y)).ToEnumerable().SequenceEqual(new[] { 3 }), "Join");
-            Assert.True(Qbservable.Provider.When(xs.And(ys).And(zs).Then((x, y, z) => x + y + z)).ToEnumerable().SequenceEqual(new[] { 6 }), "Join");
+            Assert.True(Qbservable.Provider.When(xs.And(ys).Then((x, y) => x + y)).ToEnumerable().SequenceEqual([3]), "Join");
+            Assert.True(Qbservable.Provider.When(xs.And(ys).And(zs).Then((x, y, z) => x + y + z)).ToEnumerable().SequenceEqual([6]), "Join");
         }
 
         [TestMethod]
@@ -1711,7 +1711,7 @@ namespace ReactiveTests.Tests
                 )
                 .Catch((Exception ex) => Qbservable.Provider.Return(3))
                 .ToEnumerable()
-                .SequenceEqual(new[] { 2, 3 })
+                .SequenceEqual([2, 3])
             );
         }
 
@@ -1721,7 +1721,7 @@ namespace ReactiveTests.Tests
             var xs = Observable.Range(0, 10).Where(x => x > 5).AsQbservable().Select(x => x + 1);
             var ys = xs.ToQueryable().OrderByDescending(x => x);
 
-            Assert.True(ys.SequenceEqual(new[] { 10, 9, 8, 7 }));
+            Assert.True(ys.SequenceEqual([10, 9, 8, 7]));
         }
 
         [TestMethod]
@@ -1761,8 +1761,8 @@ namespace ReactiveTests.Tests
             var obs = typeof(Observable).GetMethods(BindingFlags.Public | BindingFlags.Static).ToList();
             var qbs = typeof(Qbservable).GetMethods(BindingFlags.Public | BindingFlags.Static).ToList();
 
-            var onlyInObs = obs.Select(m => m.Name).Except(qbs.Select(m => m.Name)).Except(new[] { "First", "FirstOrDefault", "Last", "LastOrDefault", "Single", "SingleOrDefault", "ForEach", "Subscribe", "GetEnumerator", "ToEnumerable", "Multicast", "GetAwaiter", "ToEvent", "ToEventPattern", "ForEachAsync", "Wait", "RunAsync", "ToListObservable" }).ToList();
-            var onlyInQbs = qbs.Select(m => m.Name).Except(obs.Select(m => m.Name)).Except(new[] { "ToQueryable", "ToQbservable", "get_Provider", "AsQbservable" }).ToList();
+            var onlyInObs = obs.Select(m => m.Name).Except(qbs.Select(m => m.Name)).Except(["First", "FirstOrDefault", "Last", "LastOrDefault", "Single", "SingleOrDefault", "ForEach", "Subscribe", "GetEnumerator", "ToEnumerable", "Multicast", "GetAwaiter", "ToEvent", "ToEventPattern", "ForEachAsync", "Wait", "RunAsync", "ToListObservable"]).ToList();
+            var onlyInQbs = qbs.Select(m => m.Name).Except(obs.Select(m => m.Name)).Except(["ToQueryable", "ToQbservable", "get_Provider", "AsQbservable"]).ToList();
 
             Assert.True(onlyInObs.Count == 0, "Missing Qbservable operator: " + string.Join(", ", onlyInObs.ToArray()));
             Assert.True(onlyInQbs.Count == 0, "Missing Observable operator: " + string.Join(", ", onlyInQbs.ToArray()));

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Subjects/ReplaySubjectTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Subjects/ReplaySubjectTest.cs
@@ -1839,14 +1839,14 @@ namespace ReactiveTests.Tests
 
             r.OnNext(5);
 
-            Assert.True(xs.SequenceEqual(new[]
-            {
+            Assert.True(xs.SequenceEqual(
+            [
                 1, 2, 3, 4, // original
                 1, 2, 3, 4, // reentrant (+ fed back)
                 1, 2, 3, 4, // reentrant (+ first two fed back)
                 1, 2,       // reentrant
                 5           // tune in
-            }));
+            ]));
         }
 
 #if !NO_INTERNALSTEST

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/ObserverTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/ObserverTest.cs
@@ -849,7 +849,7 @@ namespace ReactiveTests.Tests
             p.Report(42);
             p.Report(43);
 
-            Assert.True(xs.SequenceEqual(new[] { 42, 43 }));
+            Assert.True(xs.SequenceEqual([42, 43]));
         }
 
         [TestMethod]
@@ -892,7 +892,7 @@ namespace ReactiveTests.Tests
             o.OnNext(42);
             o.OnNext(43);
 
-            Assert.True(xs.SequenceEqual(new[] { 42, 43 }));
+            Assert.True(xs.SequenceEqual([42, 43]));
         }
 
         private class MyProgress<T> : IProgress<T>


### PR DESCRIPTION
It looks like the 8.0.200 .NET SDK added a lot of new diagnostics suggesting the use of collection expressions.

For the most part we have taken these suggestions, but in some cases we've retained the existing code so you can see what types are being used. I find that in methods with lots of overloads (e.g., Assert.AreEqual) it becomes quite difficult to work out what will actually happen if you replace an explicitly typed list initializer with just `[...]`.