### PR TITLE
Add namespace style config to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -256,3 +256,6 @@ csharp_space_between_square_brackets = false
 # Primary constructors
 # We find these something of a mixed bag.
 dotnet_diagnostic.IDE0290.severity = none
+
+# Namespace style.
+csharp_style_namespace_declarations = block_scoped


### PR DESCRIPTION
The prevailing style for namespaces is the old block namespace. At some point I'd like to change that, but for now, the `.editorconfig` should reflect the repo style.