### PR TITLE
Fix RefCount bugs

### DIFF
--- a/Rx.NET/Documentation/ReleaseHistory/Rx.v6.md
+++ b/Rx.NET/Documentation/ReleaseHistory/Rx.v6.md
@@ -1,5 +1,15 @@
 # Rx Release History v6.0
 
+## v6.0.2
+
+This release fixes:
+
+* [Issue #2173: "RefCount with MinObservers > 1 Behaves Unexpectedly"](https://github.com/dotnet/reactive/issues/2173)
+* [Issue #2214: "RefCount with disconnect delay and minObservers throws InvalidOperationException when resubscribing to synchronously completing source"](https://github.com/dotnet/reactive/issues/2214)
+* [Issue #2215: "RefCount with disconnect delay and minObservers disconnects prematurely if observer count drops to zero and then goes back up"](https://github.com/dotnet/reactive/issues/2215)
+
+Note: the test suite now tests on .NET 9.0. No changes were required as a result of this.
+
 ## v6.0.1
 
 This release fixes:

--- a/Rx.NET/Integration/LinuxTests/LinuxTests.csproj
+++ b/Rx.NET/Integration/LinuxTests/LinuxTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net8.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Tests.System.Reactive</AssemblyName>
@@ -12,7 +12,7 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <DefineConstants>$(DefineConstants);</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0' or '$(TargetFramework)' == 'net8.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0'">
     <DefineConstants>$(DefineConstants);LINUX</DefineConstants>
   </PropertyGroup>
 
@@ -28,8 +28,8 @@
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <PackageReference Include="xunit.assert" Version="2.4.2" />
-    <PackageReference Include="System.Reactive" Version="6.0.0-preview*" />
-    <PackageReference Include="Microsoft.Reactive.Testing" Version="6.0.0-preview*" />
-    <PackageReference Include="System.Reactive.Observable.Aliases" Version="6.0.0-preview*" />
+    <PackageReference Include="System.Reactive" Version="6.0.2-preview*" />
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="6.0.2-preview*" />
+    <PackageReference Include="System.Reactive.Observable.Aliases" Version="6.0.2-preview*" />
   </ItemGroup>
 </Project>

--- a/Rx.NET/Integration/LinuxTests/LinuxTests.csproj
+++ b/Rx.NET/Integration/LinuxTests/LinuxTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Tests.System.Reactive</AssemblyName>

--- a/Rx.NET/Integration/WindowsDesktopTests/WindowsDesktopTests.csproj
+++ b/Rx.NET/Integration/WindowsDesktopTests/WindowsDesktopTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net6.0-windows10.0.19041;net7.0;net7.0-windows10.0.19041;net8.0;net8.0-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>net8.0;net8.0-windows10.0.19041;net9.0;net9.0-windows10.0.19041</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Tests.System.Reactive</AssemblyName>
@@ -9,7 +9,7 @@
     <AssemblyOriginatorKeyFile>..\..\Source\ReactiveX.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('net6.0-windows')) or $(TargetFramework.StartsWith('net7.0-windows')) or $(TargetFramework.StartsWith('net8.0-windows'))">
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('net8.0-windows')) or $(TargetFramework.StartsWith('net9.0-windows'))">
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <DefineConstants>$(DefineConstants);HAS_TRACE;HAS_WINRT;PREFER_ASYNC;HAS_TPL46;NO_REMOTING;HAS_WINFORMS;HAS_WPF;HAS_DISPATCHER;DESKTOPCLR;WINDOWS;CSWINRT</DefineConstants>
@@ -27,8 +27,8 @@
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <PackageReference Include="xunit.assert" Version="2.4.2" />
-    <PackageReference Include="System.Reactive" Version="6.0.0-preview*" />
-    <PackageReference Include="Microsoft.Reactive.Testing" Version="6.0.0-preview*" />
-    <PackageReference Include="System.Reactive.Observable.Aliases" Version="6.0.0-preview*" />
+    <PackageReference Include="System.Reactive" Version="6.0.2-preview*" />
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="6.0.2-preview*" />
+    <PackageReference Include="System.Reactive.Observable.Aliases" Version="6.0.2-preview*" />
   </ItemGroup>
 </Project>

--- a/Rx.NET/Integration/global.json
+++ b/Rx.NET/Integration/global.json
@@ -1,5 +1,0 @@
-{
-  "msbuild-sdks": {
-    "MSBuild.Sdk.Extras": "2.1.2"
-  }
-}

--- a/Rx.NET/Source/Directory.build.props
+++ b/Rx.NET/Source/Directory.build.props
@@ -70,6 +70,9 @@
 
     <DefineConstants>$(DefineConstants);WINDOWS_UWP</DefineConstants>
 
+    <!-- At some point, it looks like a fully-qualified version number stopped resolving the TargetPlatformSdkPath
+         and now it only works with 10.0, so the SDK no longer sets this for us in UAP targets. -->
+    <TargetPlatformSdkPath Condition="'$(TargetPlatformSdkPath)' == ''">$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPlatformSDKLocation('Windows', '10.0'))</TargetPlatformSdkPath>
   </PropertyGroup>
 
 

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/RefCount.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/RefCount.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT License.
 // See the LICENSE file in the project root for more information. 
 
+using System.Diagnostics;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Subjects;
@@ -138,15 +139,78 @@ namespace System.Reactive.Linq.ObservableImpl
 
         internal sealed class Lazy : Producer<TSource, Lazy._>
         {
+            // This operator's state transitions are easily misunderstood, as bugs #2214 and #2215
+            // testify. In particular, there are tricky cases around
+            //  * a transition to 0 subscribers followed by the arrival of a new subscriber before
+            //      the disconnect delay elapses
+            //  * sources that complete before returning from Connect
+            //  * sources that produce notifications without waiting for Connect (especially if
+            //      they call OnComplete before returning from Subscribe)
+            //
+            // This is further complicated by the need to handle multithreading. Although Rx
+            // requires notifications to an individual observer to be sequential, there are two
+            // reasons concurrency may occur:
+            //  * each subscription to RefCount causes a subscription to the underlying source.
+            //      (RefCount only aggregates the calls to Connect. In the common usage of the
+            //      form source.Publish().RefCount(), these subscriptions all go to a single
+            //      subject, so there won't be concurrent source notifications in practice. But
+            //      RefCount works with any IConnectableObservable<T>, and in general, connectable
+            //      observables are not required to synchronize notifications across all
+            //      subscribers for a particular connection. Since RefCount needs to detect when
+            //      sources complete by themselves, it needs to be able to handle concurrent
+            //      completions.)
+            // * new Subscribe calls to RefCount could happen concurrently with notifications
+            //      emerging for existing subscriptions, or concurrently with other calls to
+            //      Subscribe. (Strictly speaking, we've never promised that the latter will work.
+            //      The documentation does not tell you that it's OK for multiple threads to make
+            //      concurrent calls to Subscribe on a single RefCount. However, historically we
+            //      have always guarded against such calls, so for backwards compatibility we must
+            //      continue to do so.)
+            //
+            // Each call to RefCount(disconnectDelay: ts) creates a single instance of this Lazy
+            // class. When we get one instance of the nested Lazy._ sink for each subscriber.
+            // The outer Lazy class will be in one of these states:
+            //
+            // * Disconnected with 0 subscribers (the initial state, and also the state we return
+            //      to after the subscriber count drops to zero, and the disconnect delay elapses
+            //      without further subscriptions being added)
+            // * Disconnected with 0 < subscribers < minObservers (the state we enter when we get
+            //      our first subscriber and minObservers is >= 2).
+            // * Connected with at least one subscriber
+            // * Connected with 0 subscribers (in which we are typically waiting for the disconnect
+            //      delay to elapse, but we can also return to the preceding state if new
+            //      subscriptions come in before that delay completes)
+            //
+            // Where it gets tricky is the transitions between these states. Although we can use
+            // lock to protect against concurrency, re-entrancy causes problems: when we call
+            // Subscribe or Connect, those can complete their subscribers (including ones already
+            // set up, and the one we're trying to set up when calling Subscribe or Connect).
+            // So even though we may hold a lock to protect the operator's state, calling these
+            // methods can cause completion to occur, and the completion logic may try to acquire
+            // the same lock. It will succeed (because re-entrant lock acquisition is supported,
+            // because the alternative is deadlock or failure) and so we end up with a block of
+            // code owning a lock and modifying data protected by that lock right in the middle of
+            // the execution of another block of code that also owns that same lock.
+            // So we typically want to avoid any calls that could trigger such re-entrancy while
+            // updating shared state.
             private readonly object _gate;
             private readonly IScheduler _scheduler;
             private readonly TimeSpan _disconnectTime;
             private readonly IConnectableObservable<TSource> _source;
             private readonly int _minObservers;
 
+            private State _state;
             private IDisposable? _serial;
             private int _count;
             private IDisposable? _connectableSubscription;
+
+            private enum State
+            {
+                DisconnectedNoSubscribers,
+                DisconnectedWithSubscribers,
+                ConnectedWithSubscribers,
+                ConnectedWithNoSubscribers
+            }
 
             public Lazy(IConnectableObservable<TSource> source, TimeSpan disconnectTime, IScheduler scheduler, int minObservers)
             {
@@ -155,6 +219,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 _disconnectTime = disconnectTime;
                 _scheduler = scheduler;
                 _minObservers = minObservers;
+                _state = State.DisconnectedNoSubscribers;
             }
 
             protected override _ CreateSink(IObserver<TSource> observer) => new(observer);
@@ -170,14 +235,59 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public void Run(Lazy parent)
                 {
+                    // The source might complete synchronously, so it's possible that we might be
+                    // in a Disposed state for the remainder of the method. This is expected, but
+                    // anyone planning to modify this code needs to bear that in mind.
                     var subscription = parent._source.SubscribeSafe(this);
 
                     lock (parent._gate)
                     {
-                        if (++parent._count == parent._minObservers)
+                        int observerCount = ++parent._count;
+                        bool shouldConnect = false;
+                        bool shouldCancelDelayedDisconnect = false;
+                        switch (parent._state)
                         {
-                            parent._connectableSubscription ??= parent._source.Connect();
+                            case State.DisconnectedNoSubscribers:
+                            case State.DisconnectedWithSubscribers:
+                                Debug.Assert(observerCount <= parent._minObservers, "RefCount should never exceed minObservers without already having connected");
+                                shouldConnect = observerCount == parent._minObservers;
+                                parent._state = shouldConnect ? State.ConnectedWithSubscribers : State.DisconnectedWithSubscribers;
+                                break;
 
+                            case State.ConnectedWithNoSubscribers:
+                                shouldCancelDelayedDisconnect = true;
+                                parent._state = State.ConnectedWithSubscribers;
+                                break;
+                        }
+
+                        if (shouldConnect)
+                        {
+                            Debug.Assert(parent._connectableSubscription is null, "RefCount already connected when it should not be");
+                            parent._connectableSubscription = parent._source.Connect();
+
+                            // That call to Connect can cause the underlying source to complete. If
+                            // there were already subscribers (e.g., we have minObservers > 1, and
+                            // this latest subscription is the one that hit the minObserver
+                            // threshold), those would be completed inside this call, meaning that
+                            // the Disposable.Create callbacks they set as their upstreams will
+                            // run. That callback (see later in this method) acquires the same
+                            // _gate lock that we currently hold, so we need to be aware that
+                            // our fields could change during this call even though we own the lock.
+                            //
+                            // That said, it shouldn't change _state: those callbacks will only
+                            // disconnect if the observer count drops to zero, and since that count
+                            // includes the subscription currently being established, for which
+                            // we've not yet registered the upstream disposable, there should still
+                            // be at least one subscriber right now.
+                            Debug.Assert(parent._state == State.ConnectedWithSubscribers, "Unexpected state change in Connect");
+                        }
+
+                        if (shouldConnect || shouldCancelDelayedDisconnect)
+                        {
+                            // If a delayed disconnect work item has been scheduled, it will already be in
+                            // _serial, so this will cancel it. In any case, this ensures that an unused
+                            // SingleAssignmentDisposable is available for the upstream disposal callback
+                            // to use when it needs to set up the delayed disconnect work item.
                             Disposable.TrySetSerial(ref parent._serial, new SingleAssignmentDisposable());
                         }
                     }
@@ -194,21 +304,42 @@ namespace System.Reactive.Linq.ObservableImpl
                             {
                                 if (--closureParent._count == 0)
                                 {
-                                    // NB: _serial is guaranteed to be set by TrySetSerial earlier on.
-                                    var cancelable = (SingleAssignmentDisposable)Volatile.Read(ref closureParent._serial)!;
-
-                                    cancelable.Disposable = closureParent._scheduler.ScheduleAction((cancelable, closureParent), closureParent._disconnectTime, static tuple2 =>
+                                    // It's possible for the count to reach 0 without ever having gone above the
+                                    // minObservers threshold, in which case we won't ever have called Connect.
+                                    // More subtly, when sources call OnComplete inside Subscribe, it's possible for
+                                    // this Disposable callback to run *inside* the call to Connect above.
+                                    // So we only want to schedule the disconnection work item if we have already
+                                    // connected.
+                                    if (closureParent._state == State.ConnectedWithSubscribers)
                                     {
-                                        lock (tuple2.closureParent._gate)
+                                        closureParent._state = State.ConnectedWithNoSubscribers;
+
+                                        // NB: _serial is guaranteed to be set by TrySetSerial earlier on.
+                                        var cancelable = (SingleAssignmentDisposable)Volatile.Read(ref closureParent._serial)!;
+
+                                        cancelable.Disposable = closureParent._scheduler.ScheduleAction((cancelable, closureParent), closureParent._disconnectTime, static tuple2 =>
                                         {
-                                            if (ReferenceEquals(Volatile.Read(ref tuple2.closureParent._serial), tuple2.cancelable))
+                                            lock (tuple2.closureParent._gate)
                                             {
-                                                // NB: _connectableSubscription is guaranteed to be set above, and Disposable.Create protects against double-dispose.
-                                                tuple2.closureParent._connectableSubscription!.Dispose();
-                                                tuple2.closureParent._connectableSubscription = null;
+                                                if (ReferenceEquals(Volatile.Read(ref tuple2.closureParent._serial), tuple2.cancelable))
+                                                {
+                                                    tuple2.closureParent._state = State.DisconnectedNoSubscribers;
+
+                                                    // NB: _connectableSubscription is guaranteed to be set above, and Disposable.Create protects against double-dispose.
+                                                    var connectableSubscription = tuple2.closureParent._connectableSubscription!;
+                                                    tuple2.closureParent._connectableSubscription = null;
+                                                    connectableSubscription.Dispose();
+                                                }
                                             }
-                                        }
-                                    });
+                                        });
+                                    }
+                                    else
+                                    {
+                                        // This callback should only run when we have at least one subscriber.
+                                        Debug.Assert(closureParent._state == State.DisconnectedWithSubscribers);
+
+                                        closureParent._state = State.DisconnectedNoSubscribers;
+                                    }
                                 }
                             }
                         }));

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/RefCount.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/RefCount.cs
@@ -201,7 +201,7 @@ namespace System.Reactive.Linq.ObservableImpl
             private IDisposable? _connectableSubscription;
 
             /// <summary>
-            /// Represents the <see cref="Lazy"/> instances state (shared across all subscriptions
+            /// Represents the <see cref="Lazy"/> instance's state (shared across all subscriptions
             /// to that instance).
             /// </summary>
             private enum State

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/RefCount.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/RefCount.cs
@@ -242,9 +242,9 @@ namespace System.Reactive.Linq.ObservableImpl
 
                     lock (parent._gate)
                     {
-                        int observerCount = ++parent._count;
-                        bool shouldConnect = false;
-                        bool shouldCancelDelayedDisconnect = false;
+                        var observerCount = ++parent._count;
+                        var shouldConnect = false;
+                        var shouldCancelDelayedDisconnect = false;
                         switch (parent._state)
                         {
                             case State.DisconnectedNoSubscribers:

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/RefCount.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/RefCount.cs
@@ -170,7 +170,7 @@ namespace System.Reactive.Linq.ObservableImpl
             //      continue to do so.)
             //
             // Each call to RefCount(disconnectDelay) creates a single instance of this Lazy class.
-            // Then we get one instance of the nested Lazy._ sink for each subscriber. The outer
+            // Then we get one instance of the nested Lazy._sink for each subscriber. The outer
             // Lazy class will be in one of the states described in the State enumeration.
             //
             // State transitions are tricky. Although we can use a lock to protect against

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/RefCount.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/RefCount.cs
@@ -72,8 +72,9 @@ namespace System.Reactive.Linq.ObservableImpl
                             _parent._connection = conn;
                         }
 
-                        // this is the first observer, then connect
-                        doConnect = ++conn._count == _parent._minObservers;
+                        // if this is the first time the observer count has reached the minimum
+                        // observer count since we last had no observers, then connect
+                        doConnect = ++conn._count == _parent._minObservers && conn._disposable.Disposable is null;
 
                         // save the current connection for this observer
                         _targetConnection = conn;

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests.System.Reactive.csproj
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests.System.Reactive.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;net8.0;net8.0-windows10.0.19041;net9.0;net9.0-windows10.0.19041</TargetFrameworks>
-    <NoWarn>$(NoWarn);CS0618</NoWarn>
+
+    <!-- IDE0330: Prefer 'System.Threading.Lock': not applicable for as long as we support .NET 8.0 or .NET FX, because it is unavailable on those targets. -->
+    <NoWarn>$(NoWarn);CS0618;IDE0330</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net8.0-windows')) or $(TargetFramework.StartsWith('net9.0-windows')) or '$(TargetFramework)' == 'net472'">

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/RefCountTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/RefCountTest.cs
@@ -553,5 +553,181 @@ namespace ReactiveTests.Tests
             Assert.Equal(expected, list1);
             Assert.Equal(expected, list2);
         }
+
+        [TestMethod]
+        public void RefCount_minObservers_remains_connected_below_threshold_Lazy()
+        {
+            var sourceAfterInitial = new Subject<int>();
+            var connected = 0;
+            var source = Observable.Defer(() =>
+            {
+                connected++;
+                return Observable.Range(1, 5).Concat(sourceAfterInitial);
+            })
+            .Publish()
+            .RefCount(2, TimeSpan.FromMinutes(1));
+
+
+            Assert.Equal(0, connected);
+
+            var list1 = new List<int>();
+            var sub1 = source.Subscribe(list1.Add);
+
+            Assert.Equal(0, connected);
+            Assert.Empty(list1);
+
+            var list2 = new List<int>();
+            var sub2 = source.Subscribe(list2.Add);
+
+            Assert.Equal(1, connected);
+
+            sourceAfterInitial.OnNext(6);
+
+            sub1.Dispose();
+            sourceAfterInitial.OnNext(7);
+
+            var expectedSub1 = new List<int>([1, 2, 3, 4, 5, 6]);
+            var expectedSub2 = new List<int>([1, 2, 3, 4, 5, 6, 7]);
+
+            Assert.Equal(expectedSub1, list1);
+            Assert.Equal(expectedSub2, list2);
+        }
+
+        [TestMethod]
+        public void RefCount_does_not_reconnect_when_minObservers_drops_below_threshold_then_goes_above_Lazy()
+        {
+            var sourceAfterInitial = new Subject<int>();
+            var connected = 0;
+            var source = Observable.Defer(() =>
+            {
+                connected++;
+                return Observable.Range(1, 5).Concat(sourceAfterInitial);
+            })
+            .Publish()
+            .RefCount(2, TimeSpan.FromMinutes(1));
+
+
+            Assert.Equal(0, connected);
+
+            var list1 = new List<int>();
+            var sub1 = source.Subscribe(list1.Add);
+
+            Assert.Equal(0, connected);
+            Assert.Empty(list1);
+
+            var list2 = new List<int>();
+            var sub2 = source.Subscribe(list2.Add);
+
+            Assert.Equal(1, connected);
+
+            sourceAfterInitial.OnNext(6);
+
+            sub1.Dispose();
+            sourceAfterInitial.OnNext(7);
+
+            Assert.Equal(1, connected);
+
+            var list3 = new List<int>();
+            var sub3 = source.Subscribe(list3.Add);
+
+            Assert.Equal(1, connected);
+            sourceAfterInitial.OnNext(8);
+
+            var expectedSub1 = new List<int>([1, 2, 3, 4, 5, 6]);
+            var expectedSub2 = new List<int>([1, 2, 3, 4, 5, 6, 7, 8]);
+            var expectedSub3 = new List<int>([8]);
+
+            Assert.Equal(expectedSub1, list1);
+            Assert.Equal(expectedSub2, list2);
+            Assert.Equal(expectedSub3, list3);
+        }
+
+        [TestMethod]
+        public void RefCount_minObservers_remains_connected_below_threshold_Eager()
+        {
+            var sourceAfterInitial = new Subject<int>();
+            var connected = 0;
+            var source = Observable.Defer(() =>
+            {
+                connected++;
+                return Observable.Range(1, 5).Concat(sourceAfterInitial);
+            })
+            .Publish()
+            .RefCount(2);
+
+
+            Assert.Equal(0, connected);
+
+            var list1 = new List<int>();
+            var sub1 = source.Subscribe(list1.Add);
+
+            Assert.Equal(0, connected);
+            Assert.Empty(list1);
+
+            var list2 = new List<int>();
+            var sub2 = source.Subscribe(list2.Add);
+
+            Assert.Equal(1, connected);
+
+            sourceAfterInitial.OnNext(6);
+
+            sub1.Dispose();
+            sourceAfterInitial.OnNext(7);
+
+            var expectedSub1 = new List<int>([1, 2, 3, 4, 5, 6]);
+            var expectedSub2 = new List<int>([1, 2, 3, 4, 5, 6, 7]);
+
+            Assert.Equal(expectedSub1, list1);
+            Assert.Equal(expectedSub2, list2);
+        }
+
+        [TestMethod]
+        public void RefCount_does_not_reconnect_when_minObservers_drops_below_threshold_then_goes_above_Eager()
+        {
+            var sourceAfterInitial = new Subject<int>();
+            var connected = 0;
+            var source = Observable.Defer(() =>
+            {
+                connected++;
+                return Observable.Range(1, 5).Concat(sourceAfterInitial);
+            })
+            .Publish()
+            .RefCount(2);
+
+
+            Assert.Equal(0, connected);
+
+            var list1 = new List<int>();
+            var sub1 = source.Subscribe(list1.Add);
+
+            Assert.Equal(0, connected);
+            Assert.Empty(list1);
+
+            var list2 = new List<int>();
+            var sub2 = source.Subscribe(list2.Add);
+
+            Assert.Equal(1, connected);
+
+            sourceAfterInitial.OnNext(6);
+
+            sub1.Dispose();
+            sourceAfterInitial.OnNext(7);
+
+            Assert.Equal(1, connected);
+
+            var list3 = new List<int>();
+            var sub3 = source.Subscribe(list3.Add);
+
+            Assert.Equal(1, connected);
+            sourceAfterInitial.OnNext(8);
+
+            var expectedSub1 = new List<int>([1, 2, 3, 4, 5, 6]);
+            var expectedSub2 = new List<int>([1, 2, 3, 4, 5, 6, 7, 8]);
+            var expectedSub3 = new List<int>([8]);
+
+            Assert.Equal(expectedSub1, list1);
+            Assert.Equal(expectedSub2, list2);
+            Assert.Equal(expectedSub3, list3);
+        }
     }
 }

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/RefCountTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/RefCountTest.cs
@@ -19,28 +19,204 @@ namespace ReactiveTests.Tests
     [TestClass]
     public class RefCountTest : ReactiveTest
     {
-        private sealed class DematerializingConnectableObservable<T> : IConnectableObservable<T>
+        /// <summary>
+        /// A connectable observable that provides an individual notification upon connection, where
+        /// the notification can be different from one connection to the next.
+        /// </summary>
+        /// <typeparam name="T">Element type.</typeparam>
+        /// <remarks>
+        /// <para>
+        /// The most important capability this provides is to be able to provide values after
+        /// having completed. Obviously it won't do that for any single subscription because that
+        /// would break the basic Rx contract, but this can deliver completion to some subscribers,
+        /// and then go on to deliver values to subsequent subscribers. (The connectable
+        /// observables returned by <c>Publish</c> can't do this: once their subject has delivered
+        /// a completion notification it can't deliver anything else, not even to new subscribers.
+        /// That's why we need a specialized type.)
+        /// </para>
+        /// </remarks>
+        private sealed class SerialSingleNotificationConnectable<T> : IConnectableObservable<T>
         {
-            private readonly IConnectableObservable<Notification<T>> _subject;
+            private readonly object _gate = new();
+            private Notification<T> _notificationAtNextConnect;
+            private Subject<T> _sourceForNextConnect = new();
+            private Connection _nextConnectionInProgress;
 
-            public DematerializingConnectableObservable(IConnectableObservable<Notification<T>> subject)
+            public SerialSingleNotificationConnectable(Notification<T> initialNotificationAtNextConnect)
             {
-                _subject = subject;
+                _notificationAtNextConnect = initialNotificationAtNextConnect;
+                _nextConnectionInProgress = new(_sourceForNextConnect);
             }
 
-            public IDisposable Subscribe(IObserver<T> observer)
+            public List<Connection> Connections { get; } = new();
+
+            private Connection ActiveConnection => (Connections.Count > 0 &&
+                Connections[Connections.Count - 1] is Connection { Disposed: false } activeConnection)
+                ? activeConnection : null;
+
+            private Connection CurrentConnection => ActiveConnection ?? _nextConnectionInProgress;
+
+            public void SetNotificationForNextConnect(Notification<T> notification)
             {
-                return _subject.Dematerialize().Subscribe(observer);
+                _notificationAtNextConnect = notification;
+            }
+
+            public void DeliverNotificationForActiveConnection(Notification<T> notification)
+            {
+                if (ActiveConnection is not Connection activeConnection)
+                {
+                    throw new InvalidOperationException("No connection is currently active");
+                }
+
+                if (activeConnection.Source is not Subject<T> source)
+                {
+                    throw new InvalidOperationException("Active connection's source has been replaced and is no longer a Subject<T>, so it is not possible to deliver further notifications to current subscribers");
+                }
+
+                notification.Accept(source);
             }
 
             public IDisposable Connect()
             {
-                return _subject.Connect();
+                Connection connecting;
+                Notification<T> notification;
+                Subject<T> source;
+                lock (_gate)
+                {
+                    connecting = _nextConnectionInProgress;
+                    notification = _notificationAtNextConnect;
+                    source = _sourceForNextConnect;
+
+                    _sourceForNextConnect = new Subject<T>();
+                    _nextConnectionInProgress = new(_sourceForNextConnect);
+                    Connections.Add(connecting);
+                }
+
+                notification.Accept(source);
+
+                return connecting;
+            }
+
+            public IDisposable Subscribe(IObserver<T> observer)
+            {
+                Connection connection;
+                lock (_gate)
+                {
+                    connection = CurrentConnection;
+                }
+
+                return connection.Source.Subscribe(observer);
+            }
+
+            public class Connection(IObservable<T> source) : IDisposable
+            {
+                /// <summary>
+                /// Gets a value indicating whether this connection has been disposed.
+                /// </summary>
+                public bool Disposed { get; private set; }
+
+                public IObservable<T> Source { get; private set; } = source;
+
+                /// <summary>
+                /// In scenarios where <see cref="Source"/> has entered a completed state, this
+                /// replaces it with a new source so if further subscribers to the same connection
+                /// come along, tests can deliver notifications to those.
+                /// </summary>
+                /// <remarks>
+                /// Without this method, <see cref="SerialSingleNotificationConnectable{T}"/> will
+                /// deliver events only when <see cref="Connect"/> is called, meaning that only
+                /// observers that subscribed before that call will receive any notifications
+                /// (unless the notification was <c>OnComplete</c>, in which case the subject
+                /// enters a completed state, and completes all further subscribers). This enables
+                /// tests to create scenarios where subscriptions made after <c>Connect</c> (and
+                /// before that connection is disposed) can receive further notifications.
+                /// </remarks>
+                public void ReplaceSource(IObservable<T> source)
+                {
+                    Source = source;
+                }
+                public void Dispose()
+                {
+                    Disposed = true;
+                    //connection.Dispose();
+                }
             }
         }
 
+        /// <summary>
+        /// A connectable observable that logs calls to <see cref="Connect"/> but otherwise ignores
+        /// them, forwarding <see cref="Subscribe"/> calls to the current underlying source (which
+        /// can be changed over time).
+        /// </summary>
+        /// <typeparam name="T">Element type.</typeparam>
+        /// <remarks>
+        /// <para>
+        /// This is similar to <see cref="SerialSingleNotificationConnectable{T}"/>, in that the
+        /// underlying source can be changed over time, making it possible for this to complete
+        /// observers, but then revert to a state where subsequent observers will not be completed.
+        /// But this also enables simulation of unusual (but not strictly disallowed) behaviour,
+        /// in which subscribers will receive notifications before calling <see cref="Connect"/>.
+        /// It's useful to be able to do this because it can happen in more normal setups when
+        /// sources completed synchronously, and it's easy to handle this incorrectly.
+        /// </para>
+        /// </remarks>
+        private sealed class SerialConnectableIgnoringConnect<T> : IConnectableObservable<T>
+        {
+            private IObservable<T> _source;
+
+            public SerialConnectableIgnoringConnect(IObservable<T> initialSource)
+            {
+                //_sourcePublished = initialSource.Publish();
+                _source = initialSource;
+            }
+
+            public void SetSource(IObservable<T> source)
+            {
+                //_sourcePublished = source.Publish();
+                _source = source;
+            }
+
+            public List<Connection> Connections { get; } = new();
+
+            public IDisposable Connect()
+            {
+                //var connection = new Connection(_sourcePublished.Connect());
+                var connection = new Connection();
+                Connections.Add(connection);
+                return connection;
+            }
+
+            public IDisposable Subscribe(IObserver<T> observer)
+            {
+                //return _sourcePublished.Subscribe(observer);
+                return _source.Subscribe(observer);
+            }
+
+            //public class Connection(IDisposable connection) : IDisposable
+            public class Connection() : IDisposable
+            {
+                /// <summary>
+                /// Gets a value indicating whether this connection has been disposed.
+                /// </summary>
+                public bool Disposed { get; private set; }
+
+                /////// <summary>
+                /////// Gets the source that was the <see cref="CurrentSource"/> when <see cref="Connect"/> was called.
+                /////// </summary>
+                ////public IObservable<T> Source { get; } = source;
+
+                public void Dispose()
+                {
+                    Disposed = true;
+                    //connection.Dispose();
+                }
+            }
+        }
+
+        #region Immediate Disconnect
+
         [TestMethod]
-        public void RefCount_ArgumentChecking()
+        public void RefCount_NoDelay_ArgumentChecking()
         {
             ReactiveAssert.Throws<ArgumentNullException>(() => Observable.RefCount<int>(null));
             ReactiveAssert.Throws<ArgumentNullException>(() => Observable.RefCount<int>(null, 2));
@@ -50,7 +226,7 @@ namespace ReactiveTests.Tests
         }
 
         [TestMethod]
-        public void RefCount_ConnectsOnFirst()
+        public void RefCount_NoDelay_ConnectsOnFirst()
         {
             var scheduler = new TestScheduler();
 
@@ -82,7 +258,181 @@ namespace ReactiveTests.Tests
         }
 
         [TestMethod]
-        public void RefCount_NotConnected()
+        public void RefCount_NoDelay_minObservers_ConnectsOnObserverThresholdReached()
+        {
+            var scheduler = new TestScheduler();
+
+            var xs = scheduler.CreateHotObservable(
+                OnNext(210, 1),
+                OnNext(220, 2),
+                OnNext(230, 3),
+                OnNext(240, 4),
+                OnCompleted<int>(250)
+            );
+
+            var subject = new MySubject();
+            var conn = new ConnectableObservable<int>(xs, subject);
+            var res = conn.RefCount(2);
+
+            var d1 = default(IDisposable);
+            var o1 = scheduler.CreateObserver<int>();
+            scheduler.ScheduleAbsolute(210, () => { d1 = res.Subscribe(o1); });
+
+            var d2 = default(IDisposable);
+            var o2 = scheduler.CreateObserver<int>();
+            scheduler.ScheduleAbsolute(225, () => { d2 = res.Subscribe(o2); });
+
+            scheduler.Start();
+
+            o1.Messages.AssertEqual(
+                OnNext(230, 3),
+                OnNext(240, 4),
+                OnCompleted<int>(250)
+            );
+
+            Assert.True(subject.Disposed);
+        }
+
+        [TestMethod]
+        public void RefCount_NoDelay_SourceProducesValuesAndCompletesInSubscribe()
+        {
+            var connected = 0;
+            var source = Observable.Defer(() =>
+            {
+                connected++;
+                return Observable.Range(1, 5);
+            })
+            .Publish()
+            .RefCount();
+
+            Assert.Equal(0, connected);
+
+            var list1 = new List<int>();
+            source.Subscribe(list1.Add);
+
+            Assert.Equal(1, connected);
+
+            List<int> expected1 = [1, 2, 3, 4, 5];
+
+            Assert.Equal(expected1, list1);
+
+            var list2 = new List<int>();
+            source.Subscribe(list2.Add);
+
+            Assert.Equal(1, connected);
+            Assert.Empty(list2);
+        }
+
+        [TestMethod]
+        public void RefCount_NoDelay_minObservers_SourceProducesValuesAndCompletesInSubscribe()
+        {
+            var connected = 0;
+            var source = Observable.Defer(() =>
+            {
+                connected++;
+                return Observable.Range(1, 5);
+            })
+            .Publish()
+            .RefCount(2);
+
+            Assert.Equal(0, connected);
+
+            var list1 = new List<int>();
+            source.Subscribe(list1.Add);
+
+            Assert.Equal(0, connected);
+            Assert.Empty(list1);
+
+            var list2 = new List<int>();
+            source.Subscribe(list2.Add);
+
+            Assert.Equal(1, connected);
+
+            List<int> expected = [1, 2, 3, 4, 5];
+
+            Assert.Equal(expected, list1);
+            Assert.Equal(expected, list2);
+        }
+
+        [TestMethod]
+        public void RefCount_NoDelay_SourceCompletesWithNoValuesInSubscribe()
+        {
+            var subscribed = 0;
+            var unsubscribed = 0;
+
+            var o1 = Observable.Create<string>(observer =>
+            {
+                subscribed++;
+                observer.OnCompleted();
+
+                return Disposable.Create(() => unsubscribed++);
+            });
+
+            var o2 = o1.Publish().RefCount();
+
+            var s1 = o2.Subscribe();
+            Assert.Equal(1, subscribed);
+            Assert.Equal(1, unsubscribed);
+
+            var s2 = o2.Subscribe();
+            Assert.Equal(1, subscribed);
+            Assert.Equal(1, unsubscribed);
+        }
+
+        [TestMethod]
+        public void RefCount_NoDelay_minObservers_SourceCompletesWithNoValuesInSubscribe()
+        {
+            var subscribed = 0;
+            var unsubscribed = 0;
+
+            var o1 = Observable.Create<string>(observer =>
+            {
+                subscribed++;
+                observer.OnCompleted();
+
+                return Disposable.Create(() => unsubscribed++);
+            });
+
+            var o2 = o1.Publish().RefCount(2);
+
+            var s1 = o2.Subscribe();
+            Assert.Equal(0, subscribed);
+            Assert.Equal(0, unsubscribed);
+
+            var s2 = o2.Subscribe();
+            Assert.Equal(1, subscribed);
+            Assert.Equal(1, unsubscribed);
+
+            s1.Dispose();
+            s2.Dispose();
+
+            // At this point, the RefCount has 0 subscribers, and will have disconnected from
+            // its source. When we add a new subscriber, the count will be at 0, which is below
+            // minObservers, so we don't expect a new connection. RefCount _will_ call Subscribe
+            // on its source, but that source is the Subject created by Publish(). And since
+            // o1 already delivered an OnComplete, that Subject is now in a completed state, so
+            // it will immediately complete any further subscriptions. RefCount sees this, so
+            // although the connection count briefly goes up to 1, it will then go back down to
+            // 0 before this call to Subscribe returns.
+            // Basically, because this test uses o1.Publish(), once our connectable source source
+            // completes is it incapable of restarting. That's why we have other tests that use
+            // SerialSingleNotificationConnectable - that enables us to build a source that resets
+            var s3 = o2.Subscribe();
+            Assert.Equal(1, subscribed);
+            Assert.Equal(1, unsubscribed);
+
+            // While it might look like adding a second subscriber should tip us back over the threshold
+            // and trigger a reconnect, for the reasons described above o2 immdiately completed in the
+            // last call to subscribe, so the RefCount is zero at this point. This is a limitation of
+            // Publish(). It doesn't really matter for this test, but it's why some tests use
+            // SerialSingleNotificationConnectable.
+            var s4 = o2.Subscribe();
+            Assert.Equal(1, subscribed);
+            Assert.Equal(1, unsubscribed);
+        }
+
+        [TestMethod]
+        public void RefCount_NoDelay_NotConnected()
         {
             var disconnected = false;
             var count = 0;
@@ -126,7 +476,26 @@ namespace ReactiveTests.Tests
         }
 
         [TestMethod]
-        public void RefCount_OnError()
+        public void RefCount_NoDelay_minObservers_NotConnected()
+        {
+            var connected = 0;
+            var source = Observable.Defer(() =>
+            {
+                connected++;
+                return Observable.Never<int>();
+            })
+            .Publish()
+            .RefCount(2);
+
+            Assert.Equal(0, connected);
+
+            source.Subscribe();
+
+            Assert.Equal(0, connected);
+        }
+
+        [TestMethod]
+        public void RefCount_NoDelay_OnError()
         {
             var ex = new Exception();
             var xs = Observable.Throw<int>(ex, Scheduler.Immediate);
@@ -138,7 +507,33 @@ namespace ReactiveTests.Tests
         }
 
         [TestMethod]
-        public void RefCount_Publish()
+        public void RefCount_NoDelay_minObservers_OnError()
+        {
+            var ex = new Exception();
+            var xs = Observable.Throw<int>(ex, Scheduler.Immediate);
+
+            var res = xs.Publish().RefCount(2);
+
+            var exceptionsReceived = new List<Exception>();
+            void AddSubscriber()
+            {
+                res.Subscribe(
+                    _ => { Assert.Fail("OnNext unexpected"); },
+                    ex_ => { exceptionsReceived.Add(ex); },
+                    () => { Assert.Fail("OnComplete unexpected"); });
+            }
+
+            AddSubscriber();
+            Assert.Equal(0, exceptionsReceived.Count);
+
+            AddSubscriber();
+            Assert.Equal(2, exceptionsReceived.Count);
+            Assert.Same(ex, exceptionsReceived[0]);
+            Assert.Same(ex, exceptionsReceived[1]);
+        }
+
+        [TestMethod]
+        public void RefCount_NoDelay_HotSourceMultipleSubscribers()
         {
             var scheduler = new TestScheduler();
 
@@ -208,16 +603,338 @@ namespace ReactiveTests.Tests
         }
 
         [TestMethod]
-        public void RefCount_can_connect_again_if_previous_subscription_terminated_synchronously()
+        public void RefCount_NoDelay_minObservers_HotSourceMultipleSubscribers()
+        {
+            var scheduler = new TestScheduler();
+
+            var xs = scheduler.CreateHotObservable(
+                OnNext(210, 1), // 0 subscribers
+                OnNext(220, 2), // 1 subscriber
+                OnNext(230, 3), // 2 subscribers
+                OnNext(240, 4), // 1 subscriber
+                OnNext(250, 5), // 1 subscriber
+                OnNext(260, 6), // 2 subscribers
+                OnNext(270, 7), // 1 subscribers
+                OnNext(280, 8), // 0 subscribers
+                OnNext(290, 9), // 1 subscribers
+                OnNext(300, 10), // 2 subscribers
+                OnCompleted<int>(310)
+            );
+
+            var res = xs.Publish().RefCount(2);
+
+            var d1 = default(IDisposable);
+            var o1 = scheduler.CreateObserver<int>();
+            scheduler.ScheduleAbsolute(215, () => { d1 = res.Subscribe(o1); });
+            scheduler.ScheduleAbsolute(235, () => { d1.Dispose(); });
+
+            var d2 = default(IDisposable);
+            var o2 = scheduler.CreateObserver<int>();
+            scheduler.ScheduleAbsolute(225, () => { d2 = res.Subscribe(o2); });
+            scheduler.ScheduleAbsolute(275, () => { d2.Dispose(); });
+
+            var d3 = default(IDisposable);
+            var o3 = scheduler.CreateObserver<int>();
+            scheduler.ScheduleAbsolute(255, () => { d3 = res.Subscribe(o3); });
+            scheduler.ScheduleAbsolute(265, () => { d3.Dispose(); });
+
+            var d4 = default(IDisposable);
+            var o4 = scheduler.CreateObserver<int>();
+            scheduler.ScheduleAbsolute(285, () => { d4 = res.Subscribe(o4); });
+            scheduler.ScheduleAbsolute(320, () => { d4.Dispose(); });
+
+            var d5 = default(IDisposable);
+            var o5 = scheduler.CreateObserver<int>();
+            scheduler.ScheduleAbsolute(295, () => { d5 = res.Subscribe(o5); });
+            scheduler.ScheduleAbsolute(320, () => { d5.Dispose(); });
+
+            scheduler.Start();
+
+            o1.Messages.AssertEqual(
+                OnNext(230, 3)
+            );
+
+            o2.Messages.AssertEqual(
+                OnNext(230, 3),
+                OnNext(240, 4),
+                OnNext(250, 5),
+                OnNext(260, 6),
+                OnNext(270, 7)
+            );
+
+            o3.Messages.AssertEqual(
+                OnNext(260, 6)
+            );
+
+
+            o4.Messages.AssertEqual(
+                OnNext(300, 10),
+                OnCompleted<int>(310)
+            );
+
+            o5.Messages.AssertEqual(
+                OnNext(300, 10),
+                OnCompleted<int>(310)
+            );
+
+            xs.Subscriptions.AssertEqual(
+                Subscribe(225, 275),
+                Subscribe(295, 310)
+            );
+        }
+
+        [TestMethod]
+        public void RefCount_NoDelay_minObservers_SubscriptionsDropBelowThresholdButNotToZero()
+        {
+            var subject = new ReplaySubject<int>(5);
+            var connected = 0;
+            var source = Observable.Defer(() =>
+                {
+                    connected++;
+                    return subject;
+                })
+                .Publish().RefCount(2);
+
+            subject.OnNext(1);
+
+            Assert.Equal(0, connected);
+
+            var list1 = new List<int>();
+            var sub1 = source.Subscribe(list1.Add);
+            Assert.Equal(0, connected);
+            Assert.Empty(list1);
+
+            subject.OnNext(2);
+
+            var list2 = new List<int>();
+            var sub2 = source.Subscribe(list2.Add);
+
+            // Since connection only occurred with the 2nd subscriber, we expect both to get everything
+            // the ReplaySubject has stored.
+            List<int> expectedSub1 = [1, 2];
+            var expectedSub2 = expectedSub1;
+
+            Assert.Equal(expectedSub1, list1);
+            Assert.Equal(expectedSub1, list2);
+            Assert.Equal(1, connected);
+
+            subject.OnNext(3);
+
+            // Both subscribers should have received the new item.
+            expectedSub1 = expectedSub2 = [1, 2, 3];
+            Assert.Equal(expectedSub1, list1);
+            Assert.Equal(expectedSub2, list2);
+            Assert.Equal(1, connected);
+
+            var list3 = new List<int>();
+            source.Subscribe(list3.Add);
+
+            // Since we were already connected, the 3rd subscriber just gets added to the observers of
+            // the Publish multicast output, and no new connection should occur to the underlying ReplaySubject.
+            // So for this 3rd subscription, no new items should be received by any of the subscribers
+            List<int> expectedSub3 = [];
+            Assert.Equal(expectedSub1, list1);
+            Assert.Equal(expectedSub2, list2);
+            Assert.Equal(expectedSub3, list3);
+            Assert.Equal(1, connected);
+
+            subject.OnNext(4);
+
+            // All the current subscribers should have received that latest item.
+            expectedSub1 = expectedSub2 = [1, 2, 3, 4];
+            expectedSub3 = [4];
+            Assert.Equal(expectedSub1, list1);
+            Assert.Equal(expectedSub2, list2);
+            Assert.Equal(expectedSub3, list3);
+            Assert.Equal(1, connected);
+
+            sub1.Dispose();
+
+            subject.OnNext(5);
+
+            // The two remaining subscribers should have received that new item, but the one that just
+            // unsubscribed should not.
+            expectedSub1 = [1, 2, 3, 4];
+            expectedSub2 = [1, 2, 3, 4, 5];
+            expectedSub3 = [4, 5];
+            Assert.Equal(expectedSub1, list1);
+            Assert.Equal(expectedSub2, list2);
+            Assert.Equal(expectedSub3, list3);
+            Assert.Equal(1, connected);
+
+            sub2.Dispose();
+
+            subject.OnNext(6);
+
+            // We are now below the minObservers threshold of 2, but that threshold only governs when we move
+            // from a disconnected state to a connected state. We should remain connected as long as there is
+            // at least one subscriber, so we expect the remaining subscriber to receive that last item.
+            expectedSub1 = [1, 2, 3, 4];
+            expectedSub2 = [1, 2, 3, 4, 5];
+            expectedSub3 = [4, 5, 6];
+            Assert.Equal(expectedSub1, list1);
+            Assert.Equal(expectedSub2, list2);
+            Assert.Equal(expectedSub3, list3);
+            Assert.Equal(1, connected);
+        }
+
+        [TestMethod]
+        public void RefCount_NoDelay_SubscriptionsDropBelowThresholdAndThenBackAbove()
+        {
+            var sourceAfterInitial = new Subject<int>();
+            var connected = 0;
+            var source = Observable.Defer(() =>
+            {
+                connected++;
+                return Observable.Range(1, 5).Concat(sourceAfterInitial);
+            })
+            .Publish()
+            .RefCount(2);
+
+
+            Assert.Equal(0, connected);
+
+            var list1 = new List<int>();
+            var sub1 = source.Subscribe(list1.Add);
+
+            Assert.Equal(0, connected);
+            Assert.Empty(list1);
+
+            var list2 = new List<int>();
+            var sub2 = source.Subscribe(list2.Add);
+
+            Assert.Equal(1, connected);
+
+            sourceAfterInitial.OnNext(6);
+
+            sub1.Dispose();
+            sourceAfterInitial.OnNext(7);
+
+            Assert.Equal(1, connected);
+
+            var list3 = new List<int>();
+            var sub3 = source.Subscribe(list3.Add);
+
+            // This is the distinguishing feature of this test. With that last subscription, we went from 1
+            // subscriber (below minObservers) but still connected (because we already hit minObservers once
+            // and never dropped to zero), and now we're passing through minObservers again. We used to have
+            // a bug where we would erroneously attempt to reconnect at this point.
+            Assert.Equal(1, connected);
+            sourceAfterInitial.OnNext(8);
+
+            var expectedSub1 = new List<int>([1, 2, 3, 4, 5, 6]);
+            var expectedSub2 = new List<int>([1, 2, 3, 4, 5, 6, 7, 8]);
+            var expectedSub3 = new List<int>([8]);
+
+            Assert.Equal(expectedSub1, list1);
+            Assert.Equal(expectedSub2, list2);
+            Assert.Equal(expectedSub3, list3);
+        }
+
+        [TestMethod]
+        public void RefCount_NoDelay_ValuesDuringAndAfterSubscribe()
+        {
+            var subject = new ReplaySubject<int>(5);
+            var source = subject.Publish().RefCount();
+
+            subject.OnNext(1);
+
+            // Although the source is a ReplaySubject, the use of Publish means there will only be
+            // a single subscription to the ReplaySubject, so it will only replay one. (It will replay
+            // that first value on the initial connect.) So we expect each subscriber to see fewer and
+            // fewer values.
+            // all subscribers will see all the values
+            List<int> expected1 = [1];
+
+            var list1 = new List<int>();
+            source.Subscribe(list1.Add);
+            Assert.Equal(expected1, list1);
+
+            subject.OnNext(2);
+
+            var list2 = new List<int>();
+            source.Subscribe(list2.Add);
+
+            expected1 = [1, 2];
+            List<int> expected2 = [];
+
+            Assert.Equal(expected1, list1);
+            Assert.Equal(expected2, list2);
+
+            subject.OnNext(3);
+
+            var list3 = new List<int>();
+            source.Subscribe(list3.Add);
+
+            expected1 = [1, 2, 3];
+            expected2 = [3];
+            List<int> expected3 = [];
+
+            Assert.Equal(expected1, list1);
+            Assert.Equal(expected2, list2);
+            Assert.Equal(expected3, list3);
+
+            subject.OnNext(4);
+            expected1 = [1, 2, 3, 4];
+            expected2 = [3, 4];
+            expected3 = [4];
+            Assert.Equal(expected1, list1);
+            Assert.Equal(expected2, list2);
+            Assert.Equal(expected3, list3);
+        }
+
+        [TestMethod]
+        public void RefCount_NoDelay_minObservers_ValuesDuringAndAfterSubscribe()
+        {
+            var subject = new ReplaySubject<int>(5);
+            var source = subject.Publish().RefCount(2);
+
+            subject.OnNext(1);
+
+            var list1 = new List<int>();
+            source.Subscribe(list1.Add);
+            Assert.Empty(list1);
+
+            subject.OnNext(2);
+
+            List<int> expected1and2 = [1, 2];
+
+            var list2 = new List<int>();
+            source.Subscribe(list2.Add);
+
+            Assert.Equal(expected1and2, list1);
+            Assert.Equal(expected1and2, list2);
+
+            subject.OnNext(3);
+            expected1and2 = [1, 2, 3];
+            Assert.Equal(expected1and2, list1);
+            Assert.Equal(expected1and2, list2);
+
+            var list3 = new List<int>();
+            source.Subscribe(list3.Add);
+
+            List<int> expected3 = [];
+            Assert.Equal(expected1and2, list1);
+            Assert.Equal(expected1and2, list2);
+            Assert.Equal(expected3, list3);
+
+            subject.OnNext(4);
+            expected1and2 = [1, 2, 3, 4];
+            expected3 = [4];
+            Assert.Equal(expected1and2, list1);
+            Assert.Equal(expected1and2, list2);
+            Assert.Equal(expected3, list3);
+        }
+
+        [TestMethod]
+        public void RefCount_NoDelay_CanConnectAgainIfPreviousSubscriptionTerminatedFromSubscribeByCompletion()
         {
             var seen = 0;
             var terminated = false;
 
-            var subject = new ReplaySubject<Notification<int>>(1);
-            var connectable = new DematerializingConnectableObservable<int>(subject.Publish());
+            // On initial subscription, the source will produce one value and will not complete.
+            var connectable = new SerialSingleNotificationConnectable<int>(Notification.CreateOnNext(36));
             var refCount = connectable.RefCount();
-
-            subject.OnNext(Notification.CreateOnNext(36));
 
             using (refCount.Subscribe(value => seen = value, () => terminated = true))
             {
@@ -226,7 +943,9 @@ namespace ReactiveTests.Tests
 
             seen = 0;
             terminated = false;
-            subject.OnNext(Notification.CreateOnCompleted<int>());
+
+            // This time around, the source will complete when subscribed to.
+            connectable.SetNotificationForNextConnect(Notification.CreateOnCompleted<int>());
 
             using (refCount.Subscribe(value => seen = value, () => terminated = true))
             {
@@ -236,17 +955,83 @@ namespace ReactiveTests.Tests
 
             seen = 0;
             terminated = false;
-            subject.OnNext(Notification.CreateOnNext(36));
+
+            // Now we go back to the initial behaviour in which the source produces one value and does not complete.
+            connectable.SetNotificationForNextConnect(Notification.CreateOnNext(42));
 
             using (refCount.Subscribe(value => seen = value, () => terminated = true))
             {
-                Assert.Equal(36, seen);
+                Assert.Equal(42, seen);
                 Assert.False(terminated);
             }
         }
-        
+
         [TestMethod]
-        public void LazyRefCount_ArgumentChecking()
+        public void RefCount_NoDelay_minObservers_CanConnectAgainIfPreviousSubscriptionTerminatedFromSubscribeByCompletion()
+        {
+            var seen1 = 0;
+            var seen2 = 0;
+            var terminated1 = false;
+            var terminated2 = false;
+
+            // On initial subscription, the source will produce one value and will not complete.
+            var connectable = new SerialSingleNotificationConnectable<int>(Notification.CreateOnNext(36));
+            var refCount = connectable.RefCount(2);
+
+            using (refCount.Subscribe(value => seen1 = value, () => terminated1 = true))
+            {
+                Assert.Equal(0, seen1);
+                using (refCount.Subscribe(value => seen2 = value, () => terminated2 = true))
+                {
+                    Assert.Equal(36, seen1);
+                    Assert.Equal(36, seen2);
+                }
+            }
+
+            seen1 = seen2 = 0;
+            terminated1 = terminated2 = false;
+
+            // This time around, the source will complete when subscribed to.
+            connectable.SetNotificationForNextConnect(Notification.CreateOnCompleted<int>());
+
+            using (refCount.Subscribe(value => seen1 = value, () => terminated1 = true))
+            {
+                Assert.False(terminated1);
+                Assert.False(terminated2);
+                using (refCount.Subscribe(value => seen2 = value, () => terminated2 = true))
+                {
+                    Assert.Equal(0, seen1);
+                    Assert.Equal(0, seen2);
+                    Assert.True(terminated1);
+                    Assert.True(terminated2);
+                }
+            }
+
+            seen1 = seen2 = 0;
+            terminated1 = terminated2 = false;
+
+            // Now we go back to the initial behaviour in which the source produces one value and does not complete.
+            connectable.Connections[1].ReplaceSource(new BehaviorSubject<int>(42));
+
+            using (refCount.Subscribe(value => seen1 = value, () => terminated1 = true))
+            {
+                Assert.Equal(0, seen1);
+                using (refCount.Subscribe(value => seen2 = value, () => terminated2 = true))
+                {
+                    Assert.Equal(42, seen1);
+                    Assert.Equal(42, seen2);
+                    Assert.False(terminated1);
+                    Assert.False(terminated2);
+                }
+            }
+        }
+
+        #endregion
+
+        #region Delayed Disconnect
+
+        [TestMethod]
+        public void RefCount_DelayedDisconnect_ArgumentChecking()
         {
             ReactiveAssert.Throws<ArgumentNullException>(() => Observable.RefCount<int>(null, TimeSpan.FromSeconds(2)));
             ReactiveAssert.Throws<ArgumentNullException>(() => Observable.RefCount<int>(null, TimeSpan.FromSeconds(2), Scheduler.Default));
@@ -261,7 +1046,7 @@ namespace ReactiveTests.Tests
         }
 
         [TestMethod]
-        public void LazyRefCount_ConnectsOnFirst()
+        public void RefCount_DelayedDisconnect_ConnectsOnFirst()
         {
             var scheduler = new TestScheduler();
 
@@ -293,7 +1078,155 @@ namespace ReactiveTests.Tests
         }
 
         [TestMethod]
-        public void LazyRefCount_NotConnected()
+        public void RefCount_DelayedDisconnect_minObservers_ConnectsOnObserverThresholdReached()
+        {
+            var scheduler = new TestScheduler();
+
+            var xs = scheduler.CreateHotObservable(
+                OnNext(210, 1),
+                OnNext(220, 2),
+                OnNext(230, 3),
+                OnNext(240, 4),
+                OnCompleted<int>(250)
+            );
+
+            var subject = new MySubject();
+            var conn = new ConnectableObservable<int>(xs, subject);
+            var res = conn.RefCount(2, TimeSpan.FromTicks(300));
+
+            var d1 = default(IDisposable);
+            var o1 = scheduler.CreateObserver<int>();
+            scheduler.ScheduleAbsolute(210, () => { d1 = res.Subscribe(o1); });
+
+            var d2 = default(IDisposable);
+            var o2 = scheduler.CreateObserver<int>();
+            scheduler.ScheduleAbsolute(225, () => { d2 = res.Subscribe(o2); });
+
+            scheduler.Start();
+
+            o1.Messages.AssertEqual(
+                OnNext(230, 3),
+                OnNext(240, 4),
+                OnCompleted<int>(250)
+            );
+
+            Assert.True(subject.Disposed);
+        }
+
+        [TestMethod]
+        public void RefCount_DelayedDisconnect_minObservers_SourceProducesValuesAndCompletesInSubscribe()
+        {
+            var connected = 0;
+            var source = Observable.Defer(() =>
+            {
+                connected++;
+                return Observable.Range(1, 5);
+            })
+            .Publish()
+            .RefCount(2, TimeSpan.FromMinutes(1));
+
+            Assert.Equal(0, connected);
+
+            var list1 = new List<int>();
+            source.Subscribe(list1.Add);
+
+            Assert.Equal(0, connected);
+            Assert.Empty(list1);
+
+            var list2 = new List<int>();
+            source.Subscribe(list2.Add);
+
+            Assert.Equal(1, connected);
+
+            var expected = new List<int>([1, 2, 3, 4, 5]);
+
+            Assert.Equal(expected, list1);
+            Assert.Equal(expected, list2);
+        }
+
+        [TestMethod]
+        public void RefCount_DelayedDisconnect_SourceCompletesWithNoValuesInSubscribe()
+        {
+            var subscribed = 0;
+            var unsubscribed = 0;
+
+            var o1 = Observable.Create<string>(observer =>
+            {
+                subscribed++;
+                observer.OnCompleted();
+
+                return Disposable.Create(() => unsubscribed++);
+            });
+
+            var o2 = o1.Publish().RefCount(TimeSpan.FromSeconds(20));
+
+            var s1 = o2.Subscribe();
+            Assert.Equal(1, subscribed);
+            Assert.Equal(1, unsubscribed);
+
+            var s2 = o2.Subscribe();
+            Assert.Equal(1, subscribed);
+            Assert.Equal(1, unsubscribed);
+        }
+
+        [TestMethod]
+        public void RefCount_DelayedDisconnect_minObservers_SourceCompletesWithNoValuesInSubscribe()
+        {
+            var scheduler = new TestScheduler();
+            var subscribed = 0;
+            var unsubscribed = 0;
+
+            var o1 = Observable.Create<string>(observer =>
+            {
+                subscribed++;
+                observer.OnCompleted();
+
+                return Disposable.Create(() => unsubscribed++);
+            });
+
+            var o2 = o1.Publish().RefCount(2, TimeSpan.FromTicks(10), scheduler);
+
+            var s1 = o2.Subscribe();
+            Assert.Equal(0, subscribed);
+            Assert.Equal(0, unsubscribed);
+
+            // Note that although we've got a delayed disconnect, we don't need to call AdvanceBy
+            // here because the source itself completes. The disconnect is triggered by the source,
+            // not the RefCount in this test.
+            var s2 = o2.Subscribe();
+            Assert.Equal(1, subscribed);
+            Assert.Equal(1, unsubscribed);
+
+            s1.Dispose();
+            s2.Dispose();
+
+            // At this point, the RefCount has 0 subscribers, and will have disconnected from
+            // its source. When we add a new subscriber, the count will be at 0, which is below
+            // minObservers, so we don't expect a new connection. RefCount _will_ call Subscribe
+            // on its source, but that source is the Subject created by Publish(). And since
+            // o1 already delivered an OnComplete, that Subject is now in a completed state, so
+            // it will immediately complete any further subscriptions. RefCount sees this, so
+            // although the connection count briefly goes up to 1, it will then go back down to
+            // 0 before this call to Subscribe returns.
+            // Basically, because this test uses o1.Publish(), once our connectable source source
+            // completes is it incapable of restarting. That's why we have other tests that use
+            // SerialSingleNotificationConnectable - that enables us to build a source that resets
+            var s3 = o2.Subscribe();
+            Assert.Equal(1, subscribed);
+            Assert.Equal(1, unsubscribed);
+
+            // While it might look like adding a second subscriber should tip us back over the threshold
+            // and trigger a reconnect, for the reasons described above o2 immediately completed in the
+            // last call to subscribe, so the RefCount is zero at this point. This is a limitation of
+            // Publish(). It doesn't really matter for this test, but it's why some tests use
+            // SerialSingleNotificationConnectable.
+            var s4 = o2.Subscribe();
+            Assert.Equal(1, subscribed);
+            Assert.Equal(1, unsubscribed);
+        }
+
+        [TestMethod]
+        public void RefCount_DelayedDisconnect_NotConnected()
         {
             var scheduler = new TestScheduler();
             var disconnected = false;
@@ -345,7 +1278,26 @@ namespace ReactiveTests.Tests
         }
 
         [TestMethod]
-        public void LazyRefCount_OnError()
+        public void RefCount_DelayedDisconnect_minObservers_NotConnected()
+        {
+            var connected = 0;
+            var source = Observable.Defer(() =>
+            {
+                connected++;
+                return Observable.Never<int>();
+            })
+            .Publish()
+            .RefCount(2, TimeSpan.FromMinutes(1));
+
+            Assert.Equal(0, connected);
+
+            source.Subscribe();
+
+            Assert.Equal(0, connected);
+        }
+
+        [TestMethod]
+        public void RefCount_DelayedDisconnect_OnError()
         {
             var ex = new Exception();
             var xs = Observable.Throw<int>(ex, Scheduler.Immediate);
@@ -357,7 +1309,33 @@ namespace ReactiveTests.Tests
         }
 
         [TestMethod]
-        public void LazyRefCount_Publish()
+        public void RefCount_DelayedDisconnect_minObservers_OnError()
+        {
+            var ex = new Exception();
+            var xs = Observable.Throw<int>(ex, Scheduler.Immediate);
+
+            var res = xs.Publish().RefCount(2, TimeSpan.FromSeconds(200));
+
+            var exceptionsReceived = new List<Exception>();
+            void AddSubscriber()
+            {
+                res.Subscribe(
+                    _ => { Assert.Fail("OnNext unexpected"); },
+                    ex_ => { exceptionsReceived.Add(ex); },
+                    () => { Assert.Fail("OnComplete unexpected"); });
+            }
+
+            AddSubscriber();
+            Assert.Equal(0, exceptionsReceived.Count);
+
+            AddSubscriber();
+            Assert.Equal(2, exceptionsReceived.Count);
+            Assert.Same(ex, exceptionsReceived[0]);
+            Assert.Same(ex, exceptionsReceived[1]);
+        }
+
+        [TestMethod]
+        public void RefCount_DelayedDisconnect_HotSourceMultipleSubscribers()
         {
             var scheduler = new TestScheduler();
 
@@ -430,172 +1408,189 @@ namespace ReactiveTests.Tests
         }
 
         [TestMethod]
-        public void RefCount_source_already_completed_synchronously()
+        public void RefCount_DelayedDisconnect_minObservers_HotSourceMultipleSubscribers()
         {
-            var subscribed = 0;
-            var unsubscribed = 0;
-            
-            var o1 = Observable.Create<string>(observer =>
-            {
-                subscribed++;
-                observer.OnCompleted();
+            var scheduler = new TestScheduler();
 
-                return Disposable.Create(() => unsubscribed++);
+            var xs = scheduler.CreateHotObservable(
+                OnNext(210, 1), // 0 subscribers
+                OnNext(220, 2), // 1 subscriber
+                OnNext(230, 3), // 2 subscribers
+                OnNext(240, 4), // 1 subscriber
+                OnNext(250, 5), // 1 subscriber
+                OnNext(260, 6), // 2 subscribers
+                OnNext(270, 7), // 1 subscribers
+                OnNext(280, 8), // 0 subscribers
+                OnNext(290, 9), // 1 subscribers
+                OnNext(300, 10), // 2 subscribers
+                OnCompleted<int>(310)
+            );
+
+            var res = xs.Publish().RefCount(2, TimeSpan.FromTicks(9), scheduler);
+
+            var d1 = default(IDisposable);
+            var o1 = scheduler.CreateObserver<int>();
+            scheduler.ScheduleAbsolute(215, () => { d1 = res.Subscribe(o1); });
+            scheduler.ScheduleAbsolute(235, () => { d1.Dispose(); });
+
+            var d2 = default(IDisposable);
+            var o2 = scheduler.CreateObserver<int>();
+            scheduler.ScheduleAbsolute(225, () => { d2 = res.Subscribe(o2); });
+            scheduler.ScheduleAbsolute(275, () =>
+            {
+                d2.Dispose();
             });
 
-            var o2 = o1.Publish().RefCount();
+            var d3 = default(IDisposable);
+            var o3 = scheduler.CreateObserver<int>();
+            scheduler.ScheduleAbsolute(255, () => { d3 = res.Subscribe(o3); });
+            scheduler.ScheduleAbsolute(265, () => { d3.Dispose(); });
 
-            var s1 = o2.Subscribe();
-            Assert.Equal(1, subscribed);
-            Assert.Equal(1, unsubscribed);
+            var d4 = default(IDisposable);
+            var o4 = scheduler.CreateObserver<int>();
+            scheduler.ScheduleAbsolute(285, () => { d4 = res.Subscribe(o4); });
+            scheduler.ScheduleAbsolute(320, () => { d4.Dispose(); });
 
-            var s2 = o2.Subscribe();
-            Assert.Equal(1, subscribed);
-            Assert.Equal(1, unsubscribed);
+            var d5 = default(IDisposable);
+            var o5 = scheduler.CreateObserver<int>();
+            scheduler.ScheduleAbsolute(295, () => { d5 = res.Subscribe(o5); });
+            scheduler.ScheduleAbsolute(320, () => { d5.Dispose(); });
+
+            scheduler.Start();
+
+            o1.Messages.AssertEqual(
+                OnNext(230, 3)
+            );
+
+            o2.Messages.AssertEqual(
+                OnNext(230, 3),
+                OnNext(240, 4),
+                OnNext(250, 5),
+                OnNext(260, 6),
+                OnNext(270, 7)
+            );
+
+            o3.Messages.AssertEqual(
+                OnNext(260, 6)
+            );
+
+            o4.Messages.AssertEqual(
+                OnNext(300, 10),
+                OnCompleted<int>(310)
+            );
+
+            o5.Messages.AssertEqual(
+                OnNext(300, 10),
+                OnCompleted<int>(310)
+            );
+
+            xs.Subscriptions.AssertEqual(
+                Subscribe(225, 284),
+                Subscribe(295, 310)
+            );
         }
 
         [TestMethod]
-        public void RefCount_minObservers_not_connected_Eager()
+        public void RefCount_DelayedDisconnect_minObservers_SubscriptionsDropBelowThresholdButNotToZero()
         {
+            var subject = new ReplaySubject<int>(5);
             var connected = 0;
             var source = Observable.Defer(() =>
             {
                 connected++;
-                return Observable.Never<int>();
-            })
-            .Publish()
-            .RefCount(2);
-
-            Assert.Equal(0, connected);
-
-            source.Subscribe();
-
-            Assert.Equal(0, connected);
-        }
-
-        [TestMethod]
-        public void RefCount_minObservers_connected_Eager()
-        {
-            var connected = 0;
-            var source = Observable.Defer(() =>
-            {
-                connected++;
-                return Observable.Range(1, 5);
-            })
-            .Publish()
-            .RefCount(2);
-
-            Assert.Equal(0, connected);
-
-            var list1 = new List<int>();
-            source.Subscribe(list1.Add);
-
-            Assert.Equal(0, connected);
-            Assert.Empty(list1);
-
-            var list2 = new List<int>();
-            source.Subscribe(list2.Add);
-
-            Assert.Equal(1, connected);
-
-            List<int> expected = [1, 2, 3, 4, 5];
-
-            Assert.Equal(expected, list1);
-            Assert.Equal(expected, list2);
-        }
-
-        [TestMethod]
-        public void RefCount_minObservers_not_connected_Lazy()
-        {
-            var connected = 0;
-            var source = Observable.Defer(() =>
-            {
-                connected++;
-                return Observable.Never<int>();
+                return subject;
             })
             .Publish()
             .RefCount(2, TimeSpan.FromMinutes(1));
 
-            Assert.Equal(0, connected);
-
-            source.Subscribe();
-
-            Assert.Equal(0, connected);
-        }
-
-        [TestMethod]
-        public void RefCount_minObservers_connected_Lazy()
-        {
-            var connected = 0;
-            var source = Observable.Defer(() =>
-            {
-                connected++;
-                return Observable.Range(1, 5);
-            })
-            .Publish()
-            .RefCount(2, TimeSpan.FromMinutes(1));
-
-            Assert.Equal(0, connected);
-
-            var list1 = new List<int>();
-            source.Subscribe(list1.Add);
-
-            Assert.Equal(0, connected);
-            Assert.Empty(list1);
-
-            var list2 = new List<int>();
-            source.Subscribe(list2.Add);
-
-            Assert.Equal(1, connected);
-
-            var expected = new List<int>([1, 2, 3, 4, 5]);
-
-            Assert.Equal(expected, list1);
-            Assert.Equal(expected, list2);
-        }
-
-        [TestMethod]
-        public void RefCount_minObservers_remains_connected_below_threshold_Lazy()
-        {
-            var sourceAfterInitial = new Subject<int>();
-            var connected = 0;
-            var source = Observable.Defer(() =>
-            {
-                connected++;
-                return Observable.Range(1, 5).Concat(sourceAfterInitial);
-            })
-            .Publish()
-            .RefCount(2, TimeSpan.FromMinutes(1));
-
+            subject.OnNext(1);
 
             Assert.Equal(0, connected);
 
             var list1 = new List<int>();
             var sub1 = source.Subscribe(list1.Add);
-
             Assert.Equal(0, connected);
             Assert.Empty(list1);
+
+            subject.OnNext(2);
 
             var list2 = new List<int>();
             var sub2 = source.Subscribe(list2.Add);
 
-            Assert.Equal(1, connected);
-
-            sourceAfterInitial.OnNext(6);
-
-            sub1.Dispose();
-            sourceAfterInitial.OnNext(7);
-
-            var expectedSub1 = new List<int>([1, 2, 3, 4, 5, 6]);
-            var expectedSub2 = new List<int>([1, 2, 3, 4, 5, 6, 7]);
+            // Since connection only occurred with the 2nd subscriber, we expect both to get everything
+            // the ReplaySubject has stored.
+            List<int> expectedSub1 = [1, 2];
+            var expectedSub2 = expectedSub1;
 
             Assert.Equal(expectedSub1, list1);
+            Assert.Equal(expectedSub1, list2);
+            Assert.Equal(1, connected);
+
+            subject.OnNext(3);
+
+            // Both subscribers should have received the new item.
+            expectedSub1 = expectedSub2 = [1, 2, 3];
+            Assert.Equal(expectedSub1, list1);
             Assert.Equal(expectedSub2, list2);
+            Assert.Equal(1, connected);
+
+            var list3 = new List<int>();
+            source.Subscribe(list3.Add);
+
+            // Since we were already connected, the 3rd subscriber just gets added to the observers of
+            // the Publish multicast output, and no new connection should occur to the underlying ReplaySubject.
+            // So for this 3rd subscription, no new items should be received by any of the subscribers
+            List<int> expectedSub3 = [];
+            Assert.Equal(expectedSub1, list1);
+            Assert.Equal(expectedSub2, list2);
+            Assert.Equal(expectedSub3, list3);
+            Assert.Equal(1, connected);
+
+            subject.OnNext(4);
+
+            // All the current subscribers should have received that latest item.
+            expectedSub1 = expectedSub2 = [1, 2, 3, 4];
+            expectedSub3 = [4];
+            Assert.Equal(expectedSub1, list1);
+            Assert.Equal(expectedSub2, list2);
+            Assert.Equal(expectedSub3, list3);
+            Assert.Equal(1, connected);
+
+            sub1.Dispose();
+
+            subject.OnNext(5);
+
+            // The two remaining subscribers should have received that new item, but the one that just
+            // unsubscribed should not.
+            expectedSub1 = [1, 2, 3, 4];
+            expectedSub2 = [1, 2, 3, 4, 5];
+            expectedSub3 = [4, 5];
+            Assert.Equal(expectedSub1, list1);
+            Assert.Equal(expectedSub2, list2);
+            Assert.Equal(expectedSub3, list3);
+            Assert.Equal(1, connected);
+
+            sub2.Dispose();
+
+            subject.OnNext(6);
+
+            // We are now below the minObservers threshold of 2, but that threshold only governs when we move
+            // from a disconnected state to a connected state. We should remain connected as long as there is
+            // at least one subscriber, so we expect the remaining subscriber to receive that last item.
+            expectedSub1 = [1, 2, 3, 4];
+            expectedSub2 = [1, 2, 3, 4, 5];
+            expectedSub3 = [4, 5, 6];
+            Assert.Equal(expectedSub1, list1);
+            Assert.Equal(expectedSub2, list2);
+            Assert.Equal(expectedSub3, list3);
+            Assert.Equal(1, connected);
         }
 
         [TestMethod]
-        public void RefCount_does_not_reconnect_when_minObservers_drops_below_threshold_then_goes_above_Lazy()
+        public void RefCount_DelayedDisconnect_SubscriptionsDropBelowThresholdAndThenBackAbove()
         {
+            var scheduler = new TestScheduler();
+
             var sourceAfterInitial = new Subject<int>();
             var connected = 0;
             var source = Observable.Defer(() =>
@@ -604,25 +1599,30 @@ namespace ReactiveTests.Tests
                 return Observable.Range(1, 5).Concat(sourceAfterInitial);
             })
             .Publish()
-            .RefCount(2, TimeSpan.FromMinutes(1));
+            .RefCount(2, TimeSpan.FromTicks(10), scheduler);
 
 
             Assert.Equal(0, connected);
 
             var list1 = new List<int>();
-            var sub1 = source.Subscribe(list1.Add);
+            var sub1 = source.Subscribe(list1.Add); // 1 subscriber
 
             Assert.Equal(0, connected);
             Assert.Empty(list1);
 
             var list2 = new List<int>();
-            var sub2 = source.Subscribe(list2.Add);
+            var sub2 = source.Subscribe(list2.Add); // 2 subscribers
 
             Assert.Equal(1, connected);
 
             sourceAfterInitial.OnNext(6);
 
-            sub1.Dispose();
+            sub1.Dispose(); // 1 subscriber
+
+            // We don't expect a disconnect, but provide enough time for one to occur, should that bug ever creep in
+            scheduler.AdvanceBy(10);
+            Assert.Equal(1, connected);
+
             sourceAfterInitial.OnNext(7);
 
             Assert.Equal(1, connected);
@@ -630,6 +1630,10 @@ namespace ReactiveTests.Tests
             var list3 = new List<int>();
             var sub3 = source.Subscribe(list3.Add);
 
+            // This is the distinguishing feature of this test. With that last subscription, we went from 1
+            // subscriber (below minObservers) but still connected (because we already hit minObservers once
+            // and never dropped to zero), and now we're passing through minObservers again. We used to have
+            // a bug where we would erroneously attempt to reconnect at this point.
             Assert.Equal(1, connected);
             sourceAfterInitial.OnNext(8);
 
@@ -643,91 +1647,587 @@ namespace ReactiveTests.Tests
         }
 
         [TestMethod]
-        public void RefCount_minObservers_remains_connected_below_threshold_Eager()
+        public void RefCount_DelayedDisconnect_SubscriptionsDropToZeroThenNewSubscriptionArrivesBeforeDisconnectDelay()
         {
-            var sourceAfterInitial = new Subject<int>();
-            var connected = 0;
-            var source = Observable.Defer(() =>
-            {
-                connected++;
-                return Observable.Range(1, 5).Concat(sourceAfterInitial);
-            })
-            .Publish()
-            .RefCount(2);
+            var scheduler = new TestScheduler();
+            var source = new SerialSingleNotificationConnectable<int>(Notification.CreateOnNext(1));
+            var rco = source.RefCount(TimeSpan.FromTicks(10), scheduler);
 
+            var s1 = rco.Subscribe();
+            s1.Dispose();
 
-            Assert.Equal(0, connected);
+            // There are now 0 subscribers, but the time for the disconnect has not yet come.
+            Assert.Equal(1, source.Connections.Count);
+            Assert.False(source.Connections[0].Disposed);
 
-            var list1 = new List<int>();
-            var sub1 = source.Subscribe(list1.Add);
+            scheduler.AdvanceBy(9);
 
-            Assert.Equal(0, connected);
-            Assert.Empty(list1);
+            // The time has still not come,
+            Assert.Equal(1, source.Connections.Count);
+            Assert.False(source.Connections[0].Disposed);
 
-            var list2 = new List<int>();
-            var sub2 = source.Subscribe(list2.Add);
+            // Since we were still connected, this should move the connection from a 'waiting to
+            // shut down' state into an active state.
+            var seen = 0;
+            var terminated = false;
+            var s2 = rco.Subscribe(x => seen = x, () => terminated = true);
+            source.DeliverNotificationForActiveConnection(Notification.CreateOnNext(2));
+            Assert.Equal(2, seen);
+            Assert.False(terminated);
+            Assert.False(source.Connections[0].Disposed);
 
-            Assert.Equal(1, connected);
+            // This moves us past the time when `RefCount` would have shut down the connection if no new
+            // subscriptions had turned up.
+            scheduler.AdvanceBy(2);
 
-            sourceAfterInitial.OnNext(6);
+            Assert.False(terminated);
+            Assert.False(source.Connections[0].Disposed);
 
-            sub1.Dispose();
-            sourceAfterInitial.OnNext(7);
+            // We should be able to advance well beyond the disconnect delay because we have an active
+            // subscriber.
+            scheduler.AdvanceBy(20);
 
-            var expectedSub1 = new List<int>([1, 2, 3, 4, 5, 6]);
-            var expectedSub2 = new List<int>([1, 2, 3, 4, 5, 6, 7]);
-
-            Assert.Equal(expectedSub1, list1);
-            Assert.Equal(expectedSub2, list2);
+            Assert.False(terminated);
+            Assert.False(source.Connections[0].Disposed);
         }
 
         [TestMethod]
-        public void RefCount_does_not_reconnect_when_minObservers_drops_below_threshold_then_goes_above_Eager()
+        public void RefCount_DelayedDisconnect_minObservers_SubscriptionsDropToZeroThenNewSubscriptionArrivesBeforeDisconnectDelay()
         {
-            var sourceAfterInitial = new Subject<int>();
-            var connected = 0;
-            var source = Observable.Defer(() =>
-            {
-                connected++;
-                return Observable.Range(1, 5).Concat(sourceAfterInitial);
-            })
-            .Publish()
-            .RefCount(2);
+            var scheduler = new TestScheduler();
+            var source = new SerialSingleNotificationConnectable<int>(Notification.CreateOnNext(1));
+            var rco = source.RefCount(2, TimeSpan.FromTicks(10), scheduler);
 
+            var s1 = rco.Subscribe();
+            var s2 = rco.Subscribe();
+            s1.Dispose();
+            s2.Dispose();
 
-            Assert.Equal(0, connected);
+            // There are now 0 subscribers, but the time for the disconnect has not yet come.
+            Assert.Equal(1, source.Connections.Count);
+            Assert.False(source.Connections[0].Disposed);
+
+            scheduler.AdvanceBy(9);
+
+            // The time has still not come,
+            Assert.Equal(1, source.Connections.Count);
+            Assert.False(source.Connections[0].Disposed);
+
+            // Since we were still connected, this should move the connection from a 'waiting to
+            // shut down' state into an active state. (We're below the minObservers threshold, but
+            // that just determines when Connect is called. RefCount has historically always waited
+            // for the subscription count to reach 0 before disconnecting, so if that count goes
+            // above 0 while we were waiting for the disconnect delay, it should return to an
+            // active state.)
+            var seen = 0;
+            var terminated = false;
+            var s3 = rco.Subscribe(x => seen = x, () => terminated = true);
+            source.DeliverNotificationForActiveConnection(Notification.CreateOnNext(2));
+            Assert.Equal(2, seen);
+            Assert.False(terminated);
+            Assert.False(source.Connections[0].Disposed);
+
+            // This moves us past the time when `RefCount` would have shut down the connection if
+            // no new subscriptions had turned up. The arrival of a new subscriber should ensure
+            // that we remain connected.
+            scheduler.AdvanceBy(2);
+
+            Assert.False(terminated);
+            Assert.False(source.Connections[0].Disposed);
+
+            // We should be able to advance well beyond the disconnect delay because we have an active
+            // subscriber.
+            scheduler.AdvanceBy(20);
+
+            Assert.False(terminated);
+            Assert.False(source.Connections[0].Disposed);
+        }
+
+        [TestMethod]
+        public void RefCount_DelayedDisconnect_ValuesDuringAndAfterSubscribe()
+        {
+            var subject = new ReplaySubject<int>(5);
+            var source = subject.Publish().RefCount(TimeSpan.FromSeconds(20));
+
+            subject.OnNext(1);
+
+            // Although the source is a ReplaySubject, the use of Publish means there will only be
+            // a single subscription to the ReplaySubject, so it will only replay one. (It will replay
+            // that first value on the initial connect.) So we expect each subscriber to see fewer and
+            // fewer values.
+            // all subscribers will see all the values
+            List<int> expected1 = [1];
 
             var list1 = new List<int>();
-            var sub1 = source.Subscribe(list1.Add);
+            source.Subscribe(list1.Add);
+            Assert.Equal(expected1, list1);
 
-            Assert.Equal(0, connected);
-            Assert.Empty(list1);
+            subject.OnNext(2);
 
             var list2 = new List<int>();
-            var sub2 = source.Subscribe(list2.Add);
+            source.Subscribe(list2.Add);
 
-            Assert.Equal(1, connected);
+            expected1 = [1, 2];
+            List<int> expected2 = [];
 
-            sourceAfterInitial.OnNext(6);
+            Assert.Equal(expected1, list1);
+            Assert.Equal(expected2, list2);
 
-            sub1.Dispose();
-            sourceAfterInitial.OnNext(7);
-
-            Assert.Equal(1, connected);
+            subject.OnNext(3);
 
             var list3 = new List<int>();
-            var sub3 = source.Subscribe(list3.Add);
+            source.Subscribe(list3.Add);
 
-            Assert.Equal(1, connected);
-            sourceAfterInitial.OnNext(8);
+            expected1 = [1, 2, 3];
+            expected2 = [3];
+            List<int> expected3 = [];
 
-            var expectedSub1 = new List<int>([1, 2, 3, 4, 5, 6]);
-            var expectedSub2 = new List<int>([1, 2, 3, 4, 5, 6, 7, 8]);
-            var expectedSub3 = new List<int>([8]);
+            Assert.Equal(expected1, list1);
+            Assert.Equal(expected2, list2);
+            Assert.Equal(expected3, list3);
 
-            Assert.Equal(expectedSub1, list1);
-            Assert.Equal(expectedSub2, list2);
-            Assert.Equal(expectedSub3, list3);
+            subject.OnNext(4);
+            expected1 = [1, 2, 3, 4];
+            expected2 = [3, 4];
+            expected3 = [4];
+            Assert.Equal(expected1, list1);
+            Assert.Equal(expected2, list2);
+            Assert.Equal(expected3, list3);
         }
+
+        [TestMethod]
+        public void RefCount_DelayedDisconnect_minObservers_ValuesDuringAndAfterSubscribe()
+        {
+            var subject = new ReplaySubject<int>(5);
+            var source = subject.Publish().RefCount(2, TimeSpan.FromSeconds(20));
+
+            subject.OnNext(1);
+
+            var list1 = new List<int>();
+            source.Subscribe(list1.Add);
+            Assert.Empty(list1);
+
+            subject.OnNext(2);
+
+            List<int> expected1and2 = [1, 2];
+
+            var list2 = new List<int>();
+            source.Subscribe(list2.Add);
+
+            Assert.Equal(expected1and2, list1);
+            Assert.Equal(expected1and2, list2);
+
+            subject.OnNext(3);
+            expected1and2 = [1, 2, 3];
+            Assert.Equal(expected1and2, list1);
+            Assert.Equal(expected1and2, list2);
+
+            var list3 = new List<int>();
+            source.Subscribe(list3.Add);
+
+            List<int> expected3 = [];
+            Assert.Equal(expected1and2, list1);
+            Assert.Equal(expected1and2, list2);
+            Assert.Equal(expected3, list3);
+
+            subject.OnNext(4);
+            expected1and2 = [1, 2, 3, 4];
+            expected3 = [4];
+            Assert.Equal(expected1and2, list1);
+            Assert.Equal(expected1and2, list2);
+            Assert.Equal(expected3, list3);
+        }
+
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public void RefCount_DelayedDisconnect_CanConnectAgainIfPreviousSubscriptionTerminatedFromSubscribeByCompletion(
+            bool reSubscribeBeforeDelayedDisconnect)
+        {
+            var scheduler = new TestScheduler();
+            var seen = 0;
+            var terminated = false;
+
+            // On initial subscription, the source will produce one value and will not complete.
+            var connectable = new SerialSingleNotificationConnectable<int>(Notification.CreateOnNext(36));
+            var refCount = connectable.RefCount(TimeSpan.FromTicks(10), scheduler);
+
+            using (refCount.Subscribe(value => seen = value, () => terminated = true))
+            {
+                Assert.Equal(36, seen);
+                Assert.Equal(1, connectable.Connections.Count);
+                Assert.False(connectable.Connections[0].Disposed);
+            }
+
+            Assert.False(connectable.Connections[0].Disposed);
+
+            // For these initial subscriptions, we allow enough time for the delayed disconnect to occur even if
+            // reSubscribeBeforeDelayedDisconnect is false, because it's the resubscription after a source-induced
+            // completion that this test is interested in.
+            scheduler.AdvanceBy(11);
+
+            Assert.Equal(1, connectable.Connections.Count);
+            Assert.True(connectable.Connections[0].Disposed);
+
+            seen = 0;
+            terminated = false;
+
+            // This time around, when Connect is called, all subscriptions after the preceding Connect will be
+            // completed.
+            connectable.SetNotificationForNextConnect(Notification.CreateOnCompleted<int>());
+
+            using (refCount.Subscribe(value => seen = value, () => terminated = true))
+            {
+                Assert.Equal(0, seen);
+                Assert.True(terminated);
+                Assert.Equal(2, connectable.Connections.Count);
+                Assert.False(connectable.Connections[1].Disposed);
+            }
+
+            Assert.Equal(2, connectable.Connections.Count);
+            Assert.False(connectable.Connections[1].Disposed);
+
+            scheduler.AdvanceBy(reSubscribeBeforeDelayedDisconnect ? 1 : 11);
+
+            Assert.Equal(2, connectable.Connections.Count);
+            Assert.Equal(!reSubscribeBeforeDelayedDisconnect, connectable.Connections[1].Disposed);
+
+            seen = 0;
+            terminated = false;
+
+            // Now we go back to the initial behaviour in which the source produces one value and does not complete.
+            connectable.SetNotificationForNextConnect(Notification.CreateOnNext(42));
+
+            using (refCount.Subscribe(value => seen = value, () => terminated = true))
+            {
+                Assert.Equal(reSubscribeBeforeDelayedDisconnect ? 0 : 42, seen);
+                Assert.Equal(reSubscribeBeforeDelayedDisconnect, terminated);
+                Assert.Equal(reSubscribeBeforeDelayedDisconnect ? 2 : 3, connectable.Connections.Count);
+                Assert.False(connectable.Connections[reSubscribeBeforeDelayedDisconnect ? 1 : 2].Disposed);
+            }
+        }
+
+        [TestMethod]
+        public void RefCount_DelayedDisconnect_minObservers_CanConnectAgainIfPreviousSubscriptionTerminatedFromSubscribeByCompletionAndEnoughTimeForDisconnectHasPassed()
+        {
+            var scheduler = new TestScheduler();
+            var seen1 = 0;
+            var seen2 = 0;
+            var terminated1 = false;
+            var terminated2 = false;
+
+            // On initial subscription, the source will produce one value and will not complete.
+            var connectable = new SerialSingleNotificationConnectable<int>(Notification.CreateOnNext(36));
+            var refCount = connectable.RefCount(2, TimeSpan.FromTicks(10), scheduler);
+
+            using (refCount.Subscribe(value => seen1 = value, () => terminated1 = true))
+            {
+                Assert.Equal(0, seen1);
+                Assert.Empty(connectable.Connections);
+                using (refCount.Subscribe(value => seen2 = value, () => terminated2 = true))
+                {
+                    Assert.Equal(36, seen1);
+                    Assert.Equal(36, seen2);
+                    Assert.Equal(1, connectable.Connections.Count);
+                    Assert.False(connectable.Connections[0].Disposed);
+                }
+            }
+
+            Assert.Equal(1, connectable.Connections.Count);
+            Assert.False(connectable.Connections[0].Disposed);
+
+            scheduler.AdvanceBy(11);
+
+            Assert.Equal(1, connectable.Connections.Count);
+            Assert.True(connectable.Connections[0].Disposed);
+
+            seen1 = seen2 = 0;
+            terminated1 = terminated2 = false;
+
+            // This time around, when Connect is called, all subscriptions after the preceding Connect will be
+            // completed.
+            connectable.SetNotificationForNextConnect(Notification.CreateOnCompleted<int>());
+
+            using (refCount.Subscribe(value => seen1 = value, () => terminated1 = true))
+            {
+                Assert.Equal(1, connectable.Connections.Count);
+                Assert.False(terminated1);
+                Assert.False(terminated2);
+                using (refCount.Subscribe(value => seen2 = value, () => terminated2 = true))
+                {
+                    Assert.Equal(0, seen1);
+                    Assert.Equal(0, seen2);
+                    Assert.True(terminated1);
+                    Assert.True(terminated2);
+                    Assert.Equal(2, connectable.Connections.Count);
+                    Assert.False(connectable.Connections[1].Disposed);
+                }
+            }
+
+            Assert.Equal(2, connectable.Connections.Count);
+            Assert.False(connectable.Connections[1].Disposed);
+
+            scheduler.AdvanceBy(11);
+
+            Assert.Equal(2, connectable.Connections.Count);
+            Assert.True(connectable.Connections[1].Disposed);
+
+            seen1 = seen2 = 0;
+            terminated1 = terminated2 = false;
+
+            // Now we go back to the initial behaviour in which the source produces one value and does not complete.
+            connectable.SetNotificationForNextConnect(Notification.CreateOnNext(42));
+
+            using (refCount.Subscribe(value => seen1 = value, () => terminated1 = true))
+            {
+                Assert.False(terminated1);
+                Assert.Equal(0, seen1);
+                Assert.False(terminated2);
+                Assert.Equal(2, connectable.Connections.Count);
+                using (refCount.Subscribe(value => seen2 = value, () => terminated2 = true))
+                {
+                    Assert.Equal(42, seen1);
+                    Assert.Equal(42, seen2);
+                    Assert.False(terminated1);
+                    Assert.False(terminated2);
+                    Assert.Equal(3, connectable.Connections.Count);
+                    Assert.False(connectable.Connections[2].Disposed);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void RefCount_DelayedDisconnect_minObservers_CanConnectAgainIfPreviousSubscriptionTerminatedFromSubscribeByCompletionAndEnoughTimeForDisconnectHasPassed_WithPreConnectNotifications()
+        {
+            var scheduler = new TestScheduler();
+            var seen1 = 0;
+            var seen2 = 0;
+            var terminated1 = false;
+            var terminated2 = false;
+
+            // On initial subscription, the source will produce one value and will not complete.
+            var connectable = new SerialConnectableIgnoringConnect<int>(new BehaviorSubject<int>(36));
+            var refCount = connectable.RefCount(2, TimeSpan.FromTicks(10), scheduler);
+
+            using (refCount.Subscribe(value => seen1 = value, () => terminated1 = true))
+            {
+                // The SerialConnectableConnectIgnoringObservable is unusual in that it can produce values before the
+                // call to Connect. So we expect to see the value from the source, but not yet to
+                // have seen a Connect call.
+                Assert.Equal(36, seen1);
+                Assert.Empty(connectable.Connections);
+                using (refCount.Subscribe(value => seen2 = value, () => terminated2 = true))
+                {
+                    Assert.Equal(36, seen1);
+                    Assert.Equal(36, seen2);
+                    Assert.Equal(1, connectable.Connections.Count);
+                    Assert.False(connectable.Connections[0].Disposed);
+                }
+            }
+
+            Assert.Equal(1, connectable.Connections.Count);
+            Assert.False(connectable.Connections[0].Disposed);
+
+            scheduler.AdvanceBy(11);
+
+            Assert.Equal(1, connectable.Connections.Count);
+            Assert.True(connectable.Connections[0].Disposed);
+
+            seen1 = seen2 = 0;
+            terminated1 = terminated2 = false;
+
+            // This time around, the source will complete when subscribed to.
+            connectable.SetSource(Observable.Empty<int>());
+
+            using (refCount.Subscribe(value => seen1 = value, () => terminated1 = true))
+            {
+                // Again, the SerialConnectableConnectIgnoringObservable's unsual behaviour of
+                // delivering notifications immediately from subscription without waiting for the
+                // Connect means we see the initial termination immediately (and no connection yet).
+                Assert.True(terminated1);
+                Assert.False(terminated2);
+                Assert.Equal(1, connectable.Connections.Count);
+                using (refCount.Subscribe(value => seen2 = value, () => terminated2 = true))
+                {
+                    Assert.Equal(0, seen1);
+                    Assert.Equal(0, seen2);
+                    Assert.True(terminated1);
+                    Assert.True(terminated2);
+
+                    // Since the initial subscription completed immediately, the observer count
+                    // never got above 1, so we do not expect a second connection
+                    Assert.Equal(1, connectable.Connections.Count);
+                    Assert.True(connectable.Connections[0].Disposed);
+                }
+            }
+
+            Assert.Equal(1, connectable.Connections.Count);
+
+            scheduler.AdvanceBy(11);
+
+            Assert.Equal(1, connectable.Connections.Count);
+
+            seen1 = seen2 = 0;
+            terminated1 = terminated2 = false;
+
+            // Now we go back to the initial behaviour in which the source produces one value and does not complete.
+            connectable.SetSource(new BehaviorSubject<int>(42));
+
+            using (refCount.Subscribe(value => seen1 = value, () => terminated1 = true))
+            {
+                Assert.False(terminated1);
+                Assert.Equal(42, seen1);
+                Assert.False(terminated2);
+                Assert.Equal(1, connectable.Connections.Count);
+                using (refCount.Subscribe(value => seen2 = value, () => terminated2 = true))
+                {
+                    Assert.Equal(42, seen1);
+                    Assert.Equal(42, seen2);
+                    Assert.False(terminated1);
+                    Assert.False(terminated2);
+                    Assert.Equal(2, connectable.Connections.Count);
+                    Assert.False(connectable.Connections[1].Disposed);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void RefCount_DelayedDisconnect_minObservers_DoesNotConnectAgainIfPreviousSubscriptionTerminatedFromSubscribeByCompletionButNotEnoughTimeForDelayedDisconnectHasPassed()
+        {
+            var scheduler = new TestScheduler();
+            var seen1 = 0;
+            var seen2 = 0;
+            var terminated1 = false;
+            var terminated2 = false;
+
+            // On initial subscription, the source will produce one value and will not complete.
+            var connectable = new SerialSingleNotificationConnectable<int>(Notification.CreateOnNext(36));
+            var refCount = connectable.RefCount(2, TimeSpan.FromTicks(10), scheduler);
+
+            using (refCount.Subscribe(value => seen1 = value, () => terminated1 = true))
+            {
+                Assert.Equal(0, seen1);
+                Assert.Empty(connectable.Connections);
+                using (refCount.Subscribe(value => seen2 = value, () => terminated2 = true))
+                {
+                    Assert.Equal(36, seen1);
+                    Assert.Equal(36, seen2);
+                    Assert.Equal(1, connectable.Connections.Count);
+                    Assert.False(connectable.Connections[0].Disposed);
+                }
+            }
+
+            Assert.Equal(1, connectable.Connections.Count);
+            Assert.False(connectable.Connections[0].Disposed);
+
+            // For these initial subscriptions, we allow enough time for the delayed disconnect to occur, because
+            // it's the resubscription after a source-induced completion that this test is interested in.
+            scheduler.AdvanceBy(11);
+
+            Assert.Equal(1, connectable.Connections.Count);
+            Assert.True(connectable.Connections[0].Disposed);
+
+            seen1 = seen2 = 0;
+            terminated1 = terminated2 = false;
+
+            // Any further subscriptions will be completed on the next Connect.
+            connectable.SetNotificationForNextConnect(Notification.CreateOnCompleted<int>());
+
+            using (refCount.Subscribe(value => seen1 = value, () => terminated1 = true))
+            {
+                Assert.Equal(1, connectable.Connections.Count);
+                Assert.False(terminated1);
+                using (refCount.Subscribe(value => seen2 = value, () => terminated2 = true))
+                {
+                    Assert.Equal(0, seen1);
+                    Assert.Equal(0, seen2);
+                    Assert.True(terminated1);
+                    Assert.True(terminated2);
+
+                    Assert.Equal(2, connectable.Connections.Count);
+                    Assert.False(connectable.Connections[1].Disposed);
+                }
+            }
+
+            Assert.Equal(2, connectable.Connections.Count);
+            Assert.False(connectable.Connections[1].Disposed);
+
+            scheduler.AdvanceBy(5);
+
+            Assert.Equal(2, connectable.Connections.Count);
+            Assert.False(connectable.Connections[1].Disposed);
+
+            seen1 = seen2 = 0;
+            terminated1 = terminated2 = false;
+
+            // To verify that individual subscriptions continue to be forwarded to the underlying source even
+            // when no reconnect occurs, we arrange for subsequent subscriptions to get receive a single value.
+            // (This is a slightly odd thing to do, but it's not RefCount's place to have opinions on how the
+            // source should behave.)
+            connectable.Connections[1].ReplaceSource(new BehaviorSubject<int>(42));
+
+            // The connection set up in the preceding section won't be torn down until the
+            // specified disconnect delay has elapsed, so the expected behaviour if we try to establish
+            // new subscriptions in that time is that their Subscribe will be passed through to the source,
+            // and that we won't see any further connections. But now that the further subscriptions to the
+            // source will result in a value (even though earlier subscriptions to the same source have been
+            // completed) we expect these new subscriptions each to see the value.
+            using (refCount.Subscribe(value => seen1 = value, () => terminated1 = true))
+            {
+                Assert.False(terminated1);
+                Assert.Equal(42, seen1);
+                Assert.False(terminated2);
+                Assert.Equal(2, connectable.Connections.Count);
+                Assert.False(connectable.Connections[1].Disposed);
+                using (refCount.Subscribe(value => seen2 = value, () => terminated2 = true))
+                {
+                    Assert.Equal(42, seen1);
+                    Assert.Equal(42, seen2);
+                    Assert.False(terminated1);
+                    Assert.False(terminated2);
+                    Assert.Equal(2, connectable.Connections.Count);
+                    Assert.False(connectable.Connections[1].Disposed);
+                }
+            }
+
+            connectable.SetNotificationForNextConnect(Notification.CreateOnNext(99));
+
+            // If we advanced by enough for the deferred disconnect to occur, it should be able to create a fresh
+            // connection to the underlying source, at which point we'll see the value again.
+            // We were at 5, so this takes us to 11 since the initial connection, but we don't expect that to be
+            // enough, because the deferred disconnection should be relative to the most recent subscription.
+            scheduler.AdvanceBy(6);
+
+            Assert.Equal(2, connectable.Connections.Count);
+            Assert.False(connectable.Connections[1].Disposed);
+
+            // Since the last subscription occurred at 5, advancing to 16 should trigger disconnection. And
+            // since we're already up to 11, this should do it:
+            scheduler.AdvanceBy(5);
+
+            Assert.Equal(2, connectable.Connections.Count);
+            Assert.True(connectable.Connections[1].Disposed);
+
+            seen1 = seen2 = 0;
+            terminated1 = terminated2 = false;
+
+            using (refCount.Subscribe(value => seen1 = value, () => terminated1 = true))
+            {
+                Assert.Equal(0, seen1);
+                Assert.Equal(2, connectable.Connections.Count);
+                Assert.True(connectable.Connections[1].Disposed);
+                using (refCount.Subscribe(value => seen2 = value, () => terminated2 = true))
+                {
+                    Assert.Equal(99, seen1);
+                    Assert.Equal(99, seen2);
+                    Assert.False(terminated1);
+                    Assert.False(terminated2);
+                    Assert.Equal(3, connectable.Connections.Count);
+                    Assert.False(connectable.Connections[2].Disposed);
+                }
+            }
+        }
+
+        #endregion
     }
 }

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/RefCountTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/RefCountTest.cs
@@ -999,7 +999,7 @@ namespace ReactiveTests.Tests
             terminated1 = terminated2 = false;
 
             // Now we go back to the initial behaviour in which the source produces one value and does not complete.
-            connectable.Connections[1].ReplaceSource(new BehaviorSubject<int>(42));
+            connectable.SetNotificationForNextConnect(Notification.CreateOnNext(42));
 
             using (refCount.Subscribe(value => seen1 = value, () => terminated1 = true))
             {

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/RefCountTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Linq/Observable/RefCountTest.cs
@@ -108,7 +108,7 @@ namespace ReactiveTests.Tests
                 return connection.Source.Subscribe(observer);
             }
 
-            public class Connection(IObservable<T> source) : IDisposable
+            public sealed class Connection(IObservable<T> source) : IDisposable
             {
                 /// <summary>
                 /// Gets a value indicating whether this connection has been disposed.
@@ -138,7 +138,6 @@ namespace ReactiveTests.Tests
                 public void Dispose()
                 {
                     Disposed = true;
-                    //connection.Dispose();
                 }
             }
         }
@@ -166,13 +165,11 @@ namespace ReactiveTests.Tests
 
             public SerialConnectableIgnoringConnect(IObservable<T> initialSource)
             {
-                //_sourcePublished = initialSource.Publish();
                 _source = initialSource;
             }
 
             public void SetSource(IObservable<T> source)
             {
-                //_sourcePublished = source.Publish();
                 _source = source;
             }
 
@@ -180,7 +177,6 @@ namespace ReactiveTests.Tests
 
             public IDisposable Connect()
             {
-                //var connection = new Connection(_sourcePublished.Connect());
                 var connection = new Connection();
                 Connections.Add(connection);
                 return connection;
@@ -188,27 +184,19 @@ namespace ReactiveTests.Tests
 
             public IDisposable Subscribe(IObserver<T> observer)
             {
-                //return _sourcePublished.Subscribe(observer);
                 return _source.Subscribe(observer);
             }
 
-            //public class Connection(IDisposable connection) : IDisposable
-            public class Connection() : IDisposable
+            public sealed class Connection() : IDisposable
             {
                 /// <summary>
                 /// Gets a value indicating whether this connection has been disposed.
                 /// </summary>
                 public bool Disposed { get; private set; }
 
-                /////// <summary>
-                /////// Gets the source that was the <see cref="CurrentSource"/> when <see cref="Connect"/> was called.
-                /////// </summary>
-                ////public IObservable<T> Source { get; } = source;
-
                 public void Dispose()
                 {
                     Disposed = true;
-                    //connection.Dispose();
                 }
             }
         }

--- a/Rx.NET/Source/version.json
+++ b/Rx.NET/Source/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.0.1-preview.{height}",
+  "version": "6.0.2-preview.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/main$", // we release out of main
     "^refs/heads/rel/v\\d+\\.\\d+", // we also release branches starting with rel/vN.N

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -132,11 +132,11 @@ stages:
       displayName: Use .NET 9.0 SDK
       inputs:
         version: '9.0.x'
-        packageType: runtime
 
     - task: UseDotNet@2
       inputs:
         version: 8.0.x
+        packageType: runtime
 
     - task: DotNetCoreCLI@2
       inputs:

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -133,15 +133,9 @@ stages:
         version: 8.0.x
 
     - task: UseDotNet@2
-      displayName: Use .NET 7.0 SDK
+      displayName: Use .NET 9.0 SDK
       inputs:
-        version: '7.0.x'
-        packageType: runtime
-
-    - task: UseDotNet@2
-      displayName: Use .NET 6.0 SDK
-      inputs:
-        version: '6.0.x'
+        version: '9.0.x'
         packageType: runtime
 
     - task: DotNetCoreCLI@2
@@ -179,15 +173,8 @@ stages:
       inputs:
         command: test
         projects: $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LinuxTests/LinuxTests.csproj
-        arguments: -c $(BuildConfiguration) -f net7.0 --filter "TestCategory!=SkipCI"
-      displayName: Run 7.0 Tests on Linux
-
-    - task: DotNetCoreCLI@2
-      inputs:
-        command: test
-        projects: $(System.DefaultWorkingDirectory)/Rx.NET/Integration/LinuxTests/LinuxTests.csproj
-        arguments: -c $(BuildConfiguration) -f net6.0 --filter "TestCategory!=SkipCI"
-      displayName: Run 6.0 Tests on Linux
+        arguments: -c $(BuildConfiguration) -f net9.0 --filter "TestCategory!=SkipCI"
+      displayName: Run 9.0 Tests on Linux
 
   - job: WindowsDesktop    
     pool:
@@ -205,14 +192,9 @@ stages:
         performMultiLevelLookup: true
 
     - task: UseDotNet@2
-      displayName: Use .NET 7.0 SDK
+      displayName: Use .NET 9.0 SDK
       inputs:
-        version: '7.0.x'
-
-    - task: UseDotNet@2
-      displayName: Use .NET 6.0 SDK
-      inputs:
-        version: '6.0.x'
+        version: '9.0.x'
 
     - task: DotNetCoreCLI@2
       inputs:

--- a/azure-pipelines.rx.yml
+++ b/azure-pipelines.rx.yml
@@ -129,14 +129,14 @@ stages:
 
     steps:
     - task: UseDotNet@2
-      inputs:
-        version: 8.0.x
-
-    - task: UseDotNet@2
       displayName: Use .NET 9.0 SDK
       inputs:
         version: '9.0.x'
         packageType: runtime
+
+    - task: UseDotNet@2
+      inputs:
+        version: 8.0.x
 
     - task: DotNetCoreCLI@2
       inputs:


### PR DESCRIPTION
Resolves #2173, resolves #2214, resolves #2215

Adds more `RefCount` unit tests.

`RefCount` has two implementations: the `Eager` one, which disconnects the instant the subscriber count drops to 0, and the `Lazy` one, which is used by overloads of `RefCount` that specify a `disconnectDelay`, which disconnects only when the subscriber count has been at 0 for the duration specified. Both implementations had bugs.

Broadly speaking, the problems were failures to distinguish between different states when hitting significant subscriber counts.

The `Eager` implementation would crash if `minObservers` was greater than 1, and the subscriber count dropped below that threshold (but not to 0) and then back up to it. Each time `minObservers` was reached, it would reconnect, even if already connected.

The `Lazy` implementation had a similar problem, but it occurred when the reference count hit zero: the operator would set up the work item to effect the delayed disconnect every time that happened, but if the count went to zero, then 1, then back to zero, this meant it would try to set up that callback twice. (This was not harmless, because it uses a `SingleAssignmentDisposable` to manage this, and it would throw an `InvalidOperationException` the second time it went to zero.) There was also a more subtle problem that occurred with sources that complete synchronously (i.e., they call `OnComplete` before returning from `Subscribe`): it was possible for a delayed disconnect work item to get scheduled, and then for it not to get cancelled if a new subscriber arrived before the disconnect occurred. This could result in premature disconnection.