### PR TITLE
Adding ObservableDisposable

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Disposables/ObservableDisposable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/ObservableDisposable.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT License.
+// See the LICENSE file in the project root for more information. 
+
+namespace System.Reactive.Disposables;
+using System;
+using System.Reactive.Subjects;
+using System.Threading;
+
+/// <summary>
+/// Represents a disposable resource that can be observed
+/// </summary>
+public sealed class ObservableDisposable : ICancelable, IObservable<Unit>
+{
+    private Subject<Unit> _disposedNotification = new();
+    private bool _disposed;
+
+    /// <inheritdoc/>
+    public bool IsDisposed => Volatile.Read(ref _disposed);
+
+    /// <inheritdoc/>
+    public IDisposable Subscribe(IObserver<Unit> observer)
+        => _disposedNotification.Subscribe(observer);
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (Volatile.Read(ref _disposed) == false)
+        {
+            _disposedNotification.OnNext(Unit.Default);
+            _disposedNotification.OnCompleted();
+            _disposedNotification.Dispose();
+            Volatile.Write(ref _disposed, true);
+            _disposedNotification = null!;
+        }
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Disposables/DisposableTests.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Disposables/DisposableTests.cs
@@ -903,5 +903,35 @@ namespace ReactiveTests.Tests
             Assert.True(disp3);
             Assert.True(d.IsDisposed);
         }
+
+        [TestMethod]
+        public void ObservableDisposable_Observed()
+        {
+            var disp1 = false;
+
+            var observableDisposable = new ObservableDisposable();
+
+            var sub = observableDisposable
+                .Subscribe(_ => { Assert.False(disp1); disp1 = true; });
+
+            observableDisposable.Dispose();
+
+            Assert.True(disp1);
+            Assert.True(observableDisposable.IsDisposed);
+        }
+
+        [TestMethod]
+        public void ObservableDisposable_ObservationCancelled()
+        {
+            var disp1 = false;
+
+            var observableDisposable = new ObservableDisposable();
+
+            var sub = observableDisposable
+                .Subscribe(_ => { Assert.False(disp1); disp1 = true; });
+
+            sub.Dispose();
+
+        }
     }
 }


### PR DESCRIPTION
Hej,

this PR adds the class ObservableDisposable, which allows to observe when the disposable will be disposed.

This comes in handy when you want to end streams if the parent object is disposed.
I use it in serveral of my projects and want to share it, albeit the implementation might not be perfect. (I am also here to learn 😄)

Example:

```
private ObservableDisposable observableDisposable = new();

IObservbale<T1> oldObservable = ... ;
IObservbale<T2> newObservable = oldObservable
	.TakeUntil(this.observableDisposable)
	.Select(t1 => */ read data /*)
	.Publish()
	.RefCount(


public void Dispose() => this.observableDisposable.Dispose()
```