### PR TITLE
Use VS2022-compatible Roslyn refs in analyzers

### DIFF
--- a/Rx.NET/Source/src/System.Reactive.Analyzers/System.Reactive.Analyzers.csproj
+++ b/Rx.NET/Source/src/System.Reactive.Analyzers/System.Reactive.Analyzers.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #2318

We had been using V5 of the Roslyn NuGet libraries. This is unavailable on VS2022 - it's VS2026 only. We've now downgraded the reference to 4.12, because that's the version available on the oldest LTS version of VS2022 still in support (17.12 - still in support until 15th July 2026).
