### PR TITLE
Fix condition in documentation example

### DIFF
--- a/Rx.NET/Documentation/IntroToRx/03_CreatingObservableSequences.md
+++ b/Rx.NET/Documentation/IntroToRx/03_CreatingObservableSequences.md
@@ -461,7 +461,7 @@ IObservable<string> ReadFileLines(string path) =>
     {
         using (StreamReader reader = File.OpenText(path))
         {
-            while (cancellationToken.IsCancellationRequested)
+            while (!cancellationToken.IsCancellationRequested)
             {
                 string? line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false);
                 if (line is null)


### PR DESCRIPTION
Negation is missing in `ReadFileLines` example.