### PR TITLE
Update Rx PackageReferences to 6.1.0 in integration test

### DIFF
--- a/Rx.NET/Integration/LinuxTests/LinuxTests.csproj
+++ b/Rx.NET/Integration/LinuxTests/LinuxTests.csproj
@@ -28,8 +28,8 @@
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <PackageReference Include="xunit.assert" Version="2.4.2" />
-    <PackageReference Include="System.Reactive" Version="6.0.2-preview*" />
-    <PackageReference Include="Microsoft.Reactive.Testing" Version="6.0.2-preview*" />
-    <PackageReference Include="System.Reactive.Observable.Aliases" Version="6.0.2-preview*" />
+    <PackageReference Include="System.Reactive" Version="6.1.0-preview*" />
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="6.1.0-preview*" />
+    <PackageReference Include="System.Reactive.Observable.Aliases" Version="6.1.0-preview*" />
   </ItemGroup>
 </Project>

--- a/Rx.NET/Integration/WindowsDesktopTests/WindowsDesktopTests.csproj
+++ b/Rx.NET/Integration/WindowsDesktopTests/WindowsDesktopTests.csproj
@@ -27,8 +27,8 @@
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <PackageReference Include="xunit.assert" Version="2.4.2" />
-    <PackageReference Include="System.Reactive" Version="6.0.2-preview*" />
-    <PackageReference Include="Microsoft.Reactive.Testing" Version="6.0.2-preview*" />
-    <PackageReference Include="System.Reactive.Observable.Aliases" Version="6.0.2-preview*" />
+    <PackageReference Include="System.Reactive" Version="6.1.0-preview*" />
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="6.1.0-preview*" />
+    <PackageReference Include="System.Reactive.Observable.Aliases" Version="6.1.0-preview*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Missed this when updating `version.json`