### PR TITLE
Fix Ix.NET build break on Ubuntu 24

### DIFF
--- a/Ix.NET/Source/Ix.NET.sln
+++ b/Ix.NET/Source/Ix.NET.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 17.2.32131.331
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{87534290-A7A6-47A4-9A3A-D0D21A9AD1D4}"
 	ProjectSection(SolutionItems) = preProject
-		NetCore31TestReadme.txt = NetCore31TestReadme.txt
+		NetStandard21TestReadme.txt = NetStandard21TestReadme.txt
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B733D97A-F1ED-4FC3-BF8E-9AC47A89DE96}"

--- a/Ix.NET/Source/NetCore31TestReadme.txt
+++ b/Ix.NET/Source/NetCore31TestReadme.txt
@@ -1,7 +1,0 @@
-The tests all include a .NET Core 3.1 target, even though that has long since been out of support.
-
-The reason for this is that Ix.NET 6.0 offers a .NET Standard 2.1 target, and currently, the only way we have of testing this is through .NET Core 3.1.
-
-Although current versions of .NET (but not .NET Framework) support .NET Standard 2.1, they are all going to prefer the net6.0 target. We do test on currently supported versions of .NET, but we also want to test the .NET Standard 2.1 target.
-
-It might be possible to test via Mono instead, or possibly even Unity, but this would likely involve additional CI/CD work, so for now we're sticking with the .NET Core 3.1 target framework. It's unsupported, but it's better than doing no testing at all.

--- a/Ix.NET/Source/NetStandard21TestReadme.txt
+++ b/Ix.NET/Source/NetStandard21TestReadme.txt
@@ -1,0 +1,5 @@
+Ix.NET 6.0 offers a .NET Standard 2.1 target, but currently, we have no way of testing this.
+
+We used to test this target by running tests in .NET Core 3.1. Unfortunately, the test runners now crash when running tests in .NET Core 3.1. .NET Core 3.1 has long since been out of support, so there's not much we can do about this. (It now reports the absence of ssllib on the hosted build agents.)
+
+Although current versions of .NET (but not .NET Framework) support .NET Standard 2.1, they are all going to prefer the net6.0 target. It might be possible to test via Mono instead, or possibly even Unity, but this would likely involve additional CI/CD work. But for now this target is untested. If we can't find a way to test netstandard2.1, that suggests there's no scenario in which it is useful now, so we may remove it in a future release.

--- a/Ix.NET/Source/System.Interactive.Async.Providers.Tests/System.Interactive.Async.Providers.Tests.csproj
+++ b/Ix.NET/Source/System.Interactive.Async.Providers.Tests/System.Interactive.Async.Providers.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- See NetCore31TestReadme.txt for why we still use netcoreapp3.1 -->
-    <TargetFrameworks>net48;net8.0;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0;net6.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
 

--- a/Ix.NET/Source/System.Interactive.Async.Tests/System.Interactive.Async.Tests.csproj
+++ b/Ix.NET/Source/System.Interactive.Async.Tests/System.Interactive.Async.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- See NetCore31TestReadme.txt for why we still use netcoreapp3.1 -->
-    <TargetFrameworks>net48;net8.0;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0;net6.0</TargetFrameworks>
 
     <!--
       CA1510: Use ArgumentNullException.ThrowIfNull - not available on .NET 4.8

--- a/Ix.NET/Source/System.Interactive.Async.Tests/System/Linq/Operators/Distinct.cs
+++ b/Ix.NET/Source/System.Interactive.Async.Tests/System/Linq/Operators/Distinct.cs
@@ -41,8 +41,9 @@ namespace Tests
         {
             var xs = new[] { 1, 2, 1, 3, 5, 2, 1, 4 }.ToAsyncEnumerable().Distinct(k => k);
 
-            var res = new[] { 1, 2, 3, 5, 4 };
-            Assert.True(res.SequenceEqual(await xs.ToArrayAsync()));
+            var expected = new[] { 1, 2, 3, 5, 4 };
+            var actual = await xs.ToArrayAsync();
+            Assert.True(expected.SequenceEqual(actual));
         }
 
         [Fact]

--- a/Ix.NET/Source/System.Interactive.Tests/System.Interactive.Tests.csproj
+++ b/Ix.NET/Source/System.Interactive.Tests/System.Interactive.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- See NetCore31TestReadme.txt for why we still use netcoreapp3.1 -->
-    <TargetFrameworks>net48;net8.0;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0;net6.0</TargetFrameworks>
 
     <!--
       CA1822: Make member static. Not necessary for test code.

--- a/Ix.NET/Source/System.Linq.Async.Queryable.Tests/System.Linq.Async.Queryable.Tests.csproj
+++ b/Ix.NET/Source/System.Linq.Async.Queryable.Tests/System.Linq.Async.Queryable.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- See NetCore31TestReadme.txt for why we still use netcoreapp3.1 -->
-    <TargetFrameworks>net48;net8.0;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0;net6.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
 

--- a/Ix.NET/Source/System.Linq.Async.Tests/System.Linq.Async.Tests.csproj
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System.Linq.Async.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- See NetCore31TestReadme.txt for why we still use netcoreapp3.1 -->
-    <TargetFrameworks>net48;net8.0;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0;net6.0</TargetFrameworks>
 
     <!--
     CA1510: Use ArgumentNullException.ThrowIfNull - not available on .NET 4.8

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Concat.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Concat.cs
@@ -104,8 +104,9 @@ namespace Tests
 
             var c = xs.Concat(ys).Concat(zs);
 
-            var res = new[] { 1, 2, 3, 4, 5, 6, 7, 8 };
-            Assert.True(res.SequenceEqual(await c.ToArrayAsync()));
+            var expected = new[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+            var actual = await c.ToArrayAsync();
+            Assert.True(expected.SequenceEqual(actual));
         }
 
         [Fact]

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/DefaultIfEmpty.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/DefaultIfEmpty.cs
@@ -136,9 +136,10 @@ namespace Tests
         {
             var xs = AsyncEnumerable.Empty<int>().DefaultIfEmpty(42);
 
-            var res = new[] { 42 };
+            var expected = new[] { 42 };
+            var actual = await xs.ToArrayAsync();
 
-            Assert.True(res.SequenceEqual(await xs.ToArrayAsync()));
+            Assert.True(expected.SequenceEqual(actual));
         }
 
         [Fact]
@@ -156,9 +157,10 @@ namespace Tests
         {
             var xs = new[] { 1, 2, 3, 4 }.ToAsyncEnumerable().DefaultIfEmpty();
 
-            var res = new[] { 1, 2, 3, 4 };
+            var expected = new[] { 1, 2, 3, 4 };
 
-            Assert.True(res.SequenceEqual(await xs.ToArrayAsync()));
+            var actual = await xs.ToArrayAsync();
+            Assert.True(expected.SequenceEqual(actual));
         }
 
         [Fact]

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Distinct.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/Distinct.cs
@@ -52,8 +52,9 @@ namespace Tests
         {
             var xs = new[] { 1, 2, 1, 3, 5, 2, 1, 4 }.ToAsyncEnumerable().Distinct();
 
-            var res = new[] { 1, 2, 3, 5, 4 };
-            Assert.True(res.SequenceEqual(await xs.ToArrayAsync()));
+            var expected = new[] { 1, 2, 3, 5, 4 };
+            var actual = await xs.ToArrayAsync();
+            Assert.True(expected.SequenceEqual(actual));
         }
 
         [Fact]

--- a/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/OrderBy.Generated.cs
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System/Linq/Operators/OrderBy.Generated.cs
@@ -7498,8 +7498,10 @@ namespace Tests
         private async Task AssertSorted<T>(IAsyncEnumerable<T> asyncRes, IEnumerable<T> syncRes)
         {
             Assert.True(await syncRes.ToAsyncEnumerable().SequenceEqualAsync(asyncRes));
-            Assert.True(syncRes.ToList().SequenceEqual(await asyncRes.ToListAsync()));
-            Assert.True(syncRes.ToArray().SequenceEqual(await asyncRes.ToArrayAsync()));
+            var toListResult = await asyncRes.ToListAsync();
+            Assert.True(syncRes.ToList().SequenceEqual(toListResult));
+            var toArrayResult = await asyncRes.ToArrayAsync();
+            Assert.True(syncRes.ToArray().SequenceEqual(toArrayResult));
 
             int syncCount = syncRes.Count();
             int asyncCount = await asyncRes.CountAsync();

--- a/azure-pipelines.ix.yml
+++ b/azure-pipelines.ix.yml
@@ -49,7 +49,7 @@ stages:
         arguments: install --tool-path . nbgv
       displayName: Install NBGV tool
 
-    - script: ./nbgv cloud -p Ix.NET/Source
+    - script: nbgv cloud -a -p Ix.NET/Source
       displayName: Set Version
 
     - task: DotNetCoreCLI@2

--- a/azure-pipelines.ix.yml
+++ b/azure-pipelines.ix.yml
@@ -29,7 +29,7 @@ stages:
   jobs:
   - job: Build
     pool:
-      vmImage: ubuntu-latest
+      vmImage: windows-latest
     steps:
     - task: UseDotNet@2
       displayName: Use .NET Core 8.x SDK
@@ -40,12 +40,6 @@ stages:
       displayName: .NET 6.0 runtime
       inputs:
         version: '6.x'
-        packageType: runtime
-
-    - task: UseDotNet@2
-      displayName: .NET Core 3.1 runtime
-      inputs:
-        version: '3.1.x'
         packageType: runtime
 
     - task: DotNetCoreCLI@2

--- a/azure-pipelines.ix.yml
+++ b/azure-pipelines.ix.yml
@@ -91,7 +91,7 @@ stages:
         arguments: -c $(BuildConfiguration) --settings Ix.NET/Source/CodeCoverage.runsettings --collect:"XPlat Code Coverage" -- RunConfiguration.DisableAppDomain=true
       displayName: Run Tests
 
-    - script: ./reportgenerator -reports:$(Agent.TempDirectory)/**/coverage.cobertura.xml -targetdir:$(Build.SourcesDirectory)/Ix.NET/Source/coverlet/reports -reporttypes:"Cobertura"
+    - script: reportgenerator -reports:$(Agent.TempDirectory)/**/coverage.cobertura.xml -targetdir:$(Build.SourcesDirectory)/Ix.NET/Source/coverlet/reports -reporttypes:"Cobertura"
       displayName: Create reports
 
     - task: PublishCodeCoverageResults@1


### PR DESCRIPTION
Azure DevOps Hosted Build Agents now run Ubuntu 24. One consequence is that mono is no longer available on the build agents—it is not supported on Ubuntu 24.

The Ix pipeline had been running on Ubuntu, which meant that the unit tests targetting .NET FX relied on mono. We can't do that any more. This PR changes the build agent back to Windows, so we can continue to test on .NET FX.

Also, the tests were crashing on .NET Core 3.1. That runtime has been out of support for a long time, but we had continued to use it as it was the only way to test our `netstandard2.1` support. I've had to disable this, so for now we don't execute tests against the `netstandard2.1` builds. It's possible that there's no longer any reason to offer this target, so we might need to remove that in the future.

There's one more fix in this PR: the C# compiler seems to have tightened up its handling of left-to-right execution order in SDK 9.0.300, with the result that the project no longer built in the current version of Visual Studio. I think this is technically fixing a bug in the compiler, but it meant that some cases where we do code of this kind:

```cs
someArray.SequenceEquals(await GetSomeOtherArrayAsync());
```
 
now fail because of a combination of factors:

1. that `SequenceEquals` used to resolve to an `IEnumerable<T>` extension method, and still does on .NET FX, but on .NET it now resolves to an extension method on `ReadOnlySpan<T>` instead.
2. the implicit conversion from array to `ReadOnlySpan<T>` now happens before the `await` (which apparently didn't happen in older compilers) which means we're now asking the compiler to make a span survive across an `await`, which is not supported

So I had to change some tests to get it building again.