### PR TITLE
Warn when packages.config in use

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/System.Reactive.nuspec
+++ b/Rx.NET/Source/src/System.Reactive/System.Reactive.nuspec
@@ -31,15 +31,15 @@
     </references>
     <dependencies>
       <group targetFramework=".NETFramework4.7.2">
-        <dependency id="System.Threading.Tasks.Extensions" version="4.5.4" exclude="Build,Analyzers" />
+        <dependency id="System.Threading.Tasks.Extensions" version="4.6.3" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net8.0" />
       <group targetFramework="net8.0-windows10.0.19041" />
       <group targetFramework=".NETStandard2.0">
-        <dependency id="System.Threading.Tasks.Extensions" version="4.5.4" exclude="Build,Analyzers" />
+        <dependency id="System.Threading.Tasks.Extensions" version="4.6.3" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="UAP10.0.18362">
-        <dependency id="System.Threading.Tasks.Extensions" version="4.5.4" exclude="Build,Analyzers" />
+        <dependency id="System.Threading.Tasks.Extensions" version="4.6.3" exclude="Build,Analyzers" />
       </group>
     </dependencies>
     <frameworkReferences>
@@ -69,6 +69,8 @@
     <file src="$analyzerassemblypath$netstandard2.0\System.Reactive.Analyzers.dll" target="analyzers\dotnet\System.Reactive.Analyzers.dll" />
     <file src="..\..\..\Resources\Artwork\Logo.png" target="icon.png" />
     <file src="build\NuGet.Readme.md" target="readme.md" />
+    <file src="build\System.Reactive.targets" target="build\System.Reactive.targets" />
+    <file src="build\System.Reactive.PackagesConfigCheck.targets" target="build\System.Reactive.PackagesConfigCheck.targets" />
     <file src="$outputpath$net472\System.Reactive.pdb" target="lib\net472\System.Reactive.pdb" />
     <file src="$outputpath$net8.0\System.Reactive.pdb" target="lib\net8.0\System.Reactive.pdb" />
     <file src="$outputpath$net8.0-windows10.0.19041\System.Reactive.pdb" target="lib\net8.0-windows10.0.19041\System.Reactive.pdb" />

--- a/Rx.NET/Source/src/System.Reactive/build/System.Reactive.PackagesConfigCheck.targets
+++ b/Rx.NET/Source/src/System.Reactive/build/System.Reactive.PackagesConfigCheck.targets
@@ -1,0 +1,35 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="_RxCheckPackagesConfig" BeforeTargets="Build">
+  <!--
+  Projects that use System.Reactive v7.0 via the old packages.config mechanism are likely to encounter problems.
+  It is highly recommended that they use PackageReference instead of packages.config.
+
+  If for some reason your project must use packages.config, you can set the RxUseUnsupportedPackagesConfig property
+  to true to bypass this check. However, this can cause problems because the old package.config mechanism does
+  know what reference assemblies are. As of Rx 7.0, the System.Reactive package defines reference assemblies
+  that have a smaller API surface area than the runtime assemblies. (This was necessary to be able to move
+  UI-framework-specific types out of System.Reactive without breaking binary compatiblity. See
+    https://github.com/dotnet/reactive/blob/main/Rx.NET/Documentation/adr/0005-package-split.md
+  for a (very) detailed explanation of the motivation behind this change.)
+
+  The main problem that can occur if you use System.Reactive in a packages.config-based projects is that if
+  you also end up with references to any of the new UI-frameworks-specific packages (e.g. System.Reactive.Wpf)
+  then the compiler will see two lots of the relevant types. It is possible to work around this through the
+  use of reference aliases and C#'s extern keyword, but PackageReference is so much better than packages.config
+  that you are almost certainly better off migrating to PackageReference instead of trying to work around the
+  problems with packages.config.
+
+    NuGetProjectStyle=PackageReference
+  -->
+    <PropertyGroup>
+      <_RxIsPackagesConfig Condition="'$(RestoreProjectStyle)' == 'PackageReference'">false</_RxIsPackagesConfig>
+      <!-- When old-style (non-Sdk) projects use PackageReference they seem to set NuGetProjectStyle, and not RestoreProjectStyle -->
+      <_RxIsPackagesConfig Condition="'$(NuGetProjectStyle)' == 'PackageReference'">false</_RxIsPackagesConfig>
+      <_RxIsPackagesConfig Condition="'$(_RxIsPackagesConfig)' != 'false'">true</_RxIsPackagesConfig>
+    </PropertyGroup>
+
+    <Warning
+      Condition="($(_RxIsPackagesConfig) == 'true') and ($(RxUseUnsupportedPackagesConfig) != 'true')"
+      Text="The project contains a packages.config file, which is not supported by System.Reactive v7.0 or later. Please migrate to PackageReference. (You can suppress this message by setting the RxUseUnsupportedPackagesConfig property to true, but be aware this is an unsupported scenario.)"/>
+  </Target>
+</Project>

--- a/Rx.NET/Source/src/System.Reactive/build/System.Reactive.PackagesConfigCheck.targets
+++ b/Rx.NET/Source/src/System.Reactive/build/System.Reactive.PackagesConfigCheck.targets
@@ -5,14 +5,14 @@
   It is highly recommended that they use PackageReference instead of packages.config.
 
   If for some reason your project must use packages.config, you can set the RxUseUnsupportedPackagesConfig property
-  to true to bypass this check. However, this can cause problems because the old package.config mechanism does
+  to true to bypass this check. However, this can cause problems because the old packages.config mechanism doesn't
   know what reference assemblies are. As of Rx 7.0, the System.Reactive package defines reference assemblies
   that have a smaller API surface area than the runtime assemblies. (This was necessary to be able to move
-  UI-framework-specific types out of System.Reactive without breaking binary compatiblity. See
+  UI-framework-specific types out of System.Reactive without breaking binary compatibility. See
     https://github.com/dotnet/reactive/blob/main/Rx.NET/Documentation/adr/0005-package-split.md
   for a (very) detailed explanation of the motivation behind this change.)
 
-  The main problem that can occur if you use System.Reactive in a packages.config-based projects is that if
+  The main problem that can occur if you use System.Reactive in a packages.config-based project is that if
   you also end up with references to any of the new UI-frameworks-specific packages (e.g. System.Reactive.Wpf)
   then the compiler will see two lots of the relevant types. It is possible to work around this through the
   use of reference aliases and C#'s extern keyword, but PackageReference is so much better than packages.config
@@ -29,7 +29,7 @@
     </PropertyGroup>
 
     <Warning
-      Condition="($(_RxIsPackagesConfig) == 'true') and ($(RxUseUnsupportedPackagesConfig) != 'true')"
+      Condition="('$(_RxIsPackagesConfig)' == 'true') and ('$(RxUseUnsupportedPackagesConfig)' != 'true')"
       Text="The project contains a packages.config file, which is not supported by System.Reactive v7.0 or later. Please migrate to PackageReference. (You can suppress this message by setting the RxUseUnsupportedPackagesConfig property to true, but be aware this is an unsupported scenario.)"/>
   </Target>
 </Project>

--- a/Rx.NET/Source/src/System.Reactive/build/System.Reactive.targets
+++ b/Rx.NET/Source/src/System.Reactive/build/System.Reactive.targets
@@ -1,0 +1,3 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildThisFileDirectory)System.Reactive.PackagesConfigCheck.targets" />
+</Project>


### PR DESCRIPTION
Resolves #2314

`System.Reactive` presents a larger runtime API surface area than its reference assemblies: the old UI-framework-specific types have been migrated out to new packages, but they remain available in the runtime libraries for binary compatibility. (They will eventually be removed, but not for a long time.)

However, if you're on the old `packages.config` style of NuGet usage, the build tooling around that doesn't actually know what a reference assembly is, and will use the runtime assemblies even at build time. This can cause problems so we raise a warning, indicating that we don't support use of v7.0 or later of this package in an old-style `packages.config`-based project.