### PR TITLE
Use new sign tool

### DIFF
--- a/azure-pipelines.asyncrx.yml
+++ b/azure-pipelines.asyncrx.yml
@@ -93,23 +93,34 @@ stages:
       runOnce:
         deploy:
           steps:
+
+          - task: UseDotNet@2
+            displayName: Use .NET 8.0.x SDK
+            inputs:
+              version: 8.0.x
+              performMultiLevelLookup: true
+
           - task: DotNetCoreCLI@2
+            displayName: Install SignTool tool
             inputs:
               command: custom
               custom: tool
-              arguments: install --tool-path . SignClient
-            displayName: Install SignTool tool
+              arguments: install --tool-path . sign --version 0.9.1-beta.24406.1
 
-          - pwsh: |
-              .\SignClient "Sign" `
-              --baseDirectory "$(Pipeline.Workspace)\BuildPackages" `
-              --input "**/*.nupkg" `
-              --config "$(Pipeline.Workspace)\config\signclient.json" `
-              --user "$(SignClientUser)" `
-              --secret "$(SignClientSecret)" `
-              --name "Rx.NET" `
-              --description "Rx.NET" `
-              --descriptionUrl "https://github.com/dotnet/reactive"
+          - task: AzureCLI@2
+            inputs:
+              azureSubscription: 'Rx.NET Sign Service Connection'
+              scriptType: pscore
+              scriptLocation: inlineScript
+              inlineScript: |
+                .\sign code azure-key-vault `
+                "**/*.nupkg" `
+                --base-directory "$(Pipeline.Workspace)\BuildPackages" `
+                --publisher-name "Reactive Extensions for .NET (.NET Foundation)" `
+                --description "AsyncRx.NET" `
+                --description-url "https://github.com/dotnet/reactive" `
+                --azure-key-vault-url "$(SignKeyVaultUrl)" `
+                --azure-key-vault-certificate "$(SignKeyVaultCertificateName)"
             displayName: Sign packages
 
           - publish: $(Pipeline.Workspace)/BuildPackages

--- a/azure-pipelines.ix.yml
+++ b/azure-pipelines.ix.yml
@@ -128,24 +128,36 @@ stages:
       runOnce:
         deploy:
           steps:
+
+          - task: UseDotNet@2
+            displayName: Use .NET 8.0.x SDK
+            inputs:
+              version: 8.0.x
+              performMultiLevelLookup: true
+
           - task: DotNetCoreCLI@2
+            displayName: Install SignTool tool
             inputs:
               command: custom
               custom: tool
-              arguments: install --tool-path . SignClient
-            displayName: Install SignTool tool
+              arguments: install --tool-path . sign --version 0.9.1-beta.24406.1
 
-          - pwsh: |
-              .\SignClient "Sign" `
-              --baseDirectory "$(Pipeline.Workspace)\BuildPackages" `
-              --input "**/*.nupkg" `
-              --config "$(Pipeline.Workspace)\config\signclient.json" `
-              --user "$(SignClientUser)" `
-              --secret "$(SignClientSecret)" `
-              --name "Ix.NET" `
-              --description "Ix.NET" `
-              --descriptionUrl "https://github.com/dotnet/reactive"
+          - task: AzureCLI@2
+            inputs:
+              azureSubscription: 'Rx.NET Sign Service Connection'
+              scriptType: pscore
+              scriptLocation: inlineScript
+              inlineScript: |
+                .\sign code azure-key-vault `
+                "**/*.nupkg" `
+                --base-directory "$(Pipeline.Workspace)\BuildPackages" `
+                --publisher-name "Reactive Extensions for .NET (.NET Foundation)" `
+                --description "Ix.NET" `
+                --description-url "https://github.com/dotnet/reactive" `
+                --azure-key-vault-url "$(SignKeyVaultUrl)" `
+                --azure-key-vault-certificate "$(SignKeyVaultCertificateName)"
             displayName: Sign packages
+
           - publish: $(Pipeline.Workspace)/BuildPackages
             displayName: Publish Signed Packages
             artifact: SignedPackages

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -264,23 +264,36 @@ stages:
       runOnce:
         deploy:
           steps:
+
+          - task: UseDotNet@2
+            displayName: Use .NET 8.0.x SDK
+            inputs:
+              version: 8.0.x
+              performMultiLevelLookup: true
+
           - task: DotNetCoreCLI@2
+            displayName: Install SignTool tool
             inputs:
               command: custom
               custom: tool
-              arguments: install --tool-path . SignClient
-            displayName: Install SignTool tool
+              arguments: install --tool-path . sign --version 0.9.1-beta.24406.1
 
-          - pwsh: |
-              .\SignClient "Sign" `
-              --baseDirectory "$(Pipeline.Workspace)\BuildPackages" `
-              --input "**/*.nupkg" `
-              --config "$(Pipeline.Workspace)\config\signclient.json" `
-              --user "$(SignClientUser)" `
-              --secret "$(SignClientSecret)" `
-              --name "Rx.NET" `
-              --description "Rx.NET" `
-              --descriptionUrl "https://github.com/dotnet/reactive"
+          # Run the signing command
+
+          - task: AzureCLI@2
+            inputs:
+              azureSubscription: 'Rx.NET Sign Service Connection'
+              scriptType: pscore
+              scriptLocation: inlineScript
+              inlineScript: |
+                .\sign code azure-key-vault `
+                "**/*.nupkg" `
+                --base-directory "$(Pipeline.Workspace)\BuildPackages" `
+                --publisher-name "Reactive Extensions for .NET (.NET Foundation)" `
+                --description "Rx.NET" `
+                --description-url "https://github.com/dotnet/reactive" `
+                --azure-key-vault-url "$(SignKeyVaultUrl)" `
+                --azure-key-vault-certificate "$(SignKeyVaultCertificateName)"
             displayName: Sign packages
 
           - publish: $(Pipeline.Workspace)/BuildPackages


### PR DESCRIPTION
The old `signtool` has been retired. This moves over to the new [`sign`](https://github.com/dotnet/sign) tool.

This offers two significant security improvements:

1. we can use a Managed Identity instead of the old [client credentials flow](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-client-creds-grant-flow) to authenticate with Azure Key Vault
2. the critical cryptographic step now happens inside Azure Key Vault, not on the build agent

Both of these improvements remove the need for the build agent to be in possession of a critical secret.

Because of 1, we no longer need to supply the build agent with a Client Secret. That Client Secret was critical because if it had ever been leaked, they would effectively have stolen the build agent's identity, and would have been able to ask the Key Vault to perform any operation that the our build process is allowed to do. 

Because of 2, if the build process is compromised (which could happen if the project maintainers unwittingly merged a malicious PR—something that could easily happen if the malicious intent were concealed behind an apparently useful change) it is no longer possible to exfiltrate the signing key. The old `signtool` downloaded the private key of the code signing certificate and generated the signature itself, creating a risk that malicious code running during the build might be able to obtain that key. (We ran code signing as a separate, simple step to minimize this risk, but it was never ideal that such a critical key ended up in plain text on a build agent, even if only briefly.) Now, Azure Key Vault performs the crucial cryptographic operation at the heart of code signing, meaning that the private key now never needs to leave the Azure Key Vault. This is a significantly more secure design because it removes any possibility that the code signing private key might be retrieved, which would have enabled whoever retrieved it to generate signatures from any computer.

We need to remain vigilant of course. Azure Key Vault will still sign whatever our build process asks it to sign, so it is vitally important to make sure that the code signing build step only submits for signature the components we intend to sign.