### PR TITLE
Upgrade to System.Linq.AsyncEnumerable 10.0.6

### DIFF
--- a/Ix.NET/Source/ApiCompare/ApiCompare.csproj
+++ b/Ix.NET/Source/ApiCompare/ApiCompare.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
-    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" Aliases="SystemLinqAsyncEnumerable" />
+    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.6" Aliases="SystemLinqAsyncEnumerable" />
   </ItemGroup>
 
   <Target Name="_SetAliasOnBuiltInSystemLinqAsyncEnumerable" BeforeTargets="ResolveAssemblyReferences">

--- a/Ix.NET/Source/Playground/Playground.csproj
+++ b/Ix.NET/Source/Playground/Playground.csproj
@@ -21,7 +21,7 @@
   So although we get this references transitively (or automatically on .NET 10.0+) we need to put them explicitly here to set aliases.
   -->
   <ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
-    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" Aliases="SystemLinqAsyncEnumerable" />
+    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.6" Aliases="SystemLinqAsyncEnumerable" />
   </ItemGroup>
 
   <Target Name="_SetAliasOnBuiltInSystemLinqAsyncEnumerable" BeforeTargets="ResolveAssemblyReferences">

--- a/Ix.NET/Source/System.Interactive.Async.Providers.Tests/System.Interactive.Async.Providers.Tests.csproj
+++ b/Ix.NET/Source/System.Interactive.Async.Providers.Tests/System.Interactive.Async.Providers.Tests.csproj
@@ -22,7 +22,7 @@
   So although we get this references transitively (or automatically on .NET 10.0+) we need to put them explicitly here to set aliases.
   -->
   <ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
-    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" Aliases="SystemLinqAsyncEnumerable" />
+    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.6" Aliases="SystemLinqAsyncEnumerable" />
   </ItemGroup>
 
   <Target Name="_SetAliasOnBuiltInSystemLinqAsyncEnumerable" BeforeTargets="ResolveAssemblyReferences">

--- a/Ix.NET/Source/System.Interactive.Async.Tests/System.Interactive.Async.Tests.csproj
+++ b/Ix.NET/Source/System.Interactive.Async.Tests/System.Interactive.Async.Tests.csproj
@@ -27,7 +27,7 @@
   So although we get this references transitively (or automatically on .NET 10.0+) we need to put them explicitly here to set aliases.
   -->
   <ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
-    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" Aliases="SystemLinqAsyncEnumerable" />
+    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.6" Aliases="SystemLinqAsyncEnumerable" />
   </ItemGroup>
 
   <Target Name="_SetAliasOnBuiltInSystemLinqAsyncEnumerable" BeforeTargets="ResolveAssemblyReferences">

--- a/Ix.NET/Source/System.Interactive.Async/System.Interactive.Async.csproj
+++ b/Ix.NET/Source/System.Interactive.Async/System.Interactive.Async.csproj
@@ -58,7 +58,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
-    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" />
+    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Ix.NET/Source/System.Linq.Async.Queryable.Tests/System.Linq.Async.Queryable.Tests.csproj
+++ b/Ix.NET/Source/System.Linq.Async.Queryable.Tests/System.Linq.Async.Queryable.Tests.csproj
@@ -22,7 +22,7 @@
   So although we get this references transitively (or automatically on .NET 10.0+) we need to put them explicitly here to set aliases.
   -->
   <ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
-    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" Aliases="SystemLinqAsyncEnumerable" />
+    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.6" Aliases="SystemLinqAsyncEnumerable" />
   </ItemGroup>
 
   <Target Name="_SetAliasOnBuiltInSystemLinqAsyncEnumerable" BeforeTargets="ResolveAssemblyReferences">

--- a/Ix.NET/Source/System.Linq.Async.Queryable/System.Linq.Async.Queryable.csproj
+++ b/Ix.NET/Source/System.Linq.Async.Queryable/System.Linq.Async.Queryable.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
     <!-- Although we get this transitively from System.Linq.Async, we need the alias to ensure we compile against the legacy System.Linq.Async -->
-    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" Aliases="SystemLinqAsyncEnumerable" />
+    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.6" Aliases="SystemLinqAsyncEnumerable" />
   </ItemGroup>
   <Target Name="_SetAliasOnBuiltInSystemLinqAsyncEnumerable" BeforeTargets="ResolveAssemblyReferences">
 

--- a/Ix.NET/Source/System.Linq.Async.Tests/System.Linq.Async.Tests.csproj
+++ b/Ix.NET/Source/System.Linq.Async.Tests/System.Linq.Async.Tests.csproj
@@ -64,7 +64,7 @@
   So although we get this references transitively (or automatically on .NET 10.0+) we need to put them explicitly here to set aliases.
   -->
   <ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
-    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" Aliases="SystemLinqAsyncEnumerable" />
+    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.6" Aliases="SystemLinqAsyncEnumerable" />
   </ItemGroup>
 
   <Target Name="_SetAliasOnBuiltInSystemLinqAsyncEnumerable" BeforeTargets="ResolveAssemblyReferences">

--- a/Ix.NET/Source/System.Linq.Async/System.Linq.Async.csproj
+++ b/Ix.NET/Source/System.Linq.Async/System.Linq.Async.csproj
@@ -95,7 +95,7 @@
 
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
-    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" Aliases="SystemLinqAsyncEnumerable" />
+    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.6" Aliases="SystemLinqAsyncEnumerable" />
   </ItemGroup>
 
   <Target Name="_SetAliasOnBuiltInSystemLinqAsyncEnumerable" BeforeTargets="ResolveAssemblyReferences">

--- a/Ix.NET/Source/Tests.System.Interactive.ApiApprovals/Tests.System.Interactive.ApiApprovals.csproj
+++ b/Ix.NET/Source/Tests.System.Interactive.ApiApprovals/Tests.System.Interactive.ApiApprovals.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
-    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" Aliases="SystemLinqAsyncEnumerable" />
+    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.6" Aliases="SystemLinqAsyncEnumerable" />
   </ItemGroup>
 
   <Target Name="_SetAliasOnBuiltInSystemLinqAsyncEnumerable" BeforeTargets="ResolveAssemblyReferences">

--- a/Ix.NET/Source/refs/System.Interactive.Async/System.Interactive.Async.csproj
+++ b/Ix.NET/Source/refs/System.Interactive.Async/System.Interactive.Async.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
-    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" />
+    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is necessary because this dependency brings in `System.Memory`, and v10.0.0 of `System.Linq.AsyncEnumerable` brings in v10.0.0 of `System.Memory`. That version is now reported as vulnerable, so people end up with a vulnerable package warning if they use these packages.

Resolves #2311