### PR TITLE
Update System.Linq.AsyncEnumerable refs to .NET 10 GA

### DIFF
--- a/Ix.NET/Source/ApiCompare/ApiCompare.csproj
+++ b/Ix.NET/Source/ApiCompare/ApiCompare.csproj
@@ -6,8 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
-    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0-rc.1.25451.107"
-                      Aliases="SystemLinqAsyncEnumerable" />
+    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" Aliases="SystemLinqAsyncEnumerable" />
   </ItemGroup>
 
   <Target Name="_SetAliasOnBuiltInSystemLinqAsyncEnumerable" BeforeTargets="ResolveAssemblyReferences">

--- a/Ix.NET/Source/Playground/Playground.csproj
+++ b/Ix.NET/Source/Playground/Playground.csproj
@@ -20,8 +20,7 @@
   So although we get this references transitively (or automatically on .NET 10.0+) we need to put them explicitly here to set aliases.
   -->
   <ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
-    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0-rc.1.25451.107"
-                      Aliases="SystemLinqAsyncEnumerable" />
+    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" Aliases="SystemLinqAsyncEnumerable" />
   </ItemGroup>
 
   <Target Name="_SetAliasOnBuiltInSystemLinqAsyncEnumerable" BeforeTargets="ResolveAssemblyReferences">

--- a/Ix.NET/Source/System.Interactive.Async.Providers.Tests/System.Interactive.Async.Providers.Tests.csproj
+++ b/Ix.NET/Source/System.Interactive.Async.Providers.Tests/System.Interactive.Async.Providers.Tests.csproj
@@ -22,7 +22,7 @@
   So although we get this references transitively (or automatically on .NET 10.0+) we need to put them explicitly here to set aliases.
   -->
   <ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
-    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0-rc.1.25451.107" Aliases="SystemLinqAsyncEnumerable" />
+    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" Aliases="SystemLinqAsyncEnumerable" />
   </ItemGroup>
 
   <Target Name="_SetAliasOnBuiltInSystemLinqAsyncEnumerable" BeforeTargets="ResolveAssemblyReferences">

--- a/Ix.NET/Source/System.Interactive.Async.Tests/System.Interactive.Async.Tests.csproj
+++ b/Ix.NET/Source/System.Interactive.Async.Tests/System.Interactive.Async.Tests.csproj
@@ -28,7 +28,7 @@
   So although we get this references transitively (or automatically on .NET 10.0+) we need to put them explicitly here to set aliases.
   -->
   <ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
-    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0-rc.1.25451.107" Aliases="SystemLinqAsyncEnumerable" />
+    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" Aliases="SystemLinqAsyncEnumerable" />
   </ItemGroup>
 
   <Target Name="_SetAliasOnBuiltInSystemLinqAsyncEnumerable" BeforeTargets="ResolveAssemblyReferences">

--- a/Ix.NET/Source/System.Interactive.Async/System.Interactive.Async.csproj
+++ b/Ix.NET/Source/System.Interactive.Async/System.Interactive.Async.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
-    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0-rc.1.25451.107" />
+    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Ix.NET/Source/System.Linq.Async.Queryable.Tests/System.Linq.Async.Queryable.Tests.csproj
+++ b/Ix.NET/Source/System.Linq.Async.Queryable.Tests/System.Linq.Async.Queryable.Tests.csproj
@@ -22,7 +22,7 @@
   So although we get this references transitively (or automatically on .NET 10.0+) we need to put them explicitly here to set aliases.
   -->
   <ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
-    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0-rc.1.25451.107" Aliases="SystemLinqAsyncEnumerable" />
+    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" Aliases="SystemLinqAsyncEnumerable" />
   </ItemGroup>
 
   <Target Name="_SetAliasOnBuiltInSystemLinqAsyncEnumerable" BeforeTargets="ResolveAssemblyReferences">

--- a/Ix.NET/Source/System.Linq.Async.Queryable/System.Linq.Async.Queryable.csproj
+++ b/Ix.NET/Source/System.Linq.Async.Queryable/System.Linq.Async.Queryable.csproj
@@ -21,8 +21,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
     <!-- Although we get this transitively from System.Linq.Async, we need the alias to ensure we compile against the legacy System.Linq.Async -->
-    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0-rc.1.25451.107"
-                      Aliases="SystemLinqAsyncEnumerable" />
+    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" Aliases="SystemLinqAsyncEnumerable" />
   </ItemGroup>
   <Target Name="_SetAliasOnBuiltInSystemLinqAsyncEnumerable" BeforeTargets="ResolveAssemblyReferences">
 

--- a/Ix.NET/Source/System.Linq.Async.Tests/System.Linq.Async.Tests.csproj
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System.Linq.Async.Tests.csproj
@@ -64,7 +64,7 @@
   So although we get this references transitively (or automatically on .NET 10.0+) we need to put them explicitly here to set aliases.
   -->
   <ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
-    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0-rc.1.25451.107" Aliases="SystemLinqAsyncEnumerable" />
+    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" Aliases="SystemLinqAsyncEnumerable" />
   </ItemGroup>
 
   <Target Name="_SetAliasOnBuiltInSystemLinqAsyncEnumerable" BeforeTargets="ResolveAssemblyReferences">

--- a/Ix.NET/Source/System.Linq.Async/System.Linq.Async.csproj
+++ b/Ix.NET/Source/System.Linq.Async/System.Linq.Async.csproj
@@ -19,9 +19,7 @@
     <!--
     Incorporate the reference assemblies.
     -->
-    <None Include="../refs/System.Linq.Async/bin/$(Configuration)/$(TargetFramework)/**"
-          PackagePath="ref/$(TargetFramework)"
-          Pack="true" />
+    <None Include="../refs/System.Linq.Async/bin/$(Configuration)/$(TargetFramework)/**" PackagePath="ref/$(TargetFramework)" Pack="true" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -91,7 +89,7 @@
 
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
-    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0-rc.1.25451.107" Aliases="SystemLinqAsyncEnumerable" />
+    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" Aliases="SystemLinqAsyncEnumerable" />
   </ItemGroup>
 
   <Target Name="_SetAliasOnBuiltInSystemLinqAsyncEnumerable" BeforeTargets="ResolveAssemblyReferences">

--- a/Ix.NET/Source/Tests.System.Interactive.ApiApprovals/Tests.System.Interactive.ApiApprovals.csproj
+++ b/Ix.NET/Source/Tests.System.Interactive.ApiApprovals/Tests.System.Interactive.ApiApprovals.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
-    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0-rc.1.25451.107" Aliases="SystemLinqAsyncEnumerable" />
+    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" Aliases="SystemLinqAsyncEnumerable" />
   </ItemGroup>
 
   <Target Name="_SetAliasOnBuiltInSystemLinqAsyncEnumerable" BeforeTargets="ResolveAssemblyReferences">


### PR DESCRIPTION
Resolves #2252 

Now that .NET 10.0 is GA, we can update the package references for `System.Linq.AsyncEnumerable` package references to the non-preview `10.0.0`.